### PR TITLE
late result updates for `Checkpoint67l`

### DIFF
--- a/global_oce_llc90/results/output.core2.txt
+++ b/global_oce_llc90/results/output.core2.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint66h
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67l
 (PID.TID 0000.0001) // Build user:        gforget
-(PID.TID 0000.0001) // Build host:        GLACIER2.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Thu Jun 15 15:27:47 EDT 2017
+(PID.TID 0000.0001) // Build host:        GLACIER3.MIT.EDU
+(PID.TID 0000.0001) // Build date:        Fri Aug 30 15:54:21 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -52,12 +52,14 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER2.MIT.EDU
+(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER3.MIT.EDU
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 23,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -649,6 +651,8 @@
 (PID.TID 0000.0001) > mxlSurfFlag=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -773,6 +777,15 @@
 (PID.TID 0000.0001) >      HsnowFile='siHSNOW.ini',
 (PID.TID 0000.0001) >      uIceFile='siUICE.ini',
 (PID.TID 0000.0001) >      vIceFile='siVICE.ini',
+(PID.TID 0000.0001) >#the following is needed to recover old default values
+(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >      SEAICE_drag=0.002,
+(PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
+(PID.TID 0000.0001) >      SEAICEetaZmethod=0,
+(PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
+(PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
+(PID.TID 0000.0001) >      SEAICE_OLx=0,
+(PID.TID 0000.0001) >      SEAICE_OLy=0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
@@ -1420,6 +1433,9 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -1728,6 +1744,9 @@
 (PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEupdateOceanStress= /* update Ocean surf. stress */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1770,11 +1789,11 @@
 (PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
 (PID.TID 0000.0001)                 2.000000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag * density */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag */
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
 (PID.TID 0000.0001)                   F
@@ -2649,74 +2668,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   297
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   308
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   229 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   235 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   238 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   240 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   248 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   308 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   252 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   259 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   269 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   270 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   271 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   277 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   233 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   234 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   281 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   282 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   287 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   244 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   245 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   217 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   218 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   114 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   115 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   111 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   112 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   122 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   119 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   228 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   117 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   125 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   268  ADVxHEFF , Parms: UU      M1 , mate:   269
-(PID.TID 0000.0001)   set mate pointer for diag #   269  ADVyHEFF , Parms: VV      M1 , mate:   268
-(PID.TID 0000.0001)   set mate pointer for diag #   270  DFxEHEFF , Parms: UU      M1 , mate:   271
-(PID.TID 0000.0001)   set mate pointer for diag #   271  DFyEHEFF , Parms: VV      M1 , mate:   270
-(PID.TID 0000.0001)   set mate pointer for diag #   276  ADVxSNOW , Parms: UU      M1 , mate:   277
-(PID.TID 0000.0001)   set mate pointer for diag #   277  ADVySNOW , Parms: VV      M1 , mate:   276
-(PID.TID 0000.0001)   set mate pointer for diag #   278  DFxESNOW , Parms: UU      M1 , mate:   279
-(PID.TID 0000.0001)   set mate pointer for diag #   279  DFyESNOW , Parms: VV      M1 , mate:   278
-(PID.TID 0000.0001)   set mate pointer for diag #   233  SIuice   , Parms: UU      M1 , mate:   234
-(PID.TID 0000.0001)   set mate pointer for diag #   234  SIvice   , Parms: VV      M1 , mate:   233
+(PID.TID 0000.0001)   set mate pointer for diag #   279  ADVxHEFF , Parms: UU      M1 , mate:   280
+(PID.TID 0000.0001)   set mate pointer for diag #   280  ADVyHEFF , Parms: VV      M1 , mate:   279
+(PID.TID 0000.0001)   set mate pointer for diag #   281  DFxEHEFF , Parms: UU      M1 , mate:   282
+(PID.TID 0000.0001)   set mate pointer for diag #   282  DFyEHEFF , Parms: VV      M1 , mate:   281
+(PID.TID 0000.0001)   set mate pointer for diag #   287  ADVxSNOW , Parms: UU      M1 , mate:   288
+(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVySNOW , Parms: VV      M1 , mate:   287
+(PID.TID 0000.0001)   set mate pointer for diag #   289  DFxESNOW , Parms: UU      M1 , mate:   290
+(PID.TID 0000.0001)   set mate pointer for diag #   290  DFyESNOW , Parms: VV      M1 , mate:   289
+(PID.TID 0000.0001)   set mate pointer for diag #   244  SIuice   , Parms: UU      M1 , mate:   245
+(PID.TID 0000.0001)   set mate pointer for diag #   245  SIvice   , Parms: VV      M1 , mate:   244
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   217  GM_PsiX  , Parms: UU      LR , mate:   218
-(PID.TID 0000.0001)   set mate pointer for diag #   218  GM_PsiY  , Parms: VV      LR , mate:   217
-(PID.TID 0000.0001)   set mate pointer for diag #   114  DFxE_TH  , Parms: UU      MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  DFyE_TH  , Parms: VV      MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   111  ADVx_TH  , Parms: UU      MR , mate:   112
-(PID.TID 0000.0001)   set mate pointer for diag #   112  ADVy_TH  , Parms: VV      MR , mate:   111
-(PID.TID 0000.0001)   set mate pointer for diag #   121  DFxE_SLT , Parms: UU      MR , mate:   122
-(PID.TID 0000.0001)   set mate pointer for diag #   122  DFyE_SLT , Parms: VV      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVx_SLT , Parms: UU      MR , mate:   119
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADVy_SLT , Parms: VV      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   228  GM_PsiX  , Parms: UU      LR , mate:   229
+(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiY  , Parms: VV      LR , mate:   228
+(PID.TID 0000.0001)   set mate pointer for diag #   120  DFxE_TH  , Parms: UU      MR , mate:   121
+(PID.TID 0000.0001)   set mate pointer for diag #   121  DFyE_TH  , Parms: VV      MR , mate:   120
+(PID.TID 0000.0001)   set mate pointer for diag #   117  ADVx_TH  , Parms: UU      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVy_TH  , Parms: VV      MR , mate:   117
+(PID.TID 0000.0001)   set mate pointer for diag #   127  DFxE_SLT , Parms: UU      MR , mate:   128
+(PID.TID 0000.0001)   set mate pointer for diag #   128  DFyE_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   124  ADVx_SLT , Parms: UU      MR , mate:   125
+(PID.TID 0000.0001)   set mate pointer for diag #   125  ADVy_SLT , Parms: VV      MR , mate:   124
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2836,6 +2855,9 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
@@ -3103,14 +3125,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -3122,6 +3142,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -3136,6 +3159,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -3196,7 +3222,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3212,6 +3238,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
 (PID.TID 0000.0001)                       0
@@ -3399,6 +3428,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -4522,6 +4560,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4965,32 +5006,32 @@
  cg2d: Sum(rhs),rhsMax =  -2.89667992072739E-01  1.31165947868857E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.78965985890069E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.32917826615744E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.32917824171613E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5901944630486E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234117039477E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5901944630487E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234117039476E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100217402229E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379286666463E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433022553180E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379286666464E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433022553434E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5739352778241E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4879234606579E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728482806794E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728482806793E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359397594635E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383865238929E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383865238857E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5873393006783E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5773119177539E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5461075869996E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838093156724E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931298859388E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5461075870002E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838093156723E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931298859298E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8989891142390E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251161206207E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434115624006E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213740921822E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987533658174E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434115625197E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213740921797E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987533658168E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1222710237771E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002308883004E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920380579600E+00
@@ -5031,11 +5072,11 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7527346883418E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9961080813058E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2265580949272E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6602409153502E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6602409153501E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7474740302065E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691393705762E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691393705765E-05
 (PID.TID 0000.0001) %MON ke_max                       =   9.9277088111487E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3333733928680E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3333733928679E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979035714E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.0937711709687E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.3293128553806E-05
@@ -5043,8 +5084,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292366E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525964211E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410398774E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729597539684E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636121021799E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729597539642E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636121021850E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5174,40 +5215,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.26224757851278E-01  1.27905011464687E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.36968525294934E+00
+ cg2d: Sum(rhs),rhsMax =  -4.26224757851295E-01  1.27905011464687E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.36968525322733E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.88805556740182E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.88805561207409E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852434749193E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852434749168E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371596791613E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433190623287E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239327063208E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6942879932231E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433190623290E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239327063207E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6942879932216E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0991256867566E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8578922437936E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757981468903E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757981468907E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478414123166E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058774765192E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058774765250E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992069275878E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8026345978538E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9249868982797E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9249868982832E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391077726581E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392536580743E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392536580790E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051687E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093854E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7369045166750E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668607886836E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568115555842E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7369045165053E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668607886843E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568115555764E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1210551784620E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661235358E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072889E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260845036E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511358854821E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511358854822E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697156897789E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0318799939218E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609342232E+01
@@ -5238,16 +5279,16 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8243075091970E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7333547489698E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1057887027860E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995059473955E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995059473953E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1110973558922E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419828E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3060883215446E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327809880456E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327809880455E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312347E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789215082E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521114491353E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521114491352E-05
 (PID.TID 0000.0001) %MON ke_max                       =   1.3313107009674E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.2348085581656E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.2348085581655E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979310002E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.5011413893875E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.2237592678360E-05
@@ -5255,8 +5296,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956128E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524076675E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720124213E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160975870524E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6606530411346E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160975870577E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6606530411324E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5267,14 +5308,14 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1105978604936E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1105978604933E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337399852364E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8142368719714E-05
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8142368719697E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6534876363403E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853214563015E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8422173157097E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6534876363407E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853214563014E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8422173156946E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4809172516828E-02
@@ -5313,7 +5354,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078477107049E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342514010E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564288754444E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961534E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961535E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1959313010779E-06
 (PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967983955E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671552487E-08
@@ -5386,10 +5427,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.59285054289907E-01  1.25698027958351E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.10916377431084E+00
+ cg2d: Sum(rhs),rhsMax =  -5.59285054289966E-01  1.25698027958349E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.10916377404862E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.57975924814650E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.57975930056259E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5397,29 +5438,29 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514671570E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125940943670E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560558051204E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560558051201E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068861984735E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6892154118333E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6892154118327E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5258375534464E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2150974702664E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646948963743E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820777186184E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8424610141004E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820777186183E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8424610140990E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529358E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1326532725269E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354414232445E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354414232440E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819336948551E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6561559642741E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6561559642744E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366748812E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851198004E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2071679205277E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769612264033E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161277247137E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2071679205648E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769612263999E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161277247133E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1205582170152E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920323728E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137701E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315520992E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857734559939E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857734559945E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694681496378E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0349724301766E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608743589E+01
@@ -5450,8 +5491,8 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9466947752792E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1311395488412E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9557858446247E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3877148676986E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0042614004929E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3877148676983E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0042614013781E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316524487E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6122015961018E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5032837765825E-02
@@ -5459,7 +5500,7 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372788058E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452282957177E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.6804276849210E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.0314800095604E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   3.0314800095603E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979572532E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.7464980459812E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.4422500774179E-05
@@ -5467,8 +5508,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876465154E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523225355E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196495660E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026206960012E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6681477370811E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026206960007E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6681477370724E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5479,14 +5520,14 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1036451345878E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1036451345879E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3467928816755E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8139477487025E-05
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8139477487038E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6720063500654E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6720063500648E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956529998327E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8870250175895E-05
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8870250176027E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713012954204E-02
@@ -5525,9 +5566,9 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516930032636E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794438496634E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532605924118E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877179677E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877179678E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1953168675345E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688489734737E-09
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688489734736E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941368574310E-08
 (PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777782213E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8655087463369E+01
@@ -5560,7 +5601,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423778477E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322380764E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236191597019E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865976002E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865976004E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945879E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611999177E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460849297632E-08
@@ -5598,47 +5639,47 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -6.90938319677612E-01  1.23313674957072E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.04940086936170E+00
+ cg2d: Sum(rhs),rhsMax =  -6.90938319677811E-01  1.23313674957070E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.04940086917447E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   7.05019143359127E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.05019142488012E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558351740823E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558351740822E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368821655087E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577673105691E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577673105693E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793084238227E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6741838345763E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6741838345774E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8934443141443E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690531852E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274930418013E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274930418009E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837433728731E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8724538861481E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8724538861460E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399850239E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8640460627238E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303086158629E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662402855072E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373070497279E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373070497272E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1886122271726E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589464804E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9968458072516E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191389627338E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9968458072739E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191389627332E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854468189957E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1199063567507E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001246647E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901047E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404808485E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215801635037E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215801635057E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692092293853E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0380536133796E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608317437E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873327463E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416948236076E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416948236077E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027821997196E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0049661779353E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0049661779352E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396670656976E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662368493218E+02
 (PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577751415413E-01
@@ -5648,12 +5689,12 @@
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336243068319E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2089859974758E-02
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1352437309966E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1118162592059E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1118162592056E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057253864086E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013329995903E-04
 (PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699460460239E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948883745E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281781195020E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281781195021E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5343780881380E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8718909599170E-02
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9514278282207E-05
@@ -5663,9 +5704,9 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0552330029861E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8397381207523E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5093307428333E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596316045470E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596316045343E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472424419E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8654801685247E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8654801685251E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1462524953020E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378196901E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502551844E-01
@@ -5679,8 +5720,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661214268E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523297138E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776684627E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2768015423101E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5069041492949E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2768015423092E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5069041493063E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5691,14 +5732,14 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0681720498442E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0681720498446E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235175651457E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7432456097017E-05
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7432456097019E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7213162000418E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668003200547E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8734653244377E-05
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8734653244368E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625517374244E-02
@@ -5724,7 +5765,7 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945457435E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083194342E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417944700222E-03
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417944700221E-03
 (PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770802498E-02
 (PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075023261181E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546217762E-01
@@ -5737,7 +5778,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688226342828E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355958385E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535214649581E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859538671E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859538669E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947146923263E-06
 (PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068548371409E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846874330827E-08
@@ -5768,11 +5809,11 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2944037231979E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4438385083419E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4957462594537E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282924242E+01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282924241E+01
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704949598E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616016375E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205944879183E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165603255E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165603253E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897167522E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750516463E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696632721E-08
@@ -5810,40 +5851,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.20012802811670E-01  1.21310980029428E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.00015779395493E+00
+ cg2d: Sum(rhs),rhsMax =  -8.20012802811746E-01  1.21310980029430E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.00015779398710E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.53653173123588E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53653173054480E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942701610E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271662317466E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478724776398E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685261449554E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6636135780918E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271662317465E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478724776400E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685261449555E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6636135780921E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0248193957895E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541711911E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555210155595E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555210155594E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547395159094E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7823521215664E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7823521215659E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465044182408E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4807825947757E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830685125122E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830685125124E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926278023095E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873271725836E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046833135E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565099812E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4225697000791E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179480072465E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4225696999872E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179480072471E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145361334186E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192840140288E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880812235E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764860E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518610947E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553094803258E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553094803276E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689419470055E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410367180224E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031538E+01
@@ -5853,7 +5894,7 @@
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0694712073667E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661666353430E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609628934662E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310947257263E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310947257262E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413323771328E+02
@@ -5863,7 +5904,7 @@
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0977178845127E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725506025451E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711209901562E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974582438545E-07
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974582438542E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525521119213E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282618423682E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3651371877112E-03
@@ -5873,17 +5914,17 @@
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453477811E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0860393102336E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0442255777268E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9139893247036E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3855255960888E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8787464476061E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9139893247035E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3855255957349E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8787464475949E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808991549E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324250013374E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5654766239351E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177186639E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018233257E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992481325574E-04
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324250013376E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5654766239352E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177186638E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018233256E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992481325575E-04
 (PID.TID 0000.0001) %MON ke_max                       =   2.3692084537090E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3541821289629E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3541821289628E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980078924E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.1071784745450E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.8803882790054E-05
@@ -5891,8 +5932,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629606113E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523960979E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230149083515E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149948499431E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2102485831991E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149948499432E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2102485831904E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5905,12 +5946,12 @@
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0319402335790E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849188330421E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5783100444481E-05
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5783100444454E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7254127422083E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7254127422085E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180204533440E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7450247025899E-05
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7450247025878E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550169807062E-02
@@ -5922,7 +5963,7 @@
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480685976496E-01
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6675610434467E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7993114477137E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738900714790E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131654740627E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9269849237388E-05
@@ -5949,9 +5990,9 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618379193967E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594409191E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585908512767E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171390081E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171390082E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1941211875677E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413624760E-09
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413624761E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346968636E-08
 (PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955676216E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9209654059797E+01
@@ -5984,7 +6025,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692123941E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503490991268E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177228389925E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794722923E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794722924E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007332205E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508372081E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867276418E-08
@@ -6022,62 +6063,62 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.46889825398866E-01  1.19643084184092E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.42690789255449E-01
+ cg2d: Sum(rhs),rhsMax =  -9.46889518654183E-01  1.19643084184088E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.42690787149929E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.50650242963882E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.50650127071511E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217254669075E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719435046953E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0272973304112E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323746195235E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6590738387513E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5563475958746E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237903165E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4855007026935E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217254669081E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719435047193E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0272957778820E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323746267239E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6590738554484E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5563475958741E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237903167E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4855007026934E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897756739527E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5529640656650E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5529640656620E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588133026887E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2706239540509E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5638995631731E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2706239540506E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5638995631732E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582258917421E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2162533072255E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2162533072247E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005455326E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237598380E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3921466357623E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503986949432E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138454607693E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237598381E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3921464018339E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503986948781E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138454607969E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192003518495E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554768369E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820914E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644690263E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9926997188742E-05
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820949E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644690224E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9926997246405E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686687532167E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439365122669E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773861E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326477453E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989612606970E-05
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773862E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326476907E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989612583466E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962426406559E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237586444E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695396959790E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586493335896E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880497004867E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695411505183E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586492768109E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880490414454E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415256867655E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284254154230E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1519761659945E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721998690341E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0834202897968E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420227041707E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456679953562E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902361555874E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415258349829E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284226062079E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1519843633659E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721998690344E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0834202897971E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420182665232E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456671154527E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902411471673E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820801748E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860893795748E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860893795747E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1906329555157E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8721499528537E-02
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9730909946268E-05
@@ -6085,26 +6126,26 @@
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074179730E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1033968177066E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0977289048806E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0614888029589E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0184039741324E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8038678936775E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462906208E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6242895320984E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7950472599853E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893514082158E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204892623E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430861739139E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9022263007695E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0614888029588E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0184039742795E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8038678944353E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462906207E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6242895320992E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7950472599854E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893514082159E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204892622E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430861696902E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9022263007691E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   4.7555789598360E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980325992E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1823148674208E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0129286658310E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1823148674212E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0129286658309E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761383573E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525020836E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228686132659E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867044592233E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9352612515693E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867044567331E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9352606461297E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6115,24 +6156,24 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5651344847890E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5651344847881E-03
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328572363548E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3455000465802E-05
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3455000465803E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6909669724738E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6909669724739E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529434920706E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4805087613329E-05
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4805087613333E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465976422788E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120203148907E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3693977366624E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465976490376E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120203179209E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3693977338346E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8263657235874E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357569808418E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461921271095E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6546449960763E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357569983973E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461921359020E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6546449709903E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960453002212E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649925204779E-03
@@ -6158,14 +6199,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295594851E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124052922234E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5589638243903E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902950408E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020474589E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676965030931E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902945936E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020473949E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676965030786E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263103294E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935326777510E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614709031E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510755610E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557589717102E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614708980E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510755609E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557589717101E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9486937358010E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6299850577329E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.6150486977946E-01
@@ -6193,13 +6234,13 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4428924291636E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828126125463E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187955168E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125010006E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477968464460E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150374019448E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433450464E-07
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125014448E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477968462116E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150374026322E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433450462E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204530349E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732644608E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585884871E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732644613E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585884864E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495601732E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8641147281375E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0501375227415E-10
@@ -6234,89 +6275,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.07163990380819E+00  1.18154306554396E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.79620607916456E-01
+ cg2d: Sum(rhs),rhsMax =  -1.07163960034761E+00  1.18154306554654E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.79620609116763E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.63002419793563E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.63002417385332E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744024588E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430418924370E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954843747299E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316031888569E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6539533623298E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0948074941039E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744024587E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430418915670E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954828388216E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316031957764E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6539533801867E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0948074941032E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174821162E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279762055923E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802428454844E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184567919478E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401974320752E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8645063803972E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249549186907E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751667689870E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8592786727791E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182466050E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221636042E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4789083100852E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5981140716230E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926360670437E-07
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279762055998E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802428454850E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184567919414E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401974320751E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8645063803976E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249549186411E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751667689851E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8592786727555E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182466049E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221636035E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4789081052597E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5981140716032E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926360670386E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190755067682E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013005477E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144936E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772147022E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368734489379E-05
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144972E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772146983E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368734546221E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684631335885E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467138134820E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471387E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534629690E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803895196747E-05
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471388E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534629149E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803895175282E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929052701934E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5589638243903E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512291721599E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591356664562E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644488523653E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512291551586E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591356670847E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644488456259E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316196534E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261774897145E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521179268675E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834880870802E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0686889676520E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099013016764E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217401493155E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1168945728124E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316194569E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261774933893E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521178322520E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834880870792E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0686889676526E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099013491863E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217401586367E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1168944781082E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890829575E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041593477723E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0050535188239E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9781684202685E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1372594950820E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041593477720E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0050535180872E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9781684202914E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1372594956151E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522192230363E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423054707E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0845930355999E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2167341590715E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2289412927993E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7266986191191E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2780342013989E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286187725218E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9056318750465E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4680619917129E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4027773935346E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361437430325E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228879561916E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.3881788058829E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9530894969241E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980569235E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2704585230658E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0989621660630E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0845930357109E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2167341590979E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2289412936121E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7266986192559E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2780342021529E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286187725295E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9056318750448E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4680619917122E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4027773935348E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361437430327E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228879520201E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.3881788058835E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9530894969197E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980569234E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2704585230654E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0989621660631E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000806323E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261433E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228398817120E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872299545404E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3278817156738E-07
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261434E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228398817132E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872299554053E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3278817228854E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6327,29 +6368,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2472955549955E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679207381455E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9959730609029E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2472955512153E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679207381492E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9959730604419E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6324083737137E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744168218828E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0136908033361E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6324083740151E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744168218868E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0136908035528E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399681046658E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099251575688E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3408725621451E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399681113557E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099251605694E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3408725594042E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266841299E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285203437972E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443907851727E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6421982786233E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927940644153E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285203611648E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443907938666E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6421982545640E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927940644176E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561954000081E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079865180835E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8953509987610E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561954000075E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079865180732E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8953509991612E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6358,253 +6399,253 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.116967486014893D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.178494745885914D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.116967485895073D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.178494745498813D+05 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.295462231900806D+05
+(PID.TID 0000.0001)  --> fc               = 0.295462231393886D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.730280352192207D+03
-(PID.TID 0000.0001)  global fc =  0.295462231900806D+05
+(PID.TID 0000.0001)   local fc =  0.730280352192169D+03
+(PID.TID 0000.0001)  global fc =  0.295462231393886D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   106.98373787105083
-(PID.TID 0000.0001)         System time:   4.9242522269487381
-(PID.TID 0000.0001)     Wall clock time:   154.84681582450867
+(PID.TID 0000.0001)           User time:   175.84927088022232
+(PID.TID 0000.0001)         System time:   6.9069502055644989
+(PID.TID 0000.0001)     Wall clock time:   224.79516696929932
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   6.6129941195249557
-(PID.TID 0000.0001)         System time:  0.53691901266574860
-(PID.TID 0000.0001)     Wall clock time:   15.338173151016235
+(PID.TID 0000.0001)           User time:   7.8608046174049377
+(PID.TID 0000.0001)         System time:  0.50892201066017151
+(PID.TID 0000.0001)     Wall clock time:   22.180539131164551
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   100.37074375152588
-(PID.TID 0000.0001)         System time:   4.3873332142829895
-(PID.TID 0000.0001)     Wall clock time:   139.50844907760620
+(PID.TID 0000.0001)           User time:   167.98846626281738
+(PID.TID 0000.0001)         System time:   6.3980281949043274
+(PID.TID 0000.0001)     Wall clock time:   202.61455702781677
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   12.076163291931152
-(PID.TID 0000.0001)         System time:  0.70589298009872437
-(PID.TID 0000.0001)     Wall clock time:   19.327370882034302
+(PID.TID 0000.0001)           User time:   15.834592819213867
+(PID.TID 0000.0001)         System time:  0.63090401887893677
+(PID.TID 0000.0001)     Wall clock time:   21.793344974517822
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   88.294580459594727
-(PID.TID 0000.0001)         System time:   3.6814402341842651
-(PID.TID 0000.0001)     Wall clock time:   120.18102598190308
+(PID.TID 0000.0001)           User time:   152.15387344360352
+(PID.TID 0000.0001)         System time:   5.7671241760253906
+(PID.TID 0000.0001)     Wall clock time:   180.82115602493286
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.6207542419433594
-(PID.TID 0000.0001)         System time:  1.99997425079345703E-003
-(PID.TID 0000.0001)     Wall clock time:   1.6261057853698730
+(PID.TID 0000.0001)           User time:   1.6637382507324219
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.6664762496948242
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  2.99835205078125000E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.05485725402832031E-003
+(PID.TID 0000.0001)           User time:  3.99780273437500000E-003
+(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
+(PID.TID 0000.0001)     Wall clock time:  4.91714477539062500E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   80.705730438232422
-(PID.TID 0000.0001)         System time:   3.4094810485839844
-(PID.TID 0000.0001)     Wall clock time:   109.68171405792236
+(PID.TID 0000.0001)           User time:   142.50534629821777
+(PID.TID 0000.0001)         System time:   5.4591702222824097
+(PID.TID 0000.0001)     Wall clock time:   168.56213188171387
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   80.705730438232422
-(PID.TID 0000.0001)         System time:   3.4094810485839844
-(PID.TID 0000.0001)     Wall clock time:   109.68144512176514
+(PID.TID 0000.0001)           User time:   142.50534629821777
+(PID.TID 0000.0001)         System time:   5.4591702222824097
+(PID.TID 0000.0001)     Wall clock time:   168.56187033653259
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.82088088989257813
+(PID.TID 0000.0001)           User time:   1.7957534790039063
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.81883525848388672
+(PID.TID 0000.0001)     Wall clock time:   1.7980484962463379
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25895500183105469
-(PID.TID 0000.0001)         System time:  1.99890136718750000E-003
-(PID.TID 0000.0001)     Wall clock time:  0.26004266738891602
+(PID.TID 0000.0001)           User time:  0.49493026733398438
+(PID.TID 0000.0001)         System time:  1.99997425079345703E-003
+(PID.TID 0000.0001)     Wall clock time:  0.49203944206237793
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.68988800048828125
-(PID.TID 0000.0001)         System time:  9.49845314025878906E-002
-(PID.TID 0000.0001)     Wall clock time:  0.83850240707397461
+(PID.TID 0000.0001)           User time:  0.96584510803222656
+(PID.TID 0000.0001)         System time:  0.11698102951049805
+(PID.TID 0000.0001)     Wall clock time:   1.1653387546539307
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.68288803100585938
-(PID.TID 0000.0001)         System time:  9.49845314025878906E-002
-(PID.TID 0000.0001)     Wall clock time:  0.83021879196166992
+(PID.TID 0000.0001)           User time:  0.94985389709472656
+(PID.TID 0000.0001)         System time:  0.11698102951049805
+(PID.TID 0000.0001)     Wall clock time:   1.1487989425659180
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.49488449096679688E-004
+(PID.TID 0000.0001)     Wall clock time:  1.45673751831054688E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16398429870605469
-(PID.TID 0000.0001)         System time:  4.99820709228515625E-003
-(PID.TID 0000.0001)     Wall clock time:  0.16822576522827148
+(PID.TID 0000.0001)           User time:  0.17396736145019531
+(PID.TID 0000.0001)         System time:  8.99994373321533203E-003
+(PID.TID 0000.0001)     Wall clock time:  0.18477702140808105
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.09960937500000000E-002
+(PID.TID 0000.0001)           User time:  4.69951629638671875E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.79679298400878906E-002
+(PID.TID 0000.0001)     Wall clock time:  4.99951839447021484E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.926034927368164
-(PID.TID 0000.0001)         System time:  0.40294098854064941
-(PID.TID 0000.0001)     Wall clock time:   13.331125974655151
+(PID.TID 0000.0001)           User time:   25.145183563232422
+(PID.TID 0000.0001)         System time:  0.54291796684265137
+(PID.TID 0000.0001)     Wall clock time:   25.708270311355591
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.1835193634033203
-(PID.TID 0000.0001)         System time:  0.13398051261901855
-(PID.TID 0000.0001)     Wall clock time:   3.3143403530120850
+(PID.TID 0000.0001)           User time:   5.9320926666259766
+(PID.TID 0000.0001)         System time:  0.20597112178802490
+(PID.TID 0000.0001)     Wall clock time:   6.1415178775787354
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   2.8725624084472656
-(PID.TID 0000.0001)         System time:  0.11398494243621826
-(PID.TID 0000.0001)     Wall clock time:   2.9881272315979004
+(PID.TID 0000.0001)           User time:   5.3961772918701172
+(PID.TID 0000.0001)         System time:  0.17997181415557861
+(PID.TID 0000.0001)     Wall clock time:   5.5822098255157471
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.1485157012939453
-(PID.TID 0000.0001)         System time:  4.00030612945556641E-003
-(PID.TID 0000.0001)     Wall clock time:   3.1500179767608643
+(PID.TID 0000.0001)           User time:   7.1029109954833984
+(PID.TID 0000.0001)         System time:  5.99992275238037109E-003
+(PID.TID 0000.0001)     Wall clock time:   7.1100821495056152
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.059316635131836
-(PID.TID 0000.0001)         System time:  1.99902057647705078E-003
-(PID.TID 0000.0001)     Wall clock time:   11.065944910049438
+(PID.TID 0000.0001)           User time:   23.858364105224609
+(PID.TID 0000.0001)         System time:  6.99913501739501953E-003
+(PID.TID 0000.0001)     Wall clock time:   23.886381626129150
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.69789314270019531
-(PID.TID 0000.0001)         System time:  0.32895016670227051
-(PID.TID 0000.0001)     Wall clock time:   1.0239107608795166
+(PID.TID 0000.0001)           User time:   1.9236984252929688
+(PID.TID 0000.0001)         System time:   1.1138293743133545
+(PID.TID 0000.0001)     Wall clock time:   3.0422630310058594
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5257701873779297
-(PID.TID 0000.0001)         System time:  6.29897117614746094E-002
-(PID.TID 0000.0001)     Wall clock time:   1.5874240398406982
+(PID.TID 0000.0001)           User time:   3.8234214782714844
+(PID.TID 0000.0001)         System time:  0.21996772289276123
+(PID.TID 0000.0001)     Wall clock time:   4.0612704753875732
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17797660827636719
+(PID.TID 0000.0001)           User time:  0.48692321777343750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.17994880676269531
+(PID.TID 0000.0001)     Wall clock time:  0.49030947685241699
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45892715454101563
-(PID.TID 0000.0001)         System time:  2.99906730651855469E-003
-(PID.TID 0000.0001)     Wall clock time:  0.45928907394409180
+(PID.TID 0000.0001)           User time:   1.0828361511230469
+(PID.TID 0000.0001)         System time:  4.59928512573242188E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1290948390960693
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.49919891357421875E-002
-(PID.TID 0000.0001)         System time:  1.99997425079345703E-003
-(PID.TID 0000.0001)     Wall clock time:  2.86228656768798828E-002
+(PID.TID 0000.0001)           User time:  5.69877624511718750E-002
+(PID.TID 0000.0001)         System time:  8.99791717529296875E-003
+(PID.TID 0000.0001)     Wall clock time:  6.60145282745361328E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.50694465637207031
-(PID.TID 0000.0001)         System time:  5.99912405014038086E-002
-(PID.TID 0000.0001)     Wall clock time:  0.58551549911499023
+(PID.TID 0000.0001)           User time:  0.64688110351562500
+(PID.TID 0000.0001)         System time:  8.69876146316528320E-002
+(PID.TID 0000.0001)     Wall clock time:  0.73810648918151855
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.741903305053711
-(PID.TID 0000.0001)         System time:  0.23796486854553223
-(PID.TID 0000.0001)     Wall clock time:   13.979156494140625
+(PID.TID 0000.0001)           User time:   27.563823699951172
+(PID.TID 0000.0001)         System time:   1.1298283338546753
+(PID.TID 0000.0001)     Wall clock time:   28.713535308837891
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.64031982421875000E-004
+(PID.TID 0000.0001)     Wall clock time:  1.42812728881835938E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.42335891723632813E-004
+(PID.TID 0000.0001)     Wall clock time:  1.34229660034179688E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5976009368896484
-(PID.TID 0000.0001)         System time:  8.49884748458862305E-002
-(PID.TID 0000.0001)     Wall clock time:   2.6799161434173584
+(PID.TID 0000.0001)           User time:   5.7131233215332031
+(PID.TID 0000.0001)         System time:  0.26595878601074219
+(PID.TID 0000.0001)     Wall clock time:   5.9819042682647705
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.36613845825195313E-004
+(PID.TID 0000.0001)     Wall clock time:  1.38282775878906250E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.039163589477539
-(PID.TID 0000.0001)         System time:   1.3977873325347900
-(PID.TID 0000.0001)     Wall clock time:   27.889079809188843
+(PID.TID 0000.0001)           User time:   13.486946105957031
+(PID.TID 0000.0001)         System time:   1.2338124513626099
+(PID.TID 0000.0001)     Wall clock time:   26.098984003067017
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9422454833984375
-(PID.TID 0000.0001)         System time:  0.70189285278320313
-(PID.TID 0000.0001)     Wall clock time:   16.673577070236206
+(PID.TID 0000.0001)           User time:   5.5651550292968750
+(PID.TID 0000.0001)         System time:  0.66789913177490234
+(PID.TID 0000.0001)     Wall clock time:   15.248087167739868
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1938171386718750
-(PID.TID 0000.0001)         System time:  6.89897537231445313E-002
-(PID.TID 0000.0001)     Wall clock time:   2.6119511127471924
+(PID.TID 0000.0001)           User time:   1.3258056640625000
+(PID.TID 0000.0001)         System time:  8.49866867065429688E-002
+(PID.TID 0000.0001)     Wall clock time:   2.4067420959472656
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.84092330932617188E-004
+(PID.TID 0000.0001)     Wall clock time:  6.74009323120117188E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   4.7092895507812500
-(PID.TID 0000.0001)         System time:  0.18797111511230469
-(PID.TID 0000.0001)     Wall clock time:   6.1791129112243652
+(PID.TID 0000.0001)           User time:   6.5150146484375000
+(PID.TID 0000.0001)         System time:  0.21596670150756836
+(PID.TID 0000.0001)     Wall clock time:   8.0332601070404053
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.3125000000000000
-(PID.TID 0000.0001)         System time:  0.15397644042968750
-(PID.TID 0000.0001)     Wall clock time:   4.7456970214843750
+(PID.TID 0000.0001)           User time:   4.8712615966796875
+(PID.TID 0000.0001)         System time:  0.18797063827514648
+(PID.TID 0000.0001)     Wall clock time:   6.3594720363616943
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.3967895507812500
-(PID.TID 0000.0001)         System time:  3.39946746826171875E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4333548545837402
+(PID.TID 0000.0001)           User time:   1.6437530517578125
+(PID.TID 0000.0001)         System time:  2.79960632324218750E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6737260818481445
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  2.99835205078125000E-003
+(PID.TID 0000.0001)           User time:  3.99780273437500000E-003
 (PID.TID 0000.0001)         System time:  2.00033187866210938E-003
-(PID.TID 0000.0001)     Wall clock time:  7.95412063598632813E-003
+(PID.TID 0000.0001)     Wall clock time:  8.84604454040527344E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6655,9 +6696,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          37384
+(PID.TID 0000.0001) //            No. barriers =          37342
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          37384
+(PID.TID 0000.0001) //     Total barrier spins =          37342
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.ecco_v4.txt
+++ b/global_oce_llc90/results/output.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint66h
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67l
 (PID.TID 0000.0001) // Build user:        gforget
-(PID.TID 0000.0001) // Build host:        GLACIER2.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Thu Jun 15 15:27:47 EDT 2017
+(PID.TID 0000.0001) // Build host:        GLACIER3.MIT.EDU
+(PID.TID 0000.0001) // Build date:        Fri Aug 30 15:54:21 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -52,12 +52,14 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER2.MIT.EDU
+(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER3.MIT.EDU
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 23,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -619,6 +621,8 @@
 (PID.TID 0000.0001) > mxlSurfFlag=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -736,6 +740,15 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># SEAICE parameters
 (PID.TID 0000.0001) > &SEAICE_PARM01
+(PID.TID 0000.0001) >#the following is needed to recover old default values
+(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
+(PID.TID 0000.0001) >      SEAICEetaZmethod=0,
+(PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
+(PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
+(PID.TID 0000.0001) >      SEAICE_OLx=0,
+(PID.TID 0000.0001) >      SEAICE_OLy=0,
+(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
 (PID.TID 0000.0001) >      SEAICEpresPow0=1,
@@ -1570,6 +1583,9 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -1920,6 +1936,9 @@
 (PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEupdateOceanStress= /* update Ocean surf. stress */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1962,11 +1981,11 @@
 (PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
 (PID.TID 0000.0001)                 2.000000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag * density */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag */
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
 (PID.TID 0000.0001)                   F
@@ -2841,74 +2860,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   297
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   308
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   229 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   235 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   238 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   240 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   248 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   308 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   252 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   259 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   269 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   270 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   271 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   277 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   233 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   234 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   281 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   282 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   287 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   244 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   245 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   217 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   218 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   114 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   115 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   111 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   112 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   122 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   119 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   228 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   117 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   125 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   268  ADVxHEFF , Parms: UU      M1 , mate:   269
-(PID.TID 0000.0001)   set mate pointer for diag #   269  ADVyHEFF , Parms: VV      M1 , mate:   268
-(PID.TID 0000.0001)   set mate pointer for diag #   270  DFxEHEFF , Parms: UU      M1 , mate:   271
-(PID.TID 0000.0001)   set mate pointer for diag #   271  DFyEHEFF , Parms: VV      M1 , mate:   270
-(PID.TID 0000.0001)   set mate pointer for diag #   276  ADVxSNOW , Parms: UU      M1 , mate:   277
-(PID.TID 0000.0001)   set mate pointer for diag #   277  ADVySNOW , Parms: VV      M1 , mate:   276
-(PID.TID 0000.0001)   set mate pointer for diag #   278  DFxESNOW , Parms: UU      M1 , mate:   279
-(PID.TID 0000.0001)   set mate pointer for diag #   279  DFyESNOW , Parms: VV      M1 , mate:   278
-(PID.TID 0000.0001)   set mate pointer for diag #   233  SIuice   , Parms: UU      M1 , mate:   234
-(PID.TID 0000.0001)   set mate pointer for diag #   234  SIvice   , Parms: VV      M1 , mate:   233
+(PID.TID 0000.0001)   set mate pointer for diag #   279  ADVxHEFF , Parms: UU      M1 , mate:   280
+(PID.TID 0000.0001)   set mate pointer for diag #   280  ADVyHEFF , Parms: VV      M1 , mate:   279
+(PID.TID 0000.0001)   set mate pointer for diag #   281  DFxEHEFF , Parms: UU      M1 , mate:   282
+(PID.TID 0000.0001)   set mate pointer for diag #   282  DFyEHEFF , Parms: VV      M1 , mate:   281
+(PID.TID 0000.0001)   set mate pointer for diag #   287  ADVxSNOW , Parms: UU      M1 , mate:   288
+(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVySNOW , Parms: VV      M1 , mate:   287
+(PID.TID 0000.0001)   set mate pointer for diag #   289  DFxESNOW , Parms: UU      M1 , mate:   290
+(PID.TID 0000.0001)   set mate pointer for diag #   290  DFyESNOW , Parms: VV      M1 , mate:   289
+(PID.TID 0000.0001)   set mate pointer for diag #   244  SIuice   , Parms: UU      M1 , mate:   245
+(PID.TID 0000.0001)   set mate pointer for diag #   245  SIvice   , Parms: VV      M1 , mate:   244
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   217  GM_PsiX  , Parms: UU      LR , mate:   218
-(PID.TID 0000.0001)   set mate pointer for diag #   218  GM_PsiY  , Parms: VV      LR , mate:   217
-(PID.TID 0000.0001)   set mate pointer for diag #   114  DFxE_TH  , Parms: UU      MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  DFyE_TH  , Parms: VV      MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   111  ADVx_TH  , Parms: UU      MR , mate:   112
-(PID.TID 0000.0001)   set mate pointer for diag #   112  ADVy_TH  , Parms: VV      MR , mate:   111
-(PID.TID 0000.0001)   set mate pointer for diag #   121  DFxE_SLT , Parms: UU      MR , mate:   122
-(PID.TID 0000.0001)   set mate pointer for diag #   122  DFyE_SLT , Parms: VV      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVx_SLT , Parms: UU      MR , mate:   119
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADVy_SLT , Parms: VV      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   228  GM_PsiX  , Parms: UU      LR , mate:   229
+(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiY  , Parms: VV      LR , mate:   228
+(PID.TID 0000.0001)   set mate pointer for diag #   120  DFxE_TH  , Parms: UU      MR , mate:   121
+(PID.TID 0000.0001)   set mate pointer for diag #   121  DFyE_TH  , Parms: VV      MR , mate:   120
+(PID.TID 0000.0001)   set mate pointer for diag #   117  ADVx_TH  , Parms: UU      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVy_TH  , Parms: VV      MR , mate:   117
+(PID.TID 0000.0001)   set mate pointer for diag #   127  DFxE_SLT , Parms: UU      MR , mate:   128
+(PID.TID 0000.0001)   set mate pointer for diag #   128  DFyE_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   124  ADVx_SLT , Parms: UU      MR , mate:   125
+(PID.TID 0000.0001)   set mate pointer for diag #   125  ADVy_SLT , Parms: VV      MR , mate:   124
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -3028,6 +3047,9 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
@@ -3295,14 +3317,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -3314,6 +3334,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -3328,6 +3351,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -3388,7 +3414,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3404,6 +3430,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
 (PID.TID 0000.0001)                       0
@@ -3591,6 +3620,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -4714,6 +4752,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4961,7 +5002,7 @@
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.85834085263964E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   6.66839447788403E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.66839447788444E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4984,7 +5025,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.0389776212571E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2692573708558E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3261818659334E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.5029028151450E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.5029028151453E-10
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1694355439754E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2201337875924E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2656406738414E+01
@@ -5039,8 +5080,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543459189272E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535714105E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239365897769E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6152467432531E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.8700780567934E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6152467432534E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.8700780567816E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5155,10 +5196,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01131396022771E+00  1.10183783642727E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.03305191671418E-01
+ cg2d: Sum(rhs),rhsMax =   3.01131396022769E+00  1.10183783642727E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.03305191671607E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      97
-(PID.TID 0000.0001)      cg2d_last_res =   6.88065592611198E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.88065592612727E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5181,7 +5222,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9536906712839E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0928693107003E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2072774739867E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0337237595168E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0337237595188E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1049614562465E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.8305652230027E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2641500127209E+01
@@ -5236,8 +5277,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543433051682E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535770861E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720990856E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6686031460493E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.6524532991449E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6686031460553E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.6524532995707E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5352,60 +5393,60 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01096844538345E+00  1.09717250638279E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.75435888899271E-01
+ cg2d: Sum(rhs),rhsMax =   3.01096205985609E+00  1.09717250638261E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.75506714366593E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      95
-(PID.TID 0000.0001)      cg2d_last_res =   6.79567229576437E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.79606470799206E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3328663160198E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5663553039192E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5298535540336E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4433614841291E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7984233535837E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8317328195642E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1029776170350E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5201796383513E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1941682835659E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7525472353946E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5532834722223E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4425714213786E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1407216132874E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3973933316010E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8853494869774E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.4501078719862E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1515801242092E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.4650163646360E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0595932966219E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5825374280043E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3328663160111E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5663553039476E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5298503221195E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4433613886407E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7984233827793E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8317328195732E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1029776170483E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5201796384518E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1941682835636E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7525472353880E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5532834722247E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4425714213692E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1407216132889E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3973933316026E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8853494869837E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.4501078713552E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1515801241955E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.4607248023845E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0595932864202E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5825373533504E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2629166101443E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421299759589E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905938727645E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063505490E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0884096679225E-04
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905938726917E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063506299E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0884097037331E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711523006047E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7457223472446E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688781725E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887796678825E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7128485714649E-05
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7457223472443E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688781699E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887796687073E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7128488167303E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.6856814224727E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.7180082412194E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.2907877960415E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6396663718416E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6713933294740E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.2904810180104E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6396630667495E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6716985660237E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -9.2659486649252E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8694471083597E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3952510075516E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.7812264254977E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3478073754211E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.1903728390350E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   8.5652665671364E-07
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1395880449833E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.9837586146975E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8694440156259E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3952479338317E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.7824773971003E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3478073749532E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.1903728395030E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   8.5560286794795E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1396272107124E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.9845735720806E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.9027013207119E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0961877443720E+00
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4337799390126E-02
@@ -5416,25 +5457,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0413840887959E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1478529499491E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7348878512936E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3866522208609E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8633625548549E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0689579924322E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0641573078071E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.8411554164722E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0871750570734E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0996466343896E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3839301899631E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.5536370279100E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1103170423417E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3866522208665E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8633625544354E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0689579924449E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0641573078127E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.8411554160535E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0871750570860E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0996466344022E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3839302267668E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.5536370279119E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1103170423418E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973303033E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0042367608897E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0042367608951E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.5104117294223E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543413680878E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535830102E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239972734732E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5733289660119E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.2835385834208E-08
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239972734733E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5733366187676E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.2836365646796E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5455,14 +5496,14 @@
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   2.2436069697112E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9461120201925E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7988896514628E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6862786590492E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9461116859264E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7988896050326E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6862775031821E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8228461174181E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3418204923559E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0476974468042E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.9045338847486E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3418201269010E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0476973945914E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.9045338405913E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.2319652361547E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -8.6736173798840E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2482394817013E-03
@@ -5487,15 +5528,15 @@
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1469991562767E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.5515538638587E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.4976339628411E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.0414190698969E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5863784245451E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.3488050015498E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0385390960079E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.4976339628410E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.0414187666095E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5863784314522E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.3488049808824E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0385390960080E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.3132705873887E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.9998840599226E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.8126899997831E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3232661767069E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.9998840068059E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.8126900000611E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3232661771574E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8848542238091E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.3040566798063E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0151300912066E+00
@@ -5513,14 +5554,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4901468161263E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2993503434651E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3822495778125E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8178139676827E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8879626682499E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0827251019351E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2341541638902E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4203555722298E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3506034062290E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8634159831125E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0412451061209E-11
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8178139598806E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8879626667275E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0827251007985E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2341541638903E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4203555722297E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3506034009173E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8634159897340E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0412451307969E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -5549,89 +5590,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01036721275297E+00  1.09443701678467E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.32353087723731E-01
+ cg2d: Sum(rhs),rhsMax =   3.01035579197634E+00  1.09443701672661E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.32355507564128E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   7.06000606322115E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.05971385137125E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3131623193182E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5299530531061E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5331940259333E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4445172172949E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7716638454660E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.1773368134157E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2468578314549E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5205028301062E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1958964412767E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7005763866946E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6615206496730E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4340042960147E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1479675734982E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3965047821977E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8286224827175E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3013725231577E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1944397607430E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.2563715182454E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0334643494264E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4362932435538E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2617215975615E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421416949284E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905969022843E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365967897983E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0873868016043E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3131623193616E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5299530534399E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5331882461121E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4445170633861E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7716639942904E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.1773368132981E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2468578291722E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5205028304514E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1958964410701E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7005763870695E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6615206496742E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4340042959461E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1479675729953E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3965047823646E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8286224826308E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3013725220246E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1944397608370E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.2567678824676E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0334643711302E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4362937160487E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2617215975616E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421416949286E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905969021575E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365967899332E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0873868531927E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711520602497E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7456382055587E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688800963E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887754063737E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7071363499361E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.8334870681293E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.4976339628411E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2722017967370E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3478096984865E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6136613455423E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7456382055562E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688800915E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887754078449E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7071365321092E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.8334870681296E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.4976339628410E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2721805489405E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3478059124017E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6140385034584E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.1497703549041E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9118064171920E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0644507296931E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1548757756161E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3299051361496E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.3159442103668E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   9.5481821801288E-07
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1087292063369E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8777983409464E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9118042228859E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0644460390514E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1621233761961E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3299051322014E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.3159442143150E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   9.5408994119549E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1087513628221E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8783087846344E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7960612181076E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0572030248839E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4214374866822E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0703937964356E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4023719229231E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0572030248819E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4214375360309E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0703937890833E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4023724755319E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3447743191057E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5561106391500E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.9362570861424E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1370733282237E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1555729903496E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5981642958067E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5797762425940E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8357583001613E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.9694000169522E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.5619387723967E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8549256591626E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8664468116849E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3826410258274E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.6607916145484E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1120050756273E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973292305E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.8604604663023E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.3562665139008E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5561106391497E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.9362570847676E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1370733287297E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1555730541048E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5981642954620E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5797762483716E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8357583000503E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.9694000166077E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.5619387782100E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8549256590517E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8664468115738E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3826410527496E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.6607916145447E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1120050755750E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973292317E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.8604604661303E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.3562665137816E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543397934305E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535890735E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240168670869E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0976823803879E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0636053801973E-08
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535890716E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240168670732E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0976878129965E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0636884424990E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5642,29 +5683,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.7604597778751E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8735660930830E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1459923112298E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.7604596634799E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8735660931997E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1459922965808E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -8.5219394370196E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9350086375686E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1907562728542E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -8.5219393378094E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9350086380608E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1907562752226E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9441232575687E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7993287064206E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6932695029914E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9441223136358E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7993285892522E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6932629178020E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8231867900970E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3423016560980E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0482887796886E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8807923930264E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.3630322002189E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3423010025336E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0482887486586E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8807923591707E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.3630322002235E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2453872257347E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1444436449240E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.4180595946594E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2453872257352E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1444436449236E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.4180595946556E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5684,15 +5725,15 @@
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1419459236811E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.4517337306647E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.4744368212671E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3179159278571E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.2895957073240E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4227036695896E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1858762740726E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0629923732473E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3179159278600E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.2895962392059E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4227036806912E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1858756720647E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0629923732472E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4397200922157E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.7899905050202E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7046033841704E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2142628955669E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.7899904055134E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7046033841817E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2142628943803E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.6673869324057E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.1954436301909E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9945169749291E+00
@@ -5709,15 +5750,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6937182364123E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4865810313694E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3009506304395E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3514913449301E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8169628038311E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8629587606728E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0815735598244E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3514913449309E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8169627947283E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8629587545743E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0815736268976E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2579313644305E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2883358292672E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502747089356E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8283228457901E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9730044878594E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2883358292667E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502746989849E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8283228575829E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9730045480551E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.4886747942940E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6668061282529E-08
@@ -5746,89 +5787,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01125917713043E+00  1.08987441759893E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.28293384885782E-01
+ cg2d: Sum(rhs),rhsMax =   3.01123678897512E+00  1.08987441772989E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.28304920710929E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   6.70368596469663E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70694198744425E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471025101E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314453959533E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5370106400311E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4455344848087E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7478621420908E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760081197292E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988948919E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5188484046078E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978008471243E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6574423630973E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383031966204E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223636554631E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1568587304687E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960114426888E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7812386968391E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424525691734E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868906687E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0903949671454E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260358354548E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3780995692665E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631432599E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421583298827E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009721967E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365936537400E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0862490992026E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471023971E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314453963471E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5369993142478E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4455341704629E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7478620479577E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760081194808E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988937003E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5188484045217E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978008468569E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6574423609001E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383031966187E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223636552645E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1568587287119E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960114430274E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7812386985024E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424525677656E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868906260E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0913384621288E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260357518337E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3780976309306E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631432600E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421583298836E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009719718E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365936539833E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0862491579078E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711518357461E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7455628111662E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688821446E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887712622005E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7009008822280E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9794468026160E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3179159278571E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7101896970947E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1651239042160E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5787546119126E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7455628111693E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688821353E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887712644882E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7009010987159E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9794468026162E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3179159278600E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7101497599929E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1651193583181E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5791362476943E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9541334658242E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8461281851364E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8658164603715E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3130488083931E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.4421814617735E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0909155295898E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0910424303185E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8155047031939E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9541292545788E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8461241349770E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8693897822434E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3130488184124E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.4421814517544E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0893303088134E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0911020293972E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8166822414191E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0067009882391E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4060605561066E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0490236911813E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9659899968846E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0067009882701E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4060607182278E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0490236720585E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9659893905576E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3394247024139E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5328358123751E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8403694028847E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1326784147239E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.8021403810707E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976242635883E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3023530924746E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568789068E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646709791293E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2850688255911E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634364903E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453155165E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3812156368561E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.7437360684492E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1149734258287E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973280346E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391231302921E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.1981391004394E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5328358123739E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8403683951474E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1326784008767E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.8021399677695E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976242643935E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3023530707064E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568789791E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646709799328E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2850688043168E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634365617E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453155888E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3812157052084E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.7437360684375E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1149734260238E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973280367E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391231307567E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.1981391011936E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543385125809E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535934354E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240320441966E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.9793726882335E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.1432046337871E-08
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535934321E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240320441234E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.9795470078835E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.1433144212225E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5839,29 +5880,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5720176953138E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884422993467E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1046309535827E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5720176774174E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884422961239E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1046309515019E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0071452146941E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554284495723E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1525783799829E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0071449433961E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554284519663E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1525783188081E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430832100519E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998689063188E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7079183555152E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430815223554E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998686366369E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7079145754689E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8235293926845E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3428077810189E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488347959134E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8581996925384E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4877998361164E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433313442993E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439868209696E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782529165895E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3428065003301E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488347059336E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8581992609278E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4877998360904E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433313444120E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439868210049E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782529178260E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5880,16 +5921,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131741560E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438714574E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5736727196588E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3836228167506E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1622397922670E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031861102E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131741556E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438714519E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5736733291965E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3836228288284E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1622390802784E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031861083E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660502712E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5890073027262E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7493137615384E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122766423437E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5890071929926E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7493137607503E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122766416902E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -5906,15 +5947,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3025509150153E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202661468606E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8161373077738E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8527309461976E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0829843144525E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804661005943E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282755144675E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3508370469030E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8082897746598E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9443847607273E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202661357133E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8161372908067E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8527309436572E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0829844089357E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804661005924E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282755144626E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3508370359297E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8082897881603E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9443848419267E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -5943,89 +5984,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01335712276496E+00  1.08661842979334E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.24920402259670E-01
+ cg2d: Sum(rhs),rhsMax =   3.01333102443492E+00  1.08661842989017E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.25006343999623E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   6.73804455202910E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.73862936833619E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2886080754306E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5304568523482E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5411704853772E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4462775133933E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7262053818737E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.2758892226834E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2741355681754E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5155651595586E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1982153618049E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6211374276549E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7969062919134E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4076933261284E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1660180671960E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3956865207466E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7414034683996E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.9084070698545E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2493033921620E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.1704226116143E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0336381794310E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3845496405475E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2886080751321E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5304568525377E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5411572691485E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4462771186207E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7262066261459E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.2758892234480E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2741355566379E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5155651582459E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1982153620591E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6211374189094E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7969062919183E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4076933262517E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1660180646966E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3956865215061E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7414034749784E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.9084070443742E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2493033924291E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.1702323735899E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0336380012451E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3845480951881E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2594399428768E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421788278523E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906060567107E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365968660283E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0849906556696E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421788278522E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906060564688E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365968662838E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0849907634672E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711516256021E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454995390538E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688846833E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887670866034E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6942890086517E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.1364399784318E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.0917164629790E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1423204953679E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1189852859047E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5483478308576E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454995390667E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688846724E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887670895885E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6942895049523E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.1364399784242E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.0917164638059E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1423162456914E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1189861073992E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5490285351951E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.2856876703622E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9964501605951E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821459757147E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9239833319608E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2970121163312E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.5691237863195E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.1890224614435E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0869503284214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7267760235248E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9964495762776E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821479079911E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9300466700163E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2970121340637E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.5691237685872E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.1884821091155E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0869946761148E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7284054450367E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5334456274282E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9517171952171E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3895024338989E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0350694014187E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7092340740506E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9517171952864E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3895026131858E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0350693847176E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7092348457768E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3340750877155E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5097466096264E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7527857069318E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1347027164197E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.7231403038820E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.6196729698662E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0248632965084E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4450623443690E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1480062710546E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.0081488051819E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4658101018577E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4757507290126E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3795479782983E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.8115931341451E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1151557335642E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973266682E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0026834018261E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.0415529923386E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5097466096244E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7527838916808E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1347026958565E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.7231403335463E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.6196729700482E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0248633092730E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4450623443713E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1480062679977E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.0081488210855E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4658101018629E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4757507290148E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3795481147308E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.8115931341383E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1151557358113E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973266722E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0026834025637E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.0415529919427E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543374447854E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535962590E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240441572089E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -9.8883313247927E-09
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.0350944016666E-08
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535962524E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240441570300E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -9.8873666415739E-09
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.0351825143318E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6036,29 +6077,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0976047449889E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8919636596549E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0695549828057E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0976048939235E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8919636563075E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0695550140802E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.3481305894301E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9622920047555E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1253189179155E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.3481306542065E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9622920061657E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1253189176185E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9438404734935E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8005650341176E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6801185831577E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9438390577980E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8005647960298E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6801068934322E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8238739425554E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3433331671486E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0493447597181E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8368281347375E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.6085812493902E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2418145778785E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1436162880650E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3410093433728E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3433316726902E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0493445586142E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8368290621601E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.6085812493478E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2418145780964E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1436162881179E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3410093430849E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6077,16 +6118,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6219941852612E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1521402093961E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6116067776970E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3255723469036E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.2606226965489E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0802899596295E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4744037952576E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2800117606098E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1094534261191E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3255723469035E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.2606226965495E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0802899930130E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4744038031697E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2800111854551E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1094534261186E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6947516715398E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.3983849558602E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9443842826012E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3176285843917E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.3983849177530E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9443842812036E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3176285822155E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.2324523495989E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.4407348923388E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9532907423740E+00
@@ -6103,15 +6144,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6718525851041E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4812919343602E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3041511974036E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2887063407525E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8153808209430E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8574497363354E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0869553509514E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3030402639042E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2268733606013E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3524354704133E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8036007331299E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9561937940490E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2887063141253E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8153807998664E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8574497259111E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0869554527311E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3030402639037E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2268733605952E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3524354666026E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8036007389881E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9561938381101E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.7391222779732E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.3183406187123E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7082178872092E-08
@@ -6140,89 +6181,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01634786414106E+00  1.08470790956319E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.17287405270008E-01
+ cg2d: Sum(rhs),rhsMax =   3.01630609421655E+00  1.08470791308250E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.17361555769835E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      90
-(PID.TID 0000.0001)      cg2d_last_res =   6.40461887430414E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.40534713820284E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2495278617962E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5239543174701E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5455258985171E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4466347168631E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7070316532456E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9302832002801E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0431170705097E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5110678429611E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1962505180398E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5902442547892E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8517333892464E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3905845775369E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1754293890816E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3959238815969E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7077900390822E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.7923507769319E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2556007251106E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1048257119531E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0482008517249E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4250594660477E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2495278613518E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5239543174108E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5455047280884E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4466341013239E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7070315725610E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9302831999481E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0431170578371E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5110678372601E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1962505197572E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5902442421204E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8517333892609E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3905845776188E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1754293837360E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3959238824440E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7077900487757E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.7923510110257E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2556007251136E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1049208335664E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0482007458779E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4250585810655E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2583503061519E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422021144561E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906121371276E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063754557E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0836954448558E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422021144567E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906121367510E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063758691E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0836954349402E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711514283324E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454488296391E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688877898E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887628666637E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6875514703801E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.3850754661007E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3637787079130E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5679878023131E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2172684348684E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5538152868806E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454488296653E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688877724E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887628710965E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6875517039524E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.3850754660989E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3637787060156E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5679332445049E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2172667137984E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5534056621964E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0387550164606E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8882751299613E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.3405818673666E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2817056394422E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.6968155917422E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2449222558243E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0973496692309E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7309637614356E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0387494178422E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8882775121707E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.3413145217337E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2817056633686E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.6968155678158E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2426486803162E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0974192212535E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7303005492109E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9024782109673E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3738864277602E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0290431777786E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7363272396569E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9024782112866E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3738865233474E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0290431749878E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7363283573551E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3287254822510E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4863918790795E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6606299005568E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1433068497849E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.9184127199941E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3502693440761E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.7516411035758E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2863272514137E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4510703495679E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7340554639528E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3077142223392E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3170156109806E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3775468694252E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.8702647555745E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1115822670684E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973251789E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0302572365882E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8906854049493E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4863918790812E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6606284664182E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1433068405954E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.9184128157341E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3502693427241E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.7516411024202E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2863272513270E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4510703474108E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7340554630494E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3077142222517E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3170156108938E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3775470555820E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.8702647555753E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1115822725196E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973251836E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0302572361572E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8906854055841E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543365520953E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535976294E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240548436627E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -6.5802400153930E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.5240894015159E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543365520952E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535976218E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240548434057E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -6.5797770902277E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.5242743542322E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6233,29 +6274,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.2971463327300E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8865177534134E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0457995856769E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.2971456674938E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8865177635047E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0457996439872E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.5582885497165E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9594886156688E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1069437214451E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.5582892438840E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9594886121225E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1069437426507E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9450937204524E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8012371404461E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6529287790414E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9450912489132E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8012365667512E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6529203366100E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8242204407288E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3438678122781E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0498316370743E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8172143046535E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.7221826808892E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2406523034623E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1432609688837E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3072139063102E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3438654183751E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0498313653978E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8172139774455E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.7221826809102E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2406523039060E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1432609689580E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3072139024100E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6274,16 +6315,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.5380229346511E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1672104366781E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.1371690064713E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2541554891240E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.5153462517261E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4970888774798E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.6812797876446E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5281405836420E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1320020691568E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.8234205268129E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.2190778395671E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.2804130745580E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5169680997703E-10
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2541554891247E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.5153462517285E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4970889505719E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.6812797979511E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5281401641924E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1320020691581E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.8234205268128E-06
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.2190777357825E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.2804130716110E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5169680943605E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.1230918947362E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.9974688084646E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9326776260964E+00
@@ -6300,15 +6341,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6636862312512E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4795752084831E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3057514779055E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3084956038619E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8147201519236E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8770382814385E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0934636476236E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3249128302428E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4056976151691E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3551654169809E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8146819113110E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0105714961760E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3084956038722E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8147201141431E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8770382802615E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0934637036552E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3249128302442E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4056976151958E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3551654066024E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8146819261082E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0105715149680E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.8643460198128E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -3.0412607572472E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7289237666874E-08
@@ -6337,89 +6378,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01997358887212E+00  1.08353186361960E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.10625894263036E-01
+ cg2d: Sum(rhs),rhsMax =   3.01994931144849E+00  1.08353186201077E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.10574078112985E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      87
-(PID.TID 0000.0001)      cg2d_last_res =   7.00219283495057E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.00091534803738E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1960826678667E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5071468371812E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5499587496141E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465681474321E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6908105083736E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6338723676212E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7727327895179E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5060462044977E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1921712458149E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5637943074632E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9153185167876E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3717328405785E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1847145929446E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3969303645922E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.6792619440517E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.8040621380961E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2472373278469E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1384052439399E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0616646887846E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4733985005741E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1960826677746E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5071468372769E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5499464025691E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465677888164E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6908124049130E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6338723670683E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7727327944834E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5060461975291E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1921712488068E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5637942959154E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9153185166263E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3717328406962E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1847145863939E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3969303656418E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.6792619533176E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.8040691424968E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2472373280465E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1383426427431E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0616645551166E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4733985815246E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572923344626E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422270418111E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906191925021E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366221546753E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0823340057817E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422270418136E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906191922529E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366221549322E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0823339902314E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711512421740E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454128681713E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688915503E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887586138568E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6807348058682E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.6319518295653E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.5674522773681E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.9874631803048E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.4417813759788E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5693151199941E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454128682047E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688915401E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887586161040E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6807351396124E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.6319518295708E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.5674522683600E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.9875193822641E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.4417811872763E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5692186443154E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.0191167862034E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0810310350163E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.1393563119837E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   9.0634271328450E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2670597039430E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8253013782425E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2670566052348E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1208349206180E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7261792312207E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0810371095041E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.1393540316038E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   9.0558982529755E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2670597170027E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8253013651829E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2695786224096E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1207551830238E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7275492934825E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.1371588902365E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8593129836749E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3575013474172E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0307222211448E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9657963601399E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8593129842090E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3575013883114E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0307222224694E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9657980698121E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3233759060640E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4628043948842E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.5496450563154E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1582156111157E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3386370503142E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2644794919367E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5631214012520E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1527407351518E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.6144651951019E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4745367162196E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1746621528465E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1834291207783E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3751866875395E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.9236127553655E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1053109575196E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973236196E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0157338278321E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7485479723433E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4628043948901E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.5496434568145E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1582156053650E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3386375060129E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2644794908991E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5631214172112E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1527407351022E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.6144651940027E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4745367354705E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1746621527969E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1834291207286E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3751867569090E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.9236127552910E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1053109660950E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973236272E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0157338278508E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7485479753791E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543358219206E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535972866E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240652686176E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.1153040716165E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.4104701649485E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543358219204E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535972741E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240652683180E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.1153310938689E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.4102324570255E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6430,29 +6471,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.2400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0969799087129E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8738025986284E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0322364263610E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0969782968985E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8738026228248E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0322365073012E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.6369832365256E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9518612029561E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1008430153784E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.6369848961586E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9518611918780E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1008429955062E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9460802295373E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8018997835246E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6296572864304E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9460783773504E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8018994000725E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6296536118283E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8245688572963E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3444059979821E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0503117897830E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.7998723779237E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.8245670716318E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3444046017879E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0503116817452E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.7998747274890E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.8245670716230E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2396338606503E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1428995174814E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.2772787850359E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2396338614324E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1428995176234E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.2772787791379E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6461,254 +6502,254 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427572453951455D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490822412886302D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101769685003368D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427572459646263D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490822425213596D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101769711713425D+0617
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918394866837757D+07
+(PID.TID 0000.0001)  --> fc               = 0.918394884859858D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631026589701D+06
-(PID.TID 0000.0001)  global fc =  0.918394866837757D+07
+(PID.TID 0000.0001)   local fc =  0.829631037263511D+06
+(PID.TID 0000.0001)  global fc =  0.918394884859858D+07
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   111.29807736724615
-(PID.TID 0000.0001)         System time:   7.3708801269531250
-(PID.TID 0000.0001)     Wall clock time:   162.49170589447021
+(PID.TID 0000.0001)           User time:   184.96188858151436
+(PID.TID 0000.0001)         System time:   6.5989972054958344
+(PID.TID 0000.0001)     Wall clock time:   233.09662008285522
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   8.3327338919043541
-(PID.TID 0000.0001)         System time:  0.51392197608947754
-(PID.TID 0000.0001)     Wall clock time:   18.658051967620850
+(PID.TID 0000.0001)           User time:   9.1786043941974640
+(PID.TID 0000.0001)         System time:  0.60290798544883728
+(PID.TID 0000.0001)     Wall clock time:   23.720857858657837
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   102.96534347534180
-(PID.TID 0000.0001)         System time:   6.8569581508636475
-(PID.TID 0000.0001)     Wall clock time:   143.83348011970520
+(PID.TID 0000.0001)           User time:   175.78328418731689
+(PID.TID 0000.0001)         System time:   5.9960892200469971
+(PID.TID 0000.0001)     Wall clock time:   209.37569689750671
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   13.889888763427734
-(PID.TID 0000.0001)         System time:   1.2998030185699463
-(PID.TID 0000.0001)     Wall clock time:   22.477663040161133
+(PID.TID 0000.0001)           User time:   20.137938499450684
+(PID.TID 0000.0001)         System time:  0.87186801433563232
+(PID.TID 0000.0001)     Wall clock time:   26.510812997817993
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   89.075454711914063
-(PID.TID 0000.0001)         System time:   5.5571551322937012
-(PID.TID 0000.0001)     Wall clock time:   121.35576200485229
+(PID.TID 0000.0001)           User time:   155.64534568786621
+(PID.TID 0000.0001)         System time:   5.1242212057113647
+(PID.TID 0000.0001)     Wall clock time:   182.86483407020569
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.3357963562011719
-(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
-(PID.TID 0000.0001)     Wall clock time:   1.3402690887451172
+(PID.TID 0000.0001)           User time:   1.6067619323730469
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.6074078083038330
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  1.99890136718750000E-003
+(PID.TID 0000.0001)           User time:  6.98852539062500000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.68912315368652344E-003
+(PID.TID 0000.0001)     Wall clock time:  4.63223457336425781E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   79.731884002685547
-(PID.TID 0000.0001)         System time:   5.1592162847518921
-(PID.TID 0000.0001)     Wall clock time:   109.27223682403564
+(PID.TID 0000.0001)           User time:   144.52904510498047
+(PID.TID 0000.0001)         System time:   4.8282659053802490
+(PID.TID 0000.0001)     Wall clock time:   169.61703038215637
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   79.730884552001953
-(PID.TID 0000.0001)         System time:   5.1592162847518921
-(PID.TID 0000.0001)     Wall clock time:   109.27197480201721
+(PID.TID 0000.0001)           User time:   144.52904510498047
+(PID.TID 0000.0001)         System time:   4.8282659053802490
+(PID.TID 0000.0001)     Wall clock time:   169.61676955223083
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.72089004516601563
+(PID.TID 0000.0001)           User time:   1.9046993255615234
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.72129821777343750
+(PID.TID 0000.0001)     Wall clock time:   1.9058051109313965
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.24396133422851563
-(PID.TID 0000.0001)         System time:  1.99985504150390625E-003
-(PID.TID 0000.0001)     Wall clock time:  0.24737954139709473
+(PID.TID 0000.0001)           User time:  0.51293754577636719
+(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
+(PID.TID 0000.0001)     Wall clock time:  0.51328992843627930
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.91986083984375000
-(PID.TID 0000.0001)         System time:  0.30095398426055908
-(PID.TID 0000.0001)     Wall clock time:   1.2791330814361572
+(PID.TID 0000.0001)           User time:   1.1618232727050781
+(PID.TID 0000.0001)         System time:  0.15097820758819580
+(PID.TID 0000.0001)     Wall clock time:   1.3425555229187012
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.91186714172363281
-(PID.TID 0000.0001)         System time:  0.30095398426055908
-(PID.TID 0000.0001)     Wall clock time:   1.2715897560119629
+(PID.TID 0000.0001)           User time:   1.1458320617675781
+(PID.TID 0000.0001)         System time:  0.15097820758819580
+(PID.TID 0000.0001)     Wall clock time:   1.3264050483703613
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.44958496093750000E-004
+(PID.TID 0000.0001)     Wall clock time:  1.40666961669921875E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17097282409667969
-(PID.TID 0000.0001)         System time:  2.19974517822265625E-002
-(PID.TID 0000.0001)     Wall clock time:  0.19208335876464844
+(PID.TID 0000.0001)           User time:  0.17497825622558594
+(PID.TID 0000.0001)         System time:  9.99748706817626953E-003
+(PID.TID 0000.0001)     Wall clock time:  0.18647909164428711
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.09941864013671875E-002
+(PID.TID 0000.0001)           User time:  4.79793548583984375E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.55532264709472656E-002
+(PID.TID 0000.0001)     Wall clock time:  4.98595237731933594E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.169851303100586
-(PID.TID 0000.0001)         System time:  0.71389222145080566
-(PID.TID 0000.0001)     Wall clock time:   14.984013795852661
+(PID.TID 0000.0001)           User time:   28.185729980468750
+(PID.TID 0000.0001)         System time:  0.59191250801086426
+(PID.TID 0000.0001)     Wall clock time:   28.803359746932983
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   4.2283592224121094
-(PID.TID 0000.0001)         System time:  0.39993953704833984
-(PID.TID 0000.0001)     Wall clock time:   4.6263866424560547
+(PID.TID 0000.0001)           User time:   8.0337829589843750
+(PID.TID 0000.0001)         System time:  0.33194875717163086
+(PID.TID 0000.0001)     Wall clock time:   8.3700397014617920
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   3.9693889617919922
-(PID.TID 0000.0001)         System time:  0.35894393920898438
-(PID.TID 0000.0001)     Wall clock time:   4.3293797969818115
+(PID.TID 0000.0001)           User time:   7.5548648834228516
+(PID.TID 0000.0001)         System time:  0.26595759391784668
+(PID.TID 0000.0001)     Wall clock time:   7.8289067745208740
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.0875205993652344
-(PID.TID 0000.0001)         System time:  4.99892234802246094E-003
-(PID.TID 0000.0001)     Wall clock time:   3.1278221607208252
+(PID.TID 0000.0001)           User time:   7.3638420104980469
+(PID.TID 0000.0001)         System time:  1.09978914260864258E-002
+(PID.TID 0000.0001)     Wall clock time:   7.3781034946441650
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   10.869348526000977
-(PID.TID 0000.0001)         System time:  1.99959278106689453E-002
-(PID.TID 0000.0001)     Wall clock time:   10.902231216430664
+(PID.TID 0000.0001)           User time:   25.991035461425781
+(PID.TID 0000.0001)         System time:  6.99794292449951172E-003
+(PID.TID 0000.0001)     Wall clock time:   26.025759696960449
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.77987670898437500
-(PID.TID 0000.0001)         System time:  0.41193819046020508
-(PID.TID 0000.0001)     Wall clock time:   1.1863889694213867
+(PID.TID 0000.0001)           User time:  0.59191131591796875
+(PID.TID 0000.0001)         System time:  0.17297351360321045
+(PID.TID 0000.0001)     Wall clock time:  0.76579451560974121
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1548271179199219
-(PID.TID 0000.0001)         System time:  7.89885520935058594E-002
-(PID.TID 0000.0001)     Wall clock time:   1.2343888282775879
+(PID.TID 0000.0001)           User time:   2.8585815429687500
+(PID.TID 0000.0001)         System time:  0.11498200893402100
+(PID.TID 0000.0001)     Wall clock time:   2.9747333526611328
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16797065734863281
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.16982960700988770
+(PID.TID 0000.0001)           User time:  0.51389694213867188
+(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
+(PID.TID 0000.0001)     Wall clock time:  0.51527714729309082
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45293235778808594
-(PID.TID 0000.0001)         System time:  1.69959068298339844E-002
-(PID.TID 0000.0001)     Wall clock time:  0.46807026863098145
+(PID.TID 0000.0001)           User time:   1.1008415222167969
+(PID.TID 0000.0001)         System time:  6.00004196166992188E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1066582202911377
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.69947052001953125E-002
+(PID.TID 0000.0001)           User time:  5.00144958496093750E-002
 (PID.TID 0000.0001)         System time:  9.98973846435546875E-004
-(PID.TID 0000.0001)     Wall clock time:  2.74999141693115234E-002
+(PID.TID 0000.0001)     Wall clock time:  5.29921054840087891E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.49792289733886719
-(PID.TID 0000.0001)         System time:  4.89935874938964844E-002
-(PID.TID 0000.0001)     Wall clock time:  0.57064342498779297
+(PID.TID 0000.0001)           User time:  0.62287139892578125
+(PID.TID 0000.0001)         System time:  7.69870281219482422E-002
+(PID.TID 0000.0001)     Wall clock time:  0.70419549942016602
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.494102478027344
-(PID.TID 0000.0001)         System time:  0.43093442916870117
-(PID.TID 0000.0001)     Wall clock time:   12.994790077209473
+(PID.TID 0000.0001)           User time:   26.059059143066406
+(PID.TID 0000.0001)         System time:   1.2678083181381226
+(PID.TID 0000.0001)     Wall clock time:   27.345115900039673
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.49011611938476563E-004
+(PID.TID 0000.0001)     Wall clock time:  1.41382217407226563E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.36375427246093750E-004
+(PID.TID 0000.0001)     Wall clock time:  1.34468078613281250E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5506172180175781
-(PID.TID 0000.0001)         System time:  0.23596405982971191
-(PID.TID 0000.0001)     Wall clock time:   2.7854993343353271
+(PID.TID 0000.0001)           User time:   5.8951187133789063
+(PID.TID 0000.0001)         System time:  0.36294603347778320
+(PID.TID 0000.0001)     Wall clock time:   6.2606060504913330
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.35421752929687500E-004
+(PID.TID 0000.0001)     Wall clock time:  1.42097473144531250E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.622928619384766
-(PID.TID 0000.0001)         System time:   2.2156612873077393
-(PID.TID 0000.0001)     Wall clock time:   30.476047992706299
+(PID.TID 0000.0001)           User time:   13.391963958740234
+(PID.TID 0000.0001)         System time:   1.2958021163940430
+(PID.TID 0000.0001)     Wall clock time:   26.892013072967529
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9682464599609375
-(PID.TID 0000.0001)         System time:  0.62190628051757813
-(PID.TID 0000.0001)     Wall clock time:   15.007636785507202
+(PID.TID 0000.0001)           User time:   5.5811614990234375
+(PID.TID 0000.0001)         System time:  0.73788785934448242
+(PID.TID 0000.0001)     Wall clock time:   14.234842061996460
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1858215332031250
-(PID.TID 0000.0001)         System time:  5.89909553527832031E-002
-(PID.TID 0000.0001)     Wall clock time:   2.5022280216217041
+(PID.TID 0000.0001)           User time:   1.3247985839843750
+(PID.TID 0000.0001)         System time:  7.89880752563476563E-002
+(PID.TID 0000.0001)     Wall clock time:   2.2661590576171875
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.91006469726562500E-004
+(PID.TID 0000.0001)     Wall clock time:  6.69002532958984375E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.7539749145507813
-(PID.TID 0000.0001)         System time:  0.32895040512084961
-(PID.TID 0000.0001)     Wall clock time:   8.1374790668487549
+(PID.TID 0000.0001)           User time:   8.0407867431640625
+(PID.TID 0000.0001)         System time:  0.20996809005737305
+(PID.TID 0000.0001)     Wall clock time:   9.2010281085968018
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   5.5051651000976563
-(PID.TID 0000.0001)         System time:  0.31195306777954102
-(PID.TID 0000.0001)     Wall clock time:   6.8687400817871094
+(PID.TID 0000.0001)           User time:   6.6849975585937500
+(PID.TID 0000.0001)         System time:  0.18197202682495117
+(PID.TID 0000.0001)     Wall clock time:   7.8148989677429199
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.2488098144531250
-(PID.TID 0000.0001)         System time:  1.69973373413085938E-002
-(PID.TID 0000.0001)     Wall clock time:   1.2686789035797119
+(PID.TID 0000.0001)           User time:   1.3557891845703125
+(PID.TID 0000.0001)         System time:  2.79960632324218750E-002
+(PID.TID 0000.0001)     Wall clock time:   1.3860778808593750
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  3.99780273437500000E-003
-(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
-(PID.TID 0000.0001)     Wall clock time:  2.96139717102050781E-002
+(PID.TID 0000.0001)           User time:  7.00378417968750000E-003
+(PID.TID 0000.0001)         System time:  4.00018692016601563E-003
+(PID.TID 0000.0001)     Wall clock time:  3.22999954223632813E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6759,9 +6800,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          38060
+(PID.TID 0000.0001) //            No. barriers =          38018
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          38060
+(PID.TID 0000.0001) //     Total barrier spins =          38018
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.ecmwf.txt
+++ b/global_oce_llc90/results/output.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint66h
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67l
 (PID.TID 0000.0001) // Build user:        gforget
-(PID.TID 0000.0001) // Build host:        GLACIER2.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Thu Jun 15 15:27:47 EDT 2017
+(PID.TID 0000.0001) // Build host:        GLACIER3.MIT.EDU
+(PID.TID 0000.0001) // Build date:        Fri Aug 30 15:54:21 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -52,12 +52,14 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER2.MIT.EDU
+(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER3.MIT.EDU
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 23,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -620,6 +622,8 @@
 (PID.TID 0000.0001) > mxlSurfFlag=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -744,6 +748,15 @@
 (PID.TID 0000.0001) >      HsnowFile='siHSNOW.ini',
 (PID.TID 0000.0001) >      uIceFile='siUICE.ini',
 (PID.TID 0000.0001) >      vIceFile='siVICE.ini',
+(PID.TID 0000.0001) >#the following is needed to recover old default values
+(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >      SEAICE_drag=0.002,
+(PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
+(PID.TID 0000.0001) >      SEAICEetaZmethod=0,
+(PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
+(PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
+(PID.TID 0000.0001) >      SEAICE_OLx=0,
+(PID.TID 0000.0001) >      SEAICE_OLy=0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
@@ -1401,6 +1414,9 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -1716,6 +1732,9 @@
 (PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEupdateOceanStress= /* update Ocean surf. stress */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1758,11 +1777,11 @@
 (PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
 (PID.TID 0000.0001)                 2.000000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag * density */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag */
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
 (PID.TID 0000.0001)                   F
@@ -2637,74 +2656,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   297
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   308
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   229 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   235 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   238 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   240 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   248 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   308 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   252 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   259 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   269 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   270 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   271 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   277 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   233 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   234 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   281 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   282 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   287 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   244 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   245 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   217 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   218 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   114 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   115 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   111 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   112 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   122 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   119 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   228 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   117 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   125 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   268  ADVxHEFF , Parms: UU      M1 , mate:   269
-(PID.TID 0000.0001)   set mate pointer for diag #   269  ADVyHEFF , Parms: VV      M1 , mate:   268
-(PID.TID 0000.0001)   set mate pointer for diag #   270  DFxEHEFF , Parms: UU      M1 , mate:   271
-(PID.TID 0000.0001)   set mate pointer for diag #   271  DFyEHEFF , Parms: VV      M1 , mate:   270
-(PID.TID 0000.0001)   set mate pointer for diag #   276  ADVxSNOW , Parms: UU      M1 , mate:   277
-(PID.TID 0000.0001)   set mate pointer for diag #   277  ADVySNOW , Parms: VV      M1 , mate:   276
-(PID.TID 0000.0001)   set mate pointer for diag #   278  DFxESNOW , Parms: UU      M1 , mate:   279
-(PID.TID 0000.0001)   set mate pointer for diag #   279  DFyESNOW , Parms: VV      M1 , mate:   278
-(PID.TID 0000.0001)   set mate pointer for diag #   233  SIuice   , Parms: UU      M1 , mate:   234
-(PID.TID 0000.0001)   set mate pointer for diag #   234  SIvice   , Parms: VV      M1 , mate:   233
+(PID.TID 0000.0001)   set mate pointer for diag #   279  ADVxHEFF , Parms: UU      M1 , mate:   280
+(PID.TID 0000.0001)   set mate pointer for diag #   280  ADVyHEFF , Parms: VV      M1 , mate:   279
+(PID.TID 0000.0001)   set mate pointer for diag #   281  DFxEHEFF , Parms: UU      M1 , mate:   282
+(PID.TID 0000.0001)   set mate pointer for diag #   282  DFyEHEFF , Parms: VV      M1 , mate:   281
+(PID.TID 0000.0001)   set mate pointer for diag #   287  ADVxSNOW , Parms: UU      M1 , mate:   288
+(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVySNOW , Parms: VV      M1 , mate:   287
+(PID.TID 0000.0001)   set mate pointer for diag #   289  DFxESNOW , Parms: UU      M1 , mate:   290
+(PID.TID 0000.0001)   set mate pointer for diag #   290  DFyESNOW , Parms: VV      M1 , mate:   289
+(PID.TID 0000.0001)   set mate pointer for diag #   244  SIuice   , Parms: UU      M1 , mate:   245
+(PID.TID 0000.0001)   set mate pointer for diag #   245  SIvice   , Parms: VV      M1 , mate:   244
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   217  GM_PsiX  , Parms: UU      LR , mate:   218
-(PID.TID 0000.0001)   set mate pointer for diag #   218  GM_PsiY  , Parms: VV      LR , mate:   217
-(PID.TID 0000.0001)   set mate pointer for diag #   114  DFxE_TH  , Parms: UU      MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  DFyE_TH  , Parms: VV      MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   111  ADVx_TH  , Parms: UU      MR , mate:   112
-(PID.TID 0000.0001)   set mate pointer for diag #   112  ADVy_TH  , Parms: VV      MR , mate:   111
-(PID.TID 0000.0001)   set mate pointer for diag #   121  DFxE_SLT , Parms: UU      MR , mate:   122
-(PID.TID 0000.0001)   set mate pointer for diag #   122  DFyE_SLT , Parms: VV      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVx_SLT , Parms: UU      MR , mate:   119
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADVy_SLT , Parms: VV      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   228  GM_PsiX  , Parms: UU      LR , mate:   229
+(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiY  , Parms: VV      LR , mate:   228
+(PID.TID 0000.0001)   set mate pointer for diag #   120  DFxE_TH  , Parms: UU      MR , mate:   121
+(PID.TID 0000.0001)   set mate pointer for diag #   121  DFyE_TH  , Parms: VV      MR , mate:   120
+(PID.TID 0000.0001)   set mate pointer for diag #   117  ADVx_TH  , Parms: UU      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVy_TH  , Parms: VV      MR , mate:   117
+(PID.TID 0000.0001)   set mate pointer for diag #   127  DFxE_SLT , Parms: UU      MR , mate:   128
+(PID.TID 0000.0001)   set mate pointer for diag #   128  DFyE_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   124  ADVx_SLT , Parms: UU      MR , mate:   125
+(PID.TID 0000.0001)   set mate pointer for diag #   125  ADVy_SLT , Parms: VV      MR , mate:   124
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2824,6 +2843,9 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
@@ -3091,14 +3113,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -3110,6 +3130,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -3124,6 +3147,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -3184,7 +3210,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3200,6 +3226,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
 (PID.TID 0000.0001)                       0
@@ -3387,6 +3416,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -4510,6 +4548,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4933,32 +4974,32 @@
  cg2d: Sum(rhs),rhsMax =  -3.02000398532765E-01  1.24442605872837E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.82875879833997E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.36980820445620E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.36980825770440E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.4847535134488E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5227615587005E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5213963505622E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5227615587007E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5213963505625E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0391766971844E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7354125175828E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7354125175764E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8847794536575E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.8256387900037E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5559753481166E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1666417071619E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6599160594991E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6599160595005E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4602213324423E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5776583139671E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7522366949673E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7522366949671E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2122273076319E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4930152630127E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4930152630148E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8992772254698E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3234478371643E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4043589509927E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6219938756060E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1037897516262E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4043589509483E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6219938756069E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1037897516264E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1213683153251E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002518370432E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920287767691E+00
@@ -5001,7 +5042,7 @@
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.5543391515074E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6631535948513E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7504166205010E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4783168883598E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4783168883597E-05
 (PID.TID 0000.0001) %MON ke_max                       =   4.3324431303683E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   1.4000474847133E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979032097E+18
@@ -5011,8 +5052,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541848415924E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525958251E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243354047594E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1824628039228E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4413367784032E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1824628039243E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4413367783984E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5132,45 +5173,45 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.56986859507562E-01  1.19140039587201E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.44155534147103E+00
+ cg2d: Sum(rhs),rhsMax =  -4.56986859507505E-01  1.19140039587202E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.44155534137691E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.93215053260444E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.93215057124343E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9895440474911E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9895440474916E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1356620133874E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2942224606787E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2942224606792E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8274511736614E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6901083866999E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6901083867009E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.1346651976133E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0586374895086E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0507374820407E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0507374820406E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4800432174831E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9965128360046E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9965128360048E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3629462142264E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0590565904937E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6556867683720E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6556867683710E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5690093873417E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.8069700630486E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.8069700630492E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351249651145E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438944643222E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6880769509926E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3675449644572E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9586436968636E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6880769509958E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3675449644586E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9586436968669E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1198300157509E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659307535E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920277560806E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365668906266E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2505485129768E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2505485129821E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697287110988E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0321082980081E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609333722E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184131997759E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1876778798174E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1876778798176E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3164619138511E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3576503753999E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.9105068695762E+00
@@ -5213,8 +5254,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541288565146E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524151714E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239609897484E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3278154817303E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6252185031313E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3278154817304E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6252185031325E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5225,14 +5266,14 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3501412559168E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3501412559169E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6807025877763E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1612868427308E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1612868427312E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.4348618279653E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7898424735660E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1735369601772E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1735369601775E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4855876876321E-02
@@ -5334,45 +5375,45 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -6.11539590156363E-01  1.15502291631287E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.17614230422967E+00
+ cg2d: Sum(rhs),rhsMax =  -6.11539590156384E-01  1.15502291631286E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.17614230393753E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.67184055862718E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.67184073080967E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0023090891650E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1101023794990E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0023090891648E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1101023794991E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.0603261319584E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4134953361375E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6831085151103E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6831085151130E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.3947651767308E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0812687227628E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8355768558991E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8355768558989E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7171645912718E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1906959590599E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1906959590606E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.1481509215915E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2754262393754E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1032384681598E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1032384681599E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8121925391860E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.9975763946297E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.9975763946305E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303505062949E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093769537383E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1703124333576E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2805685666952E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0164941687707E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1703124333624E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2805685666978E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0164941687712E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190094581192E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000927842206E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920327524223E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365563968049E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1828454834512E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1828454834553E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694842300136E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0358604313851E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608687579E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184235206219E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1594587637422E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1594587637423E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3083248972212E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.9304796689603E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.4780570598122E+00
@@ -5402,7 +5443,7 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8779871052212E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653708550834E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3548064499819E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.0556833496482E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.0556833496483E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636493917766E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3793486652059E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.0537991485602E-04
@@ -5416,7 +5457,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523427708E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236014540229E-05
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9124467475819E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6348993449284E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6348993449415E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5427,7 +5468,7 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3841044460529E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3841044460531E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7699405636085E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2945588695280E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
@@ -5446,7 +5487,7 @@
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2530515867583E-01
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6790202811069E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8019746816009E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4721851928459E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5107921377193E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9030018209313E-05
@@ -5470,7 +5511,7 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.5011878357440E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -7.5891368144760E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.0114535278433E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.0114535278434E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5437589473878E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2805843626358E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0058955798097E-07
@@ -5499,10 +5540,10 @@
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8404669477672E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0805694450627E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2760420233393E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022456374229E-08
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022456374230E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   4.2386414651998E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7429389207811E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8238480649313E-11
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8238480649312E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -5536,55 +5577,55 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.63315938093625E-01  1.13206050185098E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.11150095827952E+00
+ cg2d: Sum(rhs),rhsMax =  -7.63315938093643E-01  1.13206050185096E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.11150095797020E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   7.09318567358718E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.09318567249334E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0569024239889E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0569024239891E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3404153197037E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.8077628799791E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.8077628799789E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7885700169541E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702564858582E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702564858584E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4889639621598E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0746963214672E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.0971196652385E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9224906472310E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2783084120927E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.0017064307630E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2783084120935E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.0017064307626E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4854922185226E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3928180025684E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3928180025685E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9969752089655E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.0611039198100E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.0611039198109E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896460363130E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243149931181E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9652404556070E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6273349870137E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0865685287727E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9652404556464E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6273349870153E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0865685287731E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1187094351585E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000021542420E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920409390129E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365555445540E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1212612866962E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1212612864825E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692241471957E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0402933245071E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608218817E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184352356981E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1336875661720E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1336875661721E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2954404271878E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5891368144760E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -9.2710397790360E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -9.2710397790361E+00
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3217785382568E+02
 (PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2508225778774E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.1497703549041E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949049426858E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0596820905719E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8765699354714E-02
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949049512627E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0596820983606E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8766051358101E-02
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1374820351229E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3140251615358E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1364233714262E-05
@@ -5601,10 +5642,10 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2405816941905E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0401414339518E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2195110013910E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7915790069844E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7915790069843E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222453595078E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3040224593054E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.9479490422220E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.9479490422216E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344303485450E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679821592210E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.3548119327209E-04
@@ -5617,8 +5658,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540682599840E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523586243E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232518036131E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2832110045801E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4767752806375E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2832110045789E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4767752806345E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5634,7 +5675,7 @@
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3577521818662E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6609668343269E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6609668343270E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9489208773255E-01
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591568197535E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
@@ -5648,7 +5689,7 @@
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2512790907835E-01
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6673093657383E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7976638434108E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4581574038830E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5059170877630E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8830007138461E-05
@@ -5672,14 +5713,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.4517337306647E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.4232500586480E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3824594702747E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3450151241692E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3759571333410E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1131085429910E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3450151244639E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3759571333446E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1131085429938E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0268554814491E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4382817231233E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6700904221765E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6848725477635E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052382338005E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6700904221378E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6848725477643E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052382337998E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.6673869324057E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.1954436301909E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9945169749291E+00
@@ -5697,14 +5738,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4865810313694E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3174126476127E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281938337884E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7609246927459E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8157454481773E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7609246927385E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8157454481899E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0793285580628E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437698779E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510491053902E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2382847006512E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7131183678499E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7573986090913E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2382847006473E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7131183678556E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7573986090887E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.4886747942940E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6668061282529E-08
@@ -5738,10 +5779,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.10500110577915E-01  1.14261627760768E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05839405692297E+00
+ cg2d: Sum(rhs),rhsMax =  -9.10500110578022E-01  1.14261627760772E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.05839405692586E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     127
-(PID.TID 0000.0001)      cg2d_last_res =   6.99104628194739E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.99104628137686E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5749,54 +5790,54 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442301505229E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4309909848955E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.5347683980092E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9792180510236E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6664584395848E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4115219340613E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.5347683980091E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9792180510237E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6664584395846E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4115219340612E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9287497596653E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9259652557045E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9259652557046E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0951820589655E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2518248606763E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.5877321008347E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2518248606768E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.5877321008345E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.6089035854123E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2408441317467E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2408441317469E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1241464818467E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0117542294441E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0117542294416E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199500511752E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763262317164E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.0405892013376E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6303167422785E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1169026309569E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.0405892012743E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6303167422792E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1169026309565E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1178155785968E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998903443054E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920505925866E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365634602047E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0527674851138E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0527674848855E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689475792605E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0460217651131E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607902327E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184478519519E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1101007558267E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1101007558270E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2812570131230E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3824594702747E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3998548572394E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1412804166294E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2182107873657E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3998548572699E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1412804166326E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2182107879904E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400543766630E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437039342551E+02
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5828517999027E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8450174044296E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8450174044297E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2834467220937E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0780241057027E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7804136755450E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7010236553377E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7804136755454E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7010236552895E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9492914100275E+00
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3653502530048E-02
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1286641101337E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1242295323363E-04
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1242295323364E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.5871124362702E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -9.1609026020359E-01
 (PID.TID 0000.0001) %MON forcing_fv_mean              =   5.3537420620898E-03
@@ -5806,12 +5847,12 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.0118011731289E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775722278350E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.6718008008550E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4568000639788E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4568000639786E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995644619599E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8465144050914E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5150884644167E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.0523719743780E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4960480675447E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5150884644168E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.0523719743781E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4960480675448E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980132625E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -3.3498463986885E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.9610837993811E-05
@@ -5819,8 +5860,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540653913943E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524312950E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229819065337E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6170777310735E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1787045074705E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6170777310737E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1787045074614E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5831,26 +5872,26 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4523825975408E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4523825975407E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8569316289130E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4102281084328E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4102281084327E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6820247239151E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6820247239152E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9917426946570E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4276553054797E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4276553054795E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4546139852233E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.9132489680855E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3485506574769E-04
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3485506574768E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8266648281192E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4420291454015E-02
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2496263522631E-01
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6582993115613E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7933791721314E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4456123072984E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5018640832781E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8650552457926E-05
@@ -5874,14 +5915,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.3497258202672E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302679747522E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0623961886435E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3349478893356E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0869815787690E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0623961886714E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3349478893383E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0869815787710E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437283965E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5653315604409E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4703735571538E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7342103728120E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2031869196498E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4703735571172E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7342103728127E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2031869196493E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -5899,14 +5940,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3188121890605E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461434200493E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7591087101109E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8060742841909E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0806700668235E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7591087101039E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8060742842030E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0806700668234E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946959507E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881941340364E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2389736723458E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6979157040366E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7291564987915E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881941340360E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2389736723421E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6979157040420E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7291564987889E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -5940,62 +5981,62 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.05309291228333E+00  1.15147095899645E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.94285870169678E-01
+ cg2d: Sum(rhs),rhsMax =  -1.05309298382474E+00  1.15147095899657E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.94285914383923E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.39617707028866E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39617782616667E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379157919308E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3759554700047E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.2412073807967E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0431235212462E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702505639636E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4473187926812E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5112755190732E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4583108488139E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2288467526323E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0087443216816E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.7667861479723E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5983213367736E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5175086282190E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1910218678515E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8395841094052E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291428468958E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8472316351727E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.2697496106105E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5631297056243E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1176777540607E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960333894E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379157919388E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3759554699970E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.2412077428919E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0431235203643E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702505614365E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4473187926802E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5112755202460E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4583108485455E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2288467526396E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0087443216836E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.7667861479719E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5983213367738E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5175086283267E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1910218678467E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8395841094445E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291428468948E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8472316351737E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.2697521444352E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5631297056168E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1176777541180E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960333892E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997553602930E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920600603701E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365790312505E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9892685925322E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686526788758E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0532935486496E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920600603654E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365790312545E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9892686017955E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686526788755E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0532935486478E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607622155E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184609678908E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0889014377022E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2658041822201E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184609679011E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0889014373429E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2658041822202E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302679747522E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8679010418644E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0986499921944E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1831380610192E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8678990191367E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0986502376249E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1831363082066E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.2856876703622E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851874125750E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7820429678172E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6623797811372E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6634443183968E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2508585063398E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0192380924694E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7524170847356E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6065668867310E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851872102945E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7820430836224E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6623648742984E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6634443161169E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2508585086195E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0192391274567E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7524175090642E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6065662601667E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5334456274282E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9945049808293E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9945049808294E+00
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3416190618818E-02
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1195830942163E-01
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1254992980915E-04
@@ -6004,25 +6045,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =   5.2722241726811E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2428438686554E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0457948937662E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1101668972458E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8560255585823E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9252753363847E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7604636937433E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6159365536819E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1922862873153E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2237780655364E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5599199888067E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.9667658990016E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9043947991123E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1101668972457E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8560255585826E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9252753363921E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7604636937427E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6159365536816E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1922862873213E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2237780655425E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5599199893072E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.9667658991804E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9043947991111E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980392903E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.4865712986642E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.4865712986644E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.6593863937244E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540788155010E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525432948E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228296981110E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0841336430262E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6101762614474E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0841336406228E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6101763977386E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6033,26 +6074,26 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4401014263407E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4401014263405E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8752934535178E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4707571412521E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4707571412520E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6513815804356E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6513815804355E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0167847721556E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4945476144608E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4945476144604E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4447036794823E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9104189249965E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3575481764776E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4447036770828E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9104189242857E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3575481743115E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8619449180057E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4344495168304E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480742893060E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6514563586383E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4344495127359E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480742886562E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6514563558454E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7891156873197E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4343457881116E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4985075979004E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8488375394139E-05
@@ -6076,14 +6117,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6116067776970E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.2782969219858E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953487764E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4836284799258E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4264120942940E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2050716787635E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4836284822239E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4264120945046E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2050716783134E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104384915E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6931169411588E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2810625819061E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9332844588740E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084476073935E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2810625789521E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9332844588925E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084476073239E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.2324523495989E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.4407348923388E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9532907423740E+00
@@ -6101,14 +6142,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4812919343602E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3202165759534E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651287217129E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7574376275524E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8116163741006E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0845825678211E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2970736101905E-07
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7574376269527E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8116163743801E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0845825677757E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2970736101906E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539422647897E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2407032330179E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6975831831317E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7402278697938E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2407032327225E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6975831835457E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7402278697099E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.7391222779732E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.3183406187123E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7082178872092E-08
@@ -6142,89 +6183,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.19099782442204E+00  1.15876340902243E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.19211726470118E-01
+ cg2d: Sum(rhs),rhsMax =  -1.19099797945359E+00  1.15876340902246E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.19211886556689E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.60659624093187E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.60658108301966E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484194653767E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2472543285360E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.9264804977866E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0414527357283E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6738726157044E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4739243083609E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1714005708628E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9037078831712E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3156084066567E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0786260686179E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9246632382682E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4566019786146E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2747117580791E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2096598087970E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0563677879751E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256225935782E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224946687470E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.3823796027183E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6052623808843E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0978595965283E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154933921540E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484194653080E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2472543284292E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.9264812537596E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0414527360883E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6738726463057E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4739243083615E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1714005700303E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9037078826740E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3156084066734E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0786260686297E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9246632381187E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4566019785833E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2747117579084E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2096598087880E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0563677879815E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256225935828E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224946688065E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.3823783040298E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6052623832988E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0978595972796E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154933921538E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995968288077E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920685815858E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366013038116E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9339573556941E-05
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920685815821E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366013038150E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9339573484341E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684477642248E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0614328732072E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607303978E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184739607396E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0689074371418E-05
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0614328732064E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607303977E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184739607958E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0689074426384E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2486529841132E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953487764E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.3305331555973E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2007233678833E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1350578255332E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.3305336472762E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2007231091542E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1350628573483E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302980420161E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8898690953883E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.0902260655384E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.5305047558027E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2179342461370E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9587389927280E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7321772789698E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4671889697281E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302980876796E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8898689207118E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.0903076205953E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.5305047570705E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2179342448693E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9587401185632E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7321771356644E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4672029713473E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0268348738097E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3177077059084E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1184298464898E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1331183816286E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0268348738098E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3177077059738E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1184298464857E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1331183816443E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.6297472305817E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -8.8507984069753E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.1924322801974E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2539060524972E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0815898534835E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0997923415428E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.4741082639539E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.4433091736869E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5132865775766E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7530885136680E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7007618054970E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7371975201430E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5392667135437E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.6525510001203E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1013889248269E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.1924322808555E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2539060524955E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0815898534882E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0997923354803E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.4741082600899E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.4433091739234E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5132865777797E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7530885135382E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7007618057215E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7371975203697E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5392667116626E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.6525510000868E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1013889248191E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980645818E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.5254190021564E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6642921729655E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.5254190022366E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6642921730013E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541030042648E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526730508E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7227965180359E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6187391305323E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.0120121897232E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7227965180357E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6187392161608E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.0120128065340E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6235,29 +6276,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3733020437374E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8808303298643E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5297955533481E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3733020437107E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8808303298640E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5297955533682E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5836504318471E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0273208803402E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5589232883320E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5836504318022E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0273208803391E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5589232883617E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4345547568641E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9076700671404E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3409255965820E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4345547439998E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9076700655558E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3409255985664E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.9107326348270E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4270676867803E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2465930954786E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6467314188924E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4270676782320E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2465930997944E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6467313932949E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7848707996260E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4242247266494E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4956797991433E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8342897897104E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8342897897140E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6266,253 +6307,253 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.122184423134963D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.209013691805053D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.122184423759812D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.209013692423412D+05 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331198114940016D+05
+(PID.TID 0000.0001)  --> fc               = 0.331198116183225D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.918430359223504D+03
-(PID.TID 0000.0001)  global fc =  0.331198114940016D+05
+(PID.TID 0000.0001)   local fc =  0.918430277248316D+03
+(PID.TID 0000.0001)  global fc =  0.331198116183225D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   110.31023292988539
-(PID.TID 0000.0001)         System time:   5.9181001335382462
-(PID.TID 0000.0001)     Wall clock time:   159.76212096214294
+(PID.TID 0000.0001)           User time:   180.75952315330505
+(PID.TID 0000.0001)         System time:   7.6088431179523468
+(PID.TID 0000.0001)     Wall clock time:   230.35281991958618
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   8.3857248350977898
-(PID.TID 0000.0001)         System time:  0.63890297710895538
-(PID.TID 0000.0001)     Wall clock time:   17.619698047637939
+(PID.TID 0000.0001)           User time:   9.2125985622406006
+(PID.TID 0000.0001)         System time:  0.59291002154350281
+(PID.TID 0000.0001)     Wall clock time:   23.590605974197388
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   101.92450809478760
-(PID.TID 0000.0001)         System time:   5.2791971564292908
-(PID.TID 0000.0001)     Wall clock time:   142.14224982261658
+(PID.TID 0000.0001)           User time:   171.54692459106445
+(PID.TID 0000.0001)         System time:   7.0159330964088440
+(PID.TID 0000.0001)     Wall clock time:   206.76213908195496
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   12.132155418395996
-(PID.TID 0000.0001)         System time:  0.70389300584793091
-(PID.TID 0000.0001)     Wall clock time:   19.665928840637207
+(PID.TID 0000.0001)           User time:   15.790599822998047
+(PID.TID 0000.0001)         System time:  0.64290195703506470
+(PID.TID 0000.0001)     Wall clock time:   21.537355899810791
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   89.792352676391602
-(PID.TID 0000.0001)         System time:   4.5753041505813599
-(PID.TID 0000.0001)     Wall clock time:   122.47627210617065
+(PID.TID 0000.0001)           User time:   155.75632476806641
+(PID.TID 0000.0001)         System time:   6.3730311393737793
+(PID.TID 0000.0001)     Wall clock time:   185.22472715377808
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.5207786560058594
+(PID.TID 0000.0001)           User time:   1.7527484893798828
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.5243594646453857
+(PID.TID 0000.0001)     Wall clock time:   1.7565860748291016
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  2.99835205078125000E-003
+(PID.TID 0000.0001)           User time:  4.99153137207031250E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.87580490112304688E-003
+(PID.TID 0000.0001)     Wall clock time:  4.59027290344238281E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   81.988529205322266
-(PID.TID 0000.0001)         System time:   4.3353408575057983
-(PID.TID 0000.0001)     Wall clock time:   111.62922382354736
+(PID.TID 0000.0001)           User time:   146.08479499816895
+(PID.TID 0000.0001)         System time:   6.1030728816986084
+(PID.TID 0000.0001)     Wall clock time:   173.04482412338257
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   81.988529205322266
-(PID.TID 0000.0001)         System time:   4.3353408575057983
-(PID.TID 0000.0001)     Wall clock time:   111.62895464897156
+(PID.TID 0000.0001)           User time:   146.08479499816895
+(PID.TID 0000.0001)         System time:   6.1030728816986084
+(PID.TID 0000.0001)     Wall clock time:   173.04456496238708
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.78088760375976563
+(PID.TID 0000.0001)           User time:   1.8227233886718750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.77988409996032715
+(PID.TID 0000.0001)     Wall clock time:   1.8258357048034668
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.24497604370117188
-(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
-(PID.TID 0000.0001)     Wall clock time:  0.24788880348205566
+(PID.TID 0000.0001)           User time:  0.48394393920898438
+(PID.TID 0000.0001)         System time:  3.00002098083496094E-003
+(PID.TID 0000.0001)     Wall clock time:  0.48762726783752441
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.83386993408203125
-(PID.TID 0000.0001)         System time:  0.16697382926940918
-(PID.TID 0000.0001)     Wall clock time:   1.0220632553100586
+(PID.TID 0000.0001)           User time:   1.1988182067871094
+(PID.TID 0000.0001)         System time:  0.17897439002990723
+(PID.TID 0000.0001)     Wall clock time:   1.4139237403869629
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.82686996459960938
-(PID.TID 0000.0001)         System time:  0.16697382926940918
-(PID.TID 0000.0001)     Wall clock time:   1.0141167640686035
+(PID.TID 0000.0001)           User time:   1.1838245391845703
+(PID.TID 0000.0001)         System time:  0.17897439002990723
+(PID.TID 0000.0001)     Wall clock time:   1.3990969657897949
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:  9.99450683593750000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.45912170410156250E-004
+(PID.TID 0000.0001)     Wall clock time:  1.45673751831054688E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14397621154785156
-(PID.TID 0000.0001)         System time:  1.19992494583129883E-002
-(PID.TID 0000.0001)     Wall clock time:  0.15500926971435547
+(PID.TID 0000.0001)           User time:  0.18695640563964844
+(PID.TID 0000.0001)         System time:  5.99873065948486328E-003
+(PID.TID 0000.0001)     Wall clock time:  0.19076776504516602
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99928283691406250E-002
+(PID.TID 0000.0001)           User time:  4.50191497802734375E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.69150733947753906E-002
+(PID.TID 0000.0001)     Wall clock time:  4.96180057525634766E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.870746612548828
-(PID.TID 0000.0001)         System time:  0.67089915275573730
-(PID.TID 0000.0001)     Wall clock time:   15.543323993682861
+(PID.TID 0000.0001)           User time:   28.883596420288086
+(PID.TID 0000.0001)         System time:   1.1298292875289917
+(PID.TID 0000.0001)     Wall clock time:   30.037258625030518
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   5.1752166748046875
-(PID.TID 0000.0001)         System time:  0.38594174385070801
-(PID.TID 0000.0001)     Wall clock time:   5.5600290298461914
+(PID.TID 0000.0001)           User time:   9.8145027160644531
+(PID.TID 0000.0001)         System time:  0.39993870258331299
+(PID.TID 0000.0001)     Wall clock time:   10.217541933059692
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   4.8842544555664063
-(PID.TID 0000.0001)         System time:  0.34894704818725586
-(PID.TID 0000.0001)     Wall clock time:   5.2340483665466309
+(PID.TID 0000.0001)           User time:   9.3115711212158203
+(PID.TID 0000.0001)         System time:  0.35794544219970703
+(PID.TID 0000.0001)     Wall clock time:   9.6764001846313477
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.1225433349609375
-(PID.TID 0000.0001)         System time:  2.99894809722900391E-003
-(PID.TID 0000.0001)     Wall clock time:   3.1239848136901855
+(PID.TID 0000.0001)           User time:   6.7879962921142578
+(PID.TID 0000.0001)         System time:  3.00002098083496094E-003
+(PID.TID 0000.0001)     Wall clock time:   6.7981786727905273
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.056308746337891
-(PID.TID 0000.0001)         System time:  2.99894809722900391E-003
-(PID.TID 0000.0001)     Wall clock time:   11.063113927841187
+(PID.TID 0000.0001)           User time:   24.522274017333984
+(PID.TID 0000.0001)         System time:  2.99918651580810547E-003
+(PID.TID 0000.0001)     Wall clock time:   24.708682060241699
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.66788482666015625
-(PID.TID 0000.0001)         System time:  0.35294663906097412
-(PID.TID 0000.0001)     Wall clock time:   1.0208261013031006
+(PID.TID 0000.0001)           User time:   1.4817810058593750
+(PID.TID 0000.0001)         System time:  0.83687281608581543
+(PID.TID 0000.0001)     Wall clock time:   2.3201298713684082
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5337867736816406
-(PID.TID 0000.0001)         System time:  0.11098265647888184
-(PID.TID 0000.0001)     Wall clock time:   1.6417531967163086
+(PID.TID 0000.0001)           User time:   3.7884216308593750
+(PID.TID 0000.0001)         System time:  0.19797039031982422
+(PID.TID 0000.0001)     Wall clock time:   3.9848408699035645
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16596603393554688
+(PID.TID 0000.0001)           User time:  0.48592376708984375
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.17025685310363770
+(PID.TID 0000.0001)     Wall clock time:  0.48757529258728027
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45293235778808594
-(PID.TID 0000.0001)         System time:  1.99971199035644531E-002
-(PID.TID 0000.0001)     Wall clock time:  0.46834993362426758
+(PID.TID 0000.0001)           User time:   1.0838165283203125
+(PID.TID 0000.0001)         System time:  4.59926128387451172E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1293156147003174
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.29911804199218750E-002
-(PID.TID 0000.0001)         System time:  2.99882888793945313E-003
-(PID.TID 0000.0001)     Wall clock time:  2.81741619110107422E-002
+(PID.TID 0000.0001)           User time:  7.10144042968750000E-002
+(PID.TID 0000.0001)         System time:  8.99839401245117188E-003
+(PID.TID 0000.0001)     Wall clock time:  8.49862098693847656E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.49092292785644531
-(PID.TID 0000.0001)         System time:  5.29901981353759766E-002
-(PID.TID 0000.0001)     Wall clock time:  0.54695820808410645
+(PID.TID 0000.0001)           User time:  0.63288116455078125
+(PID.TID 0000.0001)         System time:  9.99804735183715820E-002
+(PID.TID 0000.0001)     Wall clock time:  0.73071432113647461
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.474946975708008
-(PID.TID 0000.0001)         System time:  0.57691431045532227
-(PID.TID 0000.0001)     Wall clock time:   14.052017688751221
+(PID.TID 0000.0001)           User time:   26.985885620117188
+(PID.TID 0000.0001)         System time:   1.0718389749526978
+(PID.TID 0000.0001)     Wall clock time:   28.074772119522095
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.56164169311523438E-004
+(PID.TID 0000.0001)     Wall clock time:  1.51872634887695313E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99890136718750000E-003
+(PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.49250030517578125E-004
+(PID.TID 0000.0001)     Wall clock time:  1.40190124511718750E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5296192169189453
-(PID.TID 0000.0001)         System time:  0.16597390174865723
-(PID.TID 0000.0001)     Wall clock time:   2.6925184726715088
+(PID.TID 0000.0001)           User time:   5.9810943603515625
+(PID.TID 0000.0001)         System time:  0.27595925331115723
+(PID.TID 0000.0001)     Wall clock time:   6.2606558799743652
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.33991241455078125E-004
+(PID.TID 0000.0001)     Wall clock time:  1.59740447998046875E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.938180923461914
-(PID.TID 0000.0001)         System time:   1.5427660942077637
-(PID.TID 0000.0001)     Wall clock time:   28.331888675689697
+(PID.TID 0000.0001)           User time:   13.742912292480469
+(PID.TID 0000.0001)         System time:   1.5047709941864014
+(PID.TID 0000.0001)     Wall clock time:   27.066169261932373
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9692459106445313
-(PID.TID 0000.0001)         System time:  0.63190412521362305
-(PID.TID 0000.0001)     Wall clock time:   16.016242265701294
+(PID.TID 0000.0001)           User time:   5.5271606445312500
+(PID.TID 0000.0001)         System time:  0.73188877105712891
+(PID.TID 0000.0001)     Wall clock time:   15.005540847778320
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1998138427734375
-(PID.TID 0000.0001)         System time:  6.59899711608886719E-002
-(PID.TID 0000.0001)     Wall clock time:   2.5698621273040771
+(PID.TID 0000.0001)           User time:   1.3477935791015625
+(PID.TID 0000.0001)         System time:  7.89880752563476563E-002
+(PID.TID 0000.0001)     Wall clock time:   2.4787290096282959
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  9.99450683593750000E-004
+(PID.TID 0000.0001)           User time:  1.00708007812500000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.86953353881835938E-004
+(PID.TID 0000.0001)     Wall clock time:  6.94036483764648438E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.0082321166992188
-(PID.TID 0000.0001)         System time:  0.16597509384155273
-(PID.TID 0000.0001)     Wall clock time:   6.6689701080322266
+(PID.TID 0000.0001)           User time:   6.4340209960937500
+(PID.TID 0000.0001)         System time:  0.18197154998779297
+(PID.TID 0000.0001)     Wall clock time:   7.7541241645812988
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.9763946533203125
-(PID.TID 0000.0001)         System time:  0.14197778701782227
-(PID.TID 0000.0001)     Wall clock time:   5.6103191375732422
+(PID.TID 0000.0001)           User time:   4.8022613525390625
+(PID.TID 0000.0001)         System time:  0.14697790145874023
+(PID.TID 0000.0001)     Wall clock time:   6.0844540596008301
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.0318374633789063
-(PID.TID 0000.0001)         System time:  2.39973068237304688E-002
-(PID.TID 0000.0001)     Wall clock time:   1.0585949420928955
+(PID.TID 0000.0001)           User time:   1.6317596435546875
+(PID.TID 0000.0001)         System time:  3.49936485290527344E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6696071624755859
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  6.00433349609375000E-003
-(PID.TID 0000.0001)         System time:  1.99890136718750000E-003
-(PID.TID 0000.0001)     Wall clock time:  1.02508068084716797E-002
+(PID.TID 0000.0001)           User time:  3.99780273437500000E-003
+(PID.TID 0000.0001)         System time:  2.00033187866210938E-003
+(PID.TID 0000.0001)     Wall clock time:  4.84390258789062500E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6563,9 +6604,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          44236
+(PID.TID 0000.0001) //            No. barriers =          44194
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          44236
+(PID.TID 0000.0001) //     Total barrier spins =          44194
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.txt
+++ b/global_oce_llc90/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint66h
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67l
 (PID.TID 0000.0001) // Build user:        gforget
-(PID.TID 0000.0001) // Build host:        GLACIER2.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Thu Jun 15 15:27:47 EDT 2017
+(PID.TID 0000.0001) // Build host:        GLACIER3.MIT.EDU
+(PID.TID 0000.0001) // Build date:        Fri Aug 30 15:54:21 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -52,12 +52,14 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER2.MIT.EDU
+(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER3.MIT.EDU
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 23,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -649,6 +651,8 @@
 (PID.TID 0000.0001) > mxlSurfFlag=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -773,6 +777,15 @@
 (PID.TID 0000.0001) >      HsnowFile='siHSNOW.ini',
 (PID.TID 0000.0001) >      uIceFile='siUICE.ini',
 (PID.TID 0000.0001) >      vIceFile='siVICE.ini',
+(PID.TID 0000.0001) >#the following is needed to recover old default values
+(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >      SEAICE_drag=0.002,
+(PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
+(PID.TID 0000.0001) >      SEAICEetaZmethod=0,
+(PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
+(PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
+(PID.TID 0000.0001) >      SEAICE_OLx=0,
+(PID.TID 0000.0001) >      SEAICE_OLy=0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
@@ -1420,6 +1433,9 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -1728,6 +1744,9 @@
 (PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEupdateOceanStress= /* update Ocean surf. stress */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1770,11 +1789,11 @@
 (PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
 (PID.TID 0000.0001)                 2.000000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag * density */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag */
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
 (PID.TID 0000.0001)                   F
@@ -2649,74 +2668,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   297
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   308
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   227 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   229 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   235 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   238 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   240 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   248 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   308 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   252 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   259 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   269 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   270 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   271 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   277 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   233 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   234 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   281 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   282 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   287 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   244 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   245 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   217 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   218 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   114 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   115 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   111 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   112 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   122 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   119 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   228 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   117 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   125 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   268  ADVxHEFF , Parms: UU      M1 , mate:   269
-(PID.TID 0000.0001)   set mate pointer for diag #   269  ADVyHEFF , Parms: VV      M1 , mate:   268
-(PID.TID 0000.0001)   set mate pointer for diag #   270  DFxEHEFF , Parms: UU      M1 , mate:   271
-(PID.TID 0000.0001)   set mate pointer for diag #   271  DFyEHEFF , Parms: VV      M1 , mate:   270
-(PID.TID 0000.0001)   set mate pointer for diag #   276  ADVxSNOW , Parms: UU      M1 , mate:   277
-(PID.TID 0000.0001)   set mate pointer for diag #   277  ADVySNOW , Parms: VV      M1 , mate:   276
-(PID.TID 0000.0001)   set mate pointer for diag #   278  DFxESNOW , Parms: UU      M1 , mate:   279
-(PID.TID 0000.0001)   set mate pointer for diag #   279  DFyESNOW , Parms: VV      M1 , mate:   278
-(PID.TID 0000.0001)   set mate pointer for diag #   233  SIuice   , Parms: UU      M1 , mate:   234
-(PID.TID 0000.0001)   set mate pointer for diag #   234  SIvice   , Parms: VV      M1 , mate:   233
+(PID.TID 0000.0001)   set mate pointer for diag #   279  ADVxHEFF , Parms: UU      M1 , mate:   280
+(PID.TID 0000.0001)   set mate pointer for diag #   280  ADVyHEFF , Parms: VV      M1 , mate:   279
+(PID.TID 0000.0001)   set mate pointer for diag #   281  DFxEHEFF , Parms: UU      M1 , mate:   282
+(PID.TID 0000.0001)   set mate pointer for diag #   282  DFyEHEFF , Parms: VV      M1 , mate:   281
+(PID.TID 0000.0001)   set mate pointer for diag #   287  ADVxSNOW , Parms: UU      M1 , mate:   288
+(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVySNOW , Parms: VV      M1 , mate:   287
+(PID.TID 0000.0001)   set mate pointer for diag #   289  DFxESNOW , Parms: UU      M1 , mate:   290
+(PID.TID 0000.0001)   set mate pointer for diag #   290  DFyESNOW , Parms: VV      M1 , mate:   289
+(PID.TID 0000.0001)   set mate pointer for diag #   244  SIuice   , Parms: UU      M1 , mate:   245
+(PID.TID 0000.0001)   set mate pointer for diag #   245  SIvice   , Parms: VV      M1 , mate:   244
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   217  GM_PsiX  , Parms: UU      LR , mate:   218
-(PID.TID 0000.0001)   set mate pointer for diag #   218  GM_PsiY  , Parms: VV      LR , mate:   217
-(PID.TID 0000.0001)   set mate pointer for diag #   114  DFxE_TH  , Parms: UU      MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  DFyE_TH  , Parms: VV      MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   111  ADVx_TH  , Parms: UU      MR , mate:   112
-(PID.TID 0000.0001)   set mate pointer for diag #   112  ADVy_TH  , Parms: VV      MR , mate:   111
-(PID.TID 0000.0001)   set mate pointer for diag #   121  DFxE_SLT , Parms: UU      MR , mate:   122
-(PID.TID 0000.0001)   set mate pointer for diag #   122  DFyE_SLT , Parms: VV      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVx_SLT , Parms: UU      MR , mate:   119
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADVy_SLT , Parms: VV      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   228  GM_PsiX  , Parms: UU      LR , mate:   229
+(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiY  , Parms: VV      LR , mate:   228
+(PID.TID 0000.0001)   set mate pointer for diag #   120  DFxE_TH  , Parms: UU      MR , mate:   121
+(PID.TID 0000.0001)   set mate pointer for diag #   121  DFyE_TH  , Parms: VV      MR , mate:   120
+(PID.TID 0000.0001)   set mate pointer for diag #   117  ADVx_TH  , Parms: UU      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVy_TH  , Parms: VV      MR , mate:   117
+(PID.TID 0000.0001)   set mate pointer for diag #   127  DFxE_SLT , Parms: UU      MR , mate:   128
+(PID.TID 0000.0001)   set mate pointer for diag #   128  DFyE_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   124  ADVx_SLT , Parms: UU      MR , mate:   125
+(PID.TID 0000.0001)   set mate pointer for diag #   125  ADVy_SLT , Parms: VV      MR , mate:   124
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2836,6 +2855,9 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
@@ -3103,14 +3125,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -3122,6 +3142,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -3136,6 +3159,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -3196,7 +3222,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3212,6 +3238,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
 (PID.TID 0000.0001)                       0
@@ -3399,6 +3428,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -4522,6 +4560,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4965,32 +5006,32 @@
  cg2d: Sum(rhs),rhsMax =  -2.89207650950913E-01  1.27535774864828E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.83641865406873E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.39424631091610E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39424635865569E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262376662394E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262376662395E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5171680801189E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468437351511E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468437351512E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0375517515402E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7367557597871E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7367557597916E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2635037224614E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3848072839099E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766667313250E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766667313249E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598116154538E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318487970617E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318487970607E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4612559434672E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2013183687207E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481324545005E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481324545007E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184238370729E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010698250986E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010698250972E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8990034776967E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251798245795E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967192532498E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204602325971E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009259389370E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967192532788E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204602325965E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009259389369E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1221846198577E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002431435509E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920325945655E+00
@@ -5000,7 +5041,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0287401465945E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610216795E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063465703E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203349178932E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203349178933E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3301822453753E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8315836676857E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.0426692566356E+00
@@ -5033,7 +5074,7 @@
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2275956453778E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6666425959911E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7540183176686E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694754451182E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694754451183E-05
 (PID.TID 0000.0001) %MON ke_max                       =   2.7026108461264E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3999925383809E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979021026E+18
@@ -5043,8 +5084,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541841737610E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526005810E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243418962480E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791911007232E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364313685541E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791911007222E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364313685517E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5174,45 +5215,45 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.36103301355469E-01  1.24223801417412E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.44235519445854E+00
+ cg2d: Sum(rhs),rhsMax =  -4.36103301355495E-01  1.24223801417413E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.44235519452403E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.97327345250495E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.97327340092620E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932696988620E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285240571647E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729410301316E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932696988602E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285240571646E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729410301319E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247169403341E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6820691693935E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883534944E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.7726823920712E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796597528375E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796597528376E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731509458341E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028317192706E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028317192698E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825300125E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318898613E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363315510698E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363315510703E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770046471249E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474844570837E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474844570828E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835956E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732048137E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641619389872E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645387119074E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519455695004E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641619390142E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645387119057E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519455694980E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1207805418001E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659994559E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920324139776E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138323137E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524391916072E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524391916138E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692030172818E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0316468452690E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609436456E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241260908E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931216641109E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931216641111E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3190714409649E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3996176116447E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025805510514E+00
@@ -5239,24 +5280,24 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3598188467078E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8778552325709E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4916559940518E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337285176447E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337285173290E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7973422511481E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209674567566E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758593881560E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758593881561E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8774211805283E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511512648E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635889181493E-05
 (PID.TID 0000.0001) %MON ke_max                       =   1.7367852948958E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3275596627658E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3275596627657E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979287383E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.3712142783234E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2483229552641E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2483229552640E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278304820E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524185475E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726026982E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236989610621E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6193062963689E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236989610609E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6193062963646E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5267,12 +5308,12 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3341095674491E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3341095674436E-04
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196135995765E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1809073675267E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1809073675266E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6966438302513E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6966438302514E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158248659606E-01
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1429380406269E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
@@ -5386,10 +5427,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.81295744139994E-01  1.22564183553747E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.18649825629029E+00
+ cg2d: Sum(rhs),rhsMax =  -5.81295744139969E-01  1.22564183553749E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.18649825669420E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.70459379812296E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70459380025116E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5397,39 +5438,39 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284669972E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025084576546E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876544530055E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095703559978E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6715779165593E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876544530050E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095703559977E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6715779165614E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532788036907E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959684275E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687228020925E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687228020927E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119875938375E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496074593950E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249366879E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067769292E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392456558934E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496074593953E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249366878E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067769293E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392456558935E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278616377951E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778871299952E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778871299931E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195455846E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274854956E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1061231016612E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1061231015681E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746312763553E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151555999561E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151555999557E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1200643921829E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884008475E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692783E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150499502E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849164377737E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849164377727E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689786989452E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0346478241676E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608842191E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416224825E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666316395831E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123026860152E+03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666316395832E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123026860151E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097064713477E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5623037961368E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5623037961370E+00
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418854978354E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168629101988E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168629101976E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409094559967E+02
@@ -5438,8 +5479,8 @@
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110338762634E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368176515445E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428892003795E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263080716160E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6026339672338E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263080716159E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6026339672300E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7300591272462E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.2780756577411E+00
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2175322969937E-03
@@ -5451,7 +5492,7 @@
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442813385251E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8266158682626E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2223061829096E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7791804151474E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7791804151476E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823282709E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479069439295E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3369909901536E-02
@@ -5459,7 +5500,7 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937876433E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486171733695E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.9456878804639E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1606440639754E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1606440639753E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979547336E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.1934696455182E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.1821025660277E-05
@@ -5467,8 +5508,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881141689E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523419776E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236197081284E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9110009833558E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6195359735663E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9110009833590E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6195359735666E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5479,26 +5520,26 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4793431707300E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4793431707460E-04
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457594005674E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2978111908569E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2978111908567E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9076206356925E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9076206356926E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8344959602892E-01
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2605712609756E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865638504086E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218608125966E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3806269282316E-04
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3806269282317E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8283388458671E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535083222E-02
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527238777854E-01
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6842267100498E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8030200906190E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223750626E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129192779074E-02
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9047613610089E-05
@@ -5598,10 +5639,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.25727229094561E-01  1.21024823776091E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.12095611057859E+00
+ cg2d: Sum(rhs),rhsMax =  -7.25727229094394E-01  1.21024823776084E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.12095611032729E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.53868571399279E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53868568341296E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5609,39 +5650,39 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922110494E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3316624191672E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935142933448E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935142933445E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841978325228E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6519309208401E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6519309208397E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965625447E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186462855E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324349998179E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180603970792E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9935556938808E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186462854E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324349998178E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180603970791E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9935556938791E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065585238E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868604999803E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359398001142E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868604999801E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359398001139E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197142930450E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742524852993E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790935598E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742524853013E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790935599E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377536138E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687600494573E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194120590074E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842555816673E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687600495282E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194120590043E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842555816671E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192833239803E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496844E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446996998E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202808788E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200214044931E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200214044939E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0687575469512E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0376365963462E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608413594E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580266901E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420241303792E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029728704370E+03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420241303793E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029728704369E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990509272869E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312197355869E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312197355871E+00
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282905594226E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928382954960E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928382954950E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411051380789E+02
@@ -5651,10 +5692,10 @@
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188864300193E-03
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175827103029E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963919999129E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5678057337765E-07
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5678057337735E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5073169292408E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0413476444913E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1088228678403E-03
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1088228678402E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861560929077E-01
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4493487202610E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
@@ -5662,7 +5703,7 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5740224384831E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795817694679E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8524431303379E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2624033701093E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2624033556565E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6204983344803E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574538402E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745249616486E-02
@@ -5674,13 +5715,13 @@
 (PID.TID 0000.0001) %MON ke_mean                      =   3.9248602713292E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979803213E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426493470125E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787478435260E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787478435259E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665821588E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523573465E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771320831E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855814748681E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4561236228857E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855814748663E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4561236228984E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5691,19 +5732,19 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0162030668211E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0162030668197E-03
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156245080189E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414239244027E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414239244030E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0123522409095E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0123522409092E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937384987626E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3027980265486E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3027980265484E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796555325712E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198133966130E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3603644557752E-04
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3603644557753E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8280086640459E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519271717065E-02
@@ -5735,7 +5776,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629912665500E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8757679947332E+02
 (PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920800241038E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173325044407E+02
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173325044408E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755719956098E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481746E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9814667799294E-06
@@ -5771,7 +5812,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547220449E+01
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503680933E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225056658E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141808272303E-02
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141808272304E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730613859E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9685992420746E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234363493E-08
@@ -5810,10 +5851,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.67149197034541E-01  1.20371037440107E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05918903164230E+00
+ cg2d: Sum(rhs),rhsMax =  -8.67149197034637E-01  1.20371037440106E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.05918903186687E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.60071370444632E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.60071370366458E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5821,49 +5862,49 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340767236E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215246231287E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895540673471E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895540673465E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755463635059E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6366049942205E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6366049942206E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617984395E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345798591E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625852664817E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924724885388E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9230690964266E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006582022025E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518304659E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896870994864E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345798590E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625852664816E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924724885387E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9230690964264E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006582022026E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518304658E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896870994866E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520051367325E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360668711117E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399155549E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455621091E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9408214498818E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217609264531E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360668711107E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399155550E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455621090E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9408214495461E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217609264534E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133363809572E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1191979292709E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760074679E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525739031E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283388674E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518526245039E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518526245047E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0685358737846E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405660035871E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608120200E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734638062E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196725579429E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196725579430E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916870569673E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8729104566504E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511907946653E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511907946654E+00
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203147073075E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400671970642E-01
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400671970633E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413085044862E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874723240E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1085738066298E-02
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298774100059E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907235854828E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9895136873570E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907235854827E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9895136873569E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693309823136E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276608389562E-07
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276608389531E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.3668407825272E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -8.5617187280947E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9867974191319E-03
@@ -5874,25 +5915,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8716666329547E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437586371738E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3748343600172E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2688105733998E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5453096227051E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2688105734003E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5453096227053E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625271165E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693650435490E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2447220490887E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509979639E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509979640E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620927743E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081418700012E-04
 (PID.TID 0000.0001) %MON ke_max                       =   2.7885949866377E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.5517848982164E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   4.5517848982163E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980055921E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.4304639651302E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4448039193142E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4448039193141E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633814028E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524311651E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230135019627E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237956265483E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610906590609E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237956265491E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610906590469E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5903,19 +5944,19 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2522558962791E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2522558962785E-03
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656654151545E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854241167617E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854241167613E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0122557738928E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0122557738929E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297274520532E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462579488266E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462579488268E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734154434218E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178833893009E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3494466861579E-04
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3494466861581E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276856009030E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444994002535E-02
@@ -5935,7 +5976,7 @@
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.2831318509792E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434050E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434049E-01
 (PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484232684436E-03
 (PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962362734E-01
 (PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600943419426E-05
@@ -5946,10 +5987,10 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021697629839E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0634977156346E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655893300E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995817416421E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995817416422E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148222620374E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587902203768E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299319E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299318E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9789290821009E-06
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503313784756E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214313568533E-08
@@ -5984,8 +6025,8 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807420228960E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666936257E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101676000761E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373861460E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068078009E-08
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373861461E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068078007E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733205454997E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074412145108E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765850607581E-11
@@ -6022,60 +6063,60 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.00592192861240E+00  1.20159697286708E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.97628129034203E-01
+ cg2d: Sum(rhs),rhsMax =  -1.00592126642327E+00  1.20159697286707E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.97629027102809E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.53029605190339E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53029979487088E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300733803870E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662268094868E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9753066938578E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413282325431E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6275226594292E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721056473351E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160061977397E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954950941107E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300733803938E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662268094458E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9753033423127E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413282424008E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6275226620949E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721056473349E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160061977402E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954950941104E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301602369296E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176685286633E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495110618E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870559598813E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705534437981E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230412483851E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3723862843395E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739661822E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771664827E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6250590102413E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564433440181E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126909434958E-07
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176685286426E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495110620E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870559598865E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705534437990E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230412483850E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3723862843312E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739661820E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771664833E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6251161360704E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564433430619E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126909427874E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190811894460E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381280171E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188664E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377346526E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894010491764E-05
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188739E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377346455E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894010541128E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0683073389758E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434312287331E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852219E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882519855E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991779570346E-05
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852222E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882519079E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991779573978E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769029057524E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655893300E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764560204573E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173626770286E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2239129675838E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764877904271E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173623624331E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2239130883362E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415099503286E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289595903842E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0706488496788E-02
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415102702950E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289558115712E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0706993114765E-02
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208620679548E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644235890559E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9601095907773E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460134633492E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3862919351143E-07
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644235890560E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9601000109446E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460081305667E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3862957828276E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2667053449446E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -7.5828157462759E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8432088411559E-03
@@ -6086,25 +6127,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2083269479624E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383441627137E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2090836820817E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8491800512152E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9732333914432E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452921627E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068346585120E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1519602202410E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711423870E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566480416E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541838150445E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9025276942360E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8491800512173E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9732333930334E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452921624E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068346585092E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1519602202403E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711423867E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566480412E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541838114478E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9025276942361E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   4.9793106347594E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980305113E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460594982706E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6833524417622E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460594982718E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6833524417619E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765214316E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525442699E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228660467456E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948342655423E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4860084402830E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948342622358E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4860074759137E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6115,24 +6156,24 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6355334530565E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6355334530568E-03
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999373609256E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4296973518168E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9473469977377E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499002545399E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889120691128E-04
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889120691127E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672903189932E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160107815985E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3277815563378E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672903463347E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160107905489E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3277815237216E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8273693243316E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371765566134E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473574524939E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6274322176683E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371765945116E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473574595240E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6274321176813E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7909324212943E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420582689018E-03
@@ -6148,24 +6189,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.2371508581871E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7514785530382E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006525084569E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419512727E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659096882932E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006525036927E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419513047E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659096902463E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.0591191646476E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3794009108900E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572470343040E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460670203E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776766987508E-05
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572470300535E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460670422E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776766984921E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661035683934E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8363753843850E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962897635818E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185812773240E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662560387918E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419661101E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962897986843E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185812768314E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662560389261E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419661104E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9762180582361E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026214080646E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211145011537E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820071079500E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026214139917E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211145009425E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820071085628E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2409841947187E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8299208716971E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -6.6977716454892E-02
@@ -6193,14 +6234,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4920546435694E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755389567986E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605619741E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799445466971E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508391575718E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063436515339E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873482821E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426819767E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885244432564E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196464265458E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820919444634E-11
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799445476236E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508391568930E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063436517083E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873482824E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426819770E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885244438491E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196464256999E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820919449928E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591150038559E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3495005238107E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529705253267E-08
@@ -6234,89 +6275,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.14222695022571E+00  1.19970674505742E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.23837311722390E-01
+ cg2d: Sum(rhs),rhsMax =  -1.14222629529600E+00  1.19970674512755E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.23837242371656E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.67498532320745E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.67498541366882E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291615863E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378327007423E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491935592192E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422588000426E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6186658506147E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167154423E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569525657E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408372955540E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229585505326E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372972214005E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916415469E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0765529923263E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305476085722E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454336665207E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018529564125E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740326324E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304655886616E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7346791804700E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6039359515057E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914845261673E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291615775E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378327006841E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491902444150E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422588097284E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6186658557345E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167154268E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569525652E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408372954980E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229585505353E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372972213382E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916415470E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0765529923209E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305476085051E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454336665113E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018529562646E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740326346E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304655886626E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7346791343390E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6039359497415E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914845254041E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1189299556257E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766176901E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546352E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470784822E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352044239452E-05
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546430E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470784753E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352044289093E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0680752822352E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461824978009E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539502E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185024017321E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803574759583E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582352018479E+03
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539505E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185024016558E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803574766293E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582352018480E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8363753843850E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118488748139E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189933883031E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155846234590E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118484734074E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189933921062E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155845794800E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096977815E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267317544034E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0624634502282E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2098939252528E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214854361786E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261932901575E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240128354952E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291101477996E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096970671E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267317624473E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0624629355059E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2098939252504E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214854361812E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261933951771E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240128934833E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291099907977E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2357676847980E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850301E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6895546044395E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452627519908E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0520799792857E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6895545792290E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452627522718E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0520799819931E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3752841738518E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5092881521547E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659195026486E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3004238417539E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5584796739310E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9074644496713E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630564065E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682181479635E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5092881408945E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659195027384E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3004238372414E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5584796736327E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9074644530679E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630564074E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682181479640E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446767642666E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660711754769E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952334526341E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356199970539E-04
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660711754806E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952334526377E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356199935358E-04
 (PID.TID 0000.0001) %MON ke_max                       =   3.1301078877138E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1984100699805E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550622E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9194090250403E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.9202318324203E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1984100699612E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550620E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9194090250389E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.9202318324187E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004608014E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526751795E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228358857280E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548704640959E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9262506577658E-07
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526751797E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228358857296E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548704632156E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9262506605302E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6327,29 +6368,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3182981969641E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235154878475E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794510288996E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3182982000281E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235154878823E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794510287579E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8464858006456E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613023486132E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376046622503E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8464858014208E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613023486003E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376046627738E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614062775721E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142080269842E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3242547088283E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614063047120E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142080358290E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3242546781926E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8270594631784E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299746270763E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457182809526E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6103398671226E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299746645590E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457182878456E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6103397714820E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7869283205130E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305267547867E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4969035855310E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7873139340769E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305267547872E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4969035855311E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7873139340957E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6358,253 +6399,253 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.118385567334598D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.183174713284878D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.118385566628902D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.183174712393336D+05 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.301560280619475D+05
+(PID.TID 0000.0001)  --> fc               = 0.301560279022239D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.882753649294544D+03
-(PID.TID 0000.0001)  global fc =  0.301560280619475D+05
+(PID.TID 0000.0001)   local fc =  0.882753489523944D+03
+(PID.TID 0000.0001)  global fc =  0.301560279022239D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   103.17531792074442
-(PID.TID 0000.0001)         System time:   7.5818469300866127
-(PID.TID 0000.0001)     Wall clock time:   155.79456806182861
+(PID.TID 0000.0001)           User time:   163.75411021709442
+(PID.TID 0000.0001)         System time:   19.982961386442184
+(PID.TID 0000.0001)     Wall clock time:   226.71564316749573
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5.8231150284409523
-(PID.TID 0000.0001)         System time:  0.54391697794198990
-(PID.TID 0000.0001)     Wall clock time:   16.111523151397705
+(PID.TID 0000.0001)           User time:   8.1717575788497925
+(PID.TID 0000.0001)         System time:  0.75888398289680481
+(PID.TID 0000.0001)     Wall clock time:   23.040987968444824
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   97.352202892303467
-(PID.TID 0000.0001)         System time:   7.0379299521446228
-(PID.TID 0000.0001)     Wall clock time:   139.68285107612610
+(PID.TID 0000.0001)           User time:   155.58235263824463
+(PID.TID 0000.0001)         System time:   19.224077403545380
+(PID.TID 0000.0001)     Wall clock time:   203.67458796501160
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   11.932185649871826
-(PID.TID 0000.0001)         System time:  0.72889000177383423
-(PID.TID 0000.0001)     Wall clock time:   18.799026966094971
+(PID.TID 0000.0001)           User time:   15.906582832336426
+(PID.TID 0000.0001)         System time:  0.58991104364395142
+(PID.TID 0000.0001)     Wall clock time:   21.325172901153564
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   85.420017242431641
-(PID.TID 0000.0001)         System time:   6.3090399503707886
-(PID.TID 0000.0001)     Wall clock time:   120.88377285003662
+(PID.TID 0000.0001)           User time:   139.67576980590820
+(PID.TID 0000.0001)         System time:   18.634166359901428
+(PID.TID 0000.0001)     Wall clock time:   182.34935903549194
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.3387985229492188
-(PID.TID 0000.0001)         System time:  1.00004673004150391E-003
-(PID.TID 0000.0001)     Wall clock time:   1.3417739868164063
+(PID.TID 0000.0001)           User time:   1.3747920989990234
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.3792240619659424
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  3.99780273437500000E-003
+(PID.TID 0000.0001)           User time:  5.00106811523437500E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.34389305114746094E-003
+(PID.TID 0000.0001)     Wall clock time:  3.94606590270996094E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   78.786020278930664
-(PID.TID 0000.0001)         System time:   6.0940728187561035
-(PID.TID 0000.0001)     Wall clock time:   111.15187025070190
+(PID.TID 0000.0001)           User time:   130.34317588806152
+(PID.TID 0000.0001)         System time:   18.333213448524475
+(PID.TID 0000.0001)     Wall clock time:   170.58163905143738
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   78.786020278930664
-(PID.TID 0000.0001)         System time:   6.0940728187561035
-(PID.TID 0000.0001)     Wall clock time:   111.15162849426270
+(PID.TID 0000.0001)           User time:   130.34317588806152
+(PID.TID 0000.0001)         System time:   18.333213448524475
+(PID.TID 0000.0001)     Wall clock time:   170.58141899108887
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.63890647888183594
+(PID.TID 0000.0001)           User time:   1.2388095855712891
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.63945293426513672
+(PID.TID 0000.0001)     Wall clock time:   1.2381873130798340
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.23097229003906250
-(PID.TID 0000.0001)         System time:  1.00004673004150391E-003
-(PID.TID 0000.0001)     Wall clock time:  0.23346018791198730
+(PID.TID 0000.0001)           User time:  0.34095382690429688
+(PID.TID 0000.0001)         System time:  1.99985504150390625E-003
+(PID.TID 0000.0001)     Wall clock time:  0.34393429756164551
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.87886428833007813
-(PID.TID 0000.0001)         System time:  0.27595806121826172
-(PID.TID 0000.0001)     Wall clock time:   1.2000839710235596
+(PID.TID 0000.0001)           User time:   1.3358001708984375
+(PID.TID 0000.0001)         System time:  0.42493581771850586
+(PID.TID 0000.0001)     Wall clock time:   1.8098781108856201
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.87186622619628906
-(PID.TID 0000.0001)         System time:  0.27595806121826172
-(PID.TID 0000.0001)     Wall clock time:   1.1929137706756592
+(PID.TID 0000.0001)           User time:   1.3228034973144531
+(PID.TID 0000.0001)         System time:  0.42493581771850586
+(PID.TID 0000.0001)     Wall clock time:   1.7971000671386719
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.41620635986328125E-004
+(PID.TID 0000.0001)     Wall clock time:  1.25408172607421875E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15197372436523438
-(PID.TID 0000.0001)         System time:  1.19980573654174805E-002
-(PID.TID 0000.0001)     Wall clock time:  0.16619992256164551
+(PID.TID 0000.0001)           User time:  0.16996955871582031
+(PID.TID 0000.0001)         System time:  1.79980993270874023E-002
+(PID.TID 0000.0001)     Wall clock time:  0.18834447860717773
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.19955444335937500E-002
+(PID.TID 0000.0001)           User time:  3.49826812744140625E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.54936218261718750E-002
+(PID.TID 0000.0001)     Wall clock time:  3.80983352661132813E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.634931564331055
-(PID.TID 0000.0001)         System time:  0.97685086727142334
-(PID.TID 0000.0001)     Wall clock time:   14.614419698715210
+(PID.TID 0000.0001)           User time:   24.664253234863281
+(PID.TID 0000.0001)         System time:   3.1515215635299683
+(PID.TID 0000.0001)     Wall clock time:   27.848650693893433
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   4.3023452758789063
-(PID.TID 0000.0001)         System time:  0.33694779872894287
-(PID.TID 0000.0001)     Wall clock time:   4.6349089145660400
+(PID.TID 0000.0001)           User time:   7.3498897552490234
+(PID.TID 0000.0001)         System time:  0.98385083675384521
+(PID.TID 0000.0001)     Wall clock time:   8.3502779006958008
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   4.0073928833007813
-(PID.TID 0000.0001)         System time:  0.30795383453369141
-(PID.TID 0000.0001)     Wall clock time:   4.3181586265563965
+(PID.TID 0000.0001)           User time:   6.8729496002197266
+(PID.TID 0000.0001)         System time:  0.88086640834808350
+(PID.TID 0000.0001)     Wall clock time:   7.7725012302398682
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.8155612945556641
-(PID.TID 0000.0001)         System time:  1.99902057647705078E-003
-(PID.TID 0000.0001)     Wall clock time:   2.8194921016693115
+(PID.TID 0000.0001)           User time:   5.0562305450439453
+(PID.TID 0000.0001)         System time:  3.99947166442871094E-003
+(PID.TID 0000.0001)     Wall clock time:   5.0656237602233887
 (PID.TID 0000.0001)          No. starts:          32
 (PID.TID 0000.0001)           No. stops:          32
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   10.489404678344727
-(PID.TID 0000.0001)         System time:  1.99997425079345703E-003
-(PID.TID 0000.0001)     Wall clock time:   10.492004156112671
+(PID.TID 0000.0001)           User time:   17.332370758056641
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   17.345649957656860
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0808353424072266
-(PID.TID 0000.0001)         System time:  0.53591823577880859
-(PID.TID 0000.0001)     Wall clock time:   1.6155788898468018
+(PID.TID 0000.0001)           User time:   6.0790939331054688
+(PID.TID 0000.0001)         System time:   3.4804683923721313
+(PID.TID 0000.0001)     Wall clock time:   9.5626752376556396
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4797763824462891
-(PID.TID 0000.0001)         System time:  0.13498103618621826
-(PID.TID 0000.0001)     Wall clock time:   1.6150419712066650
+(PID.TID 0000.0001)           User time:   3.4084854125976563
+(PID.TID 0000.0001)         System time:  0.63190555572509766
+(PID.TID 0000.0001)     Wall clock time:   4.0410265922546387
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15597152709960938
-(PID.TID 0000.0001)         System time:  9.99927520751953125E-004
-(PID.TID 0000.0001)     Wall clock time:  0.15901088714599609
+(PID.TID 0000.0001)           User time:  0.33093643188476563
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.33239269256591797
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45293807983398438
-(PID.TID 0000.0001)         System time:  2.89959907531738281E-002
-(PID.TID 0000.0001)     Wall clock time:  0.47926282882690430
+(PID.TID 0000.0001)           User time:   1.0538330078125000
+(PID.TID 0000.0001)         System time:  0.22996497154235840
+(PID.TID 0000.0001)     Wall clock time:   1.2843255996704102
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.29930877685546875E-002
-(PID.TID 0000.0001)         System time:  1.99937820434570313E-003
-(PID.TID 0000.0001)     Wall clock time:  2.72917747497558594E-002
+(PID.TID 0000.0001)           User time:  3.90090942382812500E-002
+(PID.TID 0000.0001)         System time:  6.99830055236816406E-003
+(PID.TID 0000.0001)     Wall clock time:  4.71351146697998047E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.50293731689453125
-(PID.TID 0000.0001)         System time:  8.09849500656127930E-002
-(PID.TID 0000.0001)     Wall clock time:  0.61259388923645020
+(PID.TID 0000.0001)           User time:  0.56690979003906250
+(PID.TID 0000.0001)         System time:  0.11298394203186035
+(PID.TID 0000.0001)     Wall clock time:  0.70579576492309570
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.165985107421875
-(PID.TID 0000.0001)         System time:  0.76688432693481445
-(PID.TID 0000.0001)     Wall clock time:   13.934147834777832
+(PID.TID 0000.0001)           User time:   23.909355163574219
+(PID.TID 0000.0001)         System time:   4.0943768024444580
+(PID.TID 0000.0001)     Wall clock time:   28.014472484588623
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.46150588989257813E-004
+(PID.TID 0000.0001)     Wall clock time:  1.21116638183593750E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.34468078613281250E-004
+(PID.TID 0000.0001)     Wall clock time:  1.13248825073242188E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4356174468994141
-(PID.TID 0000.0001)         System time:  0.22196626663208008
-(PID.TID 0000.0001)     Wall clock time:   2.6561760902404785
+(PID.TID 0000.0001)           User time:   5.2871971130371094
+(PID.TID 0000.0001)         System time:   1.0128479003906250
+(PID.TID 0000.0001)     Wall clock time:   6.3805456161499023
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.28269195556640625E-004
+(PID.TID 0000.0001)     Wall clock time:  1.28746032714843750E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.011871337890625
-(PID.TID 0000.0001)         System time:   2.4376291036605835
-(PID.TID 0000.0001)     Wall clock time:   31.213120937347412
+(PID.TID 0000.0001)           User time:   18.153228759765625
+(PID.TID 0000.0001)         System time:   4.3713333606719971
+(PID.TID 0000.0001)     Wall clock time:   35.662077665328979
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9822387695312500
-(PID.TID 0000.0001)         System time:  0.57791185379028320
-(PID.TID 0000.0001)     Wall clock time:   16.974350214004517
+(PID.TID 0000.0001)           User time:   5.5251617431640625
+(PID.TID 0000.0001)         System time:  0.70489311218261719
+(PID.TID 0000.0001)     Wall clock time:   14.738681077957153
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2158126831054688
-(PID.TID 0000.0001)         System time:  5.29923439025878906E-002
-(PID.TID 0000.0001)     Wall clock time:   2.7066199779510498
+(PID.TID 0000.0001)           User time:   1.3787841796875000
+(PID.TID 0000.0001)         System time:  8.99848937988281250E-002
+(PID.TID 0000.0001)     Wall clock time:   2.6728370189666748
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:  9.91821289062500000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.84092330932617188E-004
+(PID.TID 0000.0001)     Wall clock time:  6.93082809448242188E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   4.0143966674804688
-(PID.TID 0000.0001)         System time:  0.15397691726684570
-(PID.TID 0000.0001)     Wall clock time:   5.6087670326232910
+(PID.TID 0000.0001)           User time:   6.4490203857421875
+(PID.TID 0000.0001)         System time:  0.20696830749511719
+(PID.TID 0000.0001)     Wall clock time:   7.5803489685058594
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.6475982666015625
-(PID.TID 0000.0001)         System time:  0.12398099899291992
-(PID.TID 0000.0001)     Wall clock time:   4.2100260257720947
+(PID.TID 0000.0001)           User time:   4.8062591552734375
+(PID.TID 0000.0001)         System time:  0.15797615051269531
+(PID.TID 0000.0001)     Wall clock time:   5.8831369876861572
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.3667984008789063
-(PID.TID 0000.0001)         System time:  2.89959907531738281E-002
-(PID.TID 0000.0001)     Wall clock time:   1.3986809253692627
+(PID.TID 0000.0001)           User time:   1.6427612304687500
+(PID.TID 0000.0001)         System time:  4.89921569824218750E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6971499919891357
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  2.99835205078125000E-003
+(PID.TID 0000.0001)           User time:  3.99780273437500000E-003
 (PID.TID 0000.0001)         System time:  1.99890136718750000E-003
-(PID.TID 0000.0001)     Wall clock time:  7.23910331726074219E-003
+(PID.TID 0000.0001)     Wall clock time:  7.66110420227050781E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6655,9 +6696,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          41236
+(PID.TID 0000.0001) //            No. barriers =          41194
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          41236
+(PID.TID 0000.0001) //     Total barrier spins =          41194
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecco_v4.txt
+++ b/global_oce_llc90/results/output_adm.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint66h
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67l
 (PID.TID 0000.0001) // Build user:        gforget
 (PID.TID 0000.0001) // Build host:        GLACIER3.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Thu Jun 15 05:24:19 EDT 2017
+(PID.TID 0000.0001) // Build date:        Fri Aug 30 05:39:32 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -52,6 +52,8 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -618,6 +620,8 @@
 (PID.TID 0000.0001) > mxlSurfFlag=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -735,6 +739,15 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># SEAICE parameters
 (PID.TID 0000.0001) > &SEAICE_PARM01
+(PID.TID 0000.0001) >#the following is needed to recover old default values
+(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
+(PID.TID 0000.0001) >      SEAICEetaZmethod=0,
+(PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
+(PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
+(PID.TID 0000.0001) >      SEAICE_OLx=0,
+(PID.TID 0000.0001) >      SEAICE_OLy=0,
+(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
 (PID.TID 0000.0001) >      SEAICEpresPow0=1,
@@ -1467,6 +1480,9 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -1817,6 +1833,9 @@
 (PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEupdateOceanStress= /* update Ocean surf. stress */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1859,11 +1878,11 @@
 (PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
 (PID.TID 0000.0001)                 2.000000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag * density */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag */
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag */
-(PID.TID 0000.0001)                 5.500000000000000E+00
+(PID.TID 0000.0001)                 5.344995140913508E-03
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
 (PID.TID 0000.0001)                   F
@@ -2858,6 +2877,9 @@
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -3123,14 +3145,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -3142,6 +3162,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -3156,6 +3179,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -3216,7 +3242,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3232,6 +3258,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
 (PID.TID 0000.0001)                       0
@@ -3419,6 +3448,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -4542,6 +4580,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4596,7 +4637,7 @@
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.88423159374540E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   6.69695334641673E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.69695334641693E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4619,7 +4660,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.0389435394644E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2692573716907E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3261818668319E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.9888495968183E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.9888495968177E-10
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1694298705653E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2201349397050E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2656406738420E+01
@@ -4674,8 +4715,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543459171387E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535714105E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239365710578E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5200859174617E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.6790152687243E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5200859174611E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.6790152686452E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4790,61 +4831,61 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01104293457198E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420776911E+00  1.09717250746361E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.75695590430442E-01
+ cg2d: Sum(rhs),rhsMax =   3.01104293457201E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369155231E+00  1.09717250746374E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.75699120156014E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      95
-(PID.TID 0000.0001)      cg2d_last_res =   6.78876446628010E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.78904152132910E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3328663411660E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5663552870510E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5295767852367E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4433365936372E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7988753615163E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8317328003626E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1029776135331E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5199916682617E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1941713051103E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7523863457632E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5532834981125E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4425714264340E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1402388839792E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3973929795612E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8852379471763E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.4501079084163E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1515801227379E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.5618890471389E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0595833105085E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5825088836405E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3328663411863E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5663552870662E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5295765239633E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4433365875661E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7988750893801E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8317328003033E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1029776137147E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5199916685390E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1941713051101E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7523863457672E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5532834981137E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4425714264355E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1402388840252E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3973929795595E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8852379471759E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.4501079078214E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1515801227246E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   4.5614814339439E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0595833105293E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5825087911929E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2629166101042E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0000861507835E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905938715214E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366056732306E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0892090821759E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0000861507836E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905938715138E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366056732396E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0892090831583E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711523006047E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8979615038529E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703689895E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856187302862E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6634321431961E-05
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8979615038520E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703689893E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856187303439E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6634321395039E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.6856814224712E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.7180082412717E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.2644629895451E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6398942913210E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6726418884711E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.2644310842336E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6398942742659E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6726562524618E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -9.2659486649252E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8694439638982E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3952478840541E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.7798732831238E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3478039169357E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.1903762974732E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   8.1662595738789E-07
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1402781671318E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.9862694321907E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8694436417833E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3952480502009E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.7801454302844E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3478039158155E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.1903762985935E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   8.1655127677891E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1402795753642E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.9862906660285E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.9027013207119E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0961877438461E+00
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4337661943561E-02
@@ -4855,25 +4896,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0412814671694E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1478533754020E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7348235684098E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3866522097184E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8633620901882E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0689580078657E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0641572959638E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.8411554300672E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0871750724555E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0996466498230E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3838714009834E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.5536370502694E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3866522096818E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8633620901581E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0689580078799E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0641572959272E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.8411554300372E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0871750724696E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0996466498371E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3838714022963E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.5536370502705E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   5.1103145598785E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973303524E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0042367565927E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0042367565843E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.5104117299492E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543413639933E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535814585E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239971418205E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4786792581546E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7176281319075E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4786806134855E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7176352399645E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4894,14 +4935,14 @@
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   2.2433864258799E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9460762576651E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7988778739151E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6862627193551E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9460762064800E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7988778551604E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6862620352916E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8228461174182E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3417891962425E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0476952804533E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.9045271674832E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3417891666985E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0476952791125E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.9045268651092E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.2319652373087E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -8.6736173798840E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2482394803071E-03
@@ -4927,14 +4968,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.5515538637205E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -7.4976339629281E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.0559555727628E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5865646745838E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.3489230965142E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0385390936701E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.0559555396012E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5865646748376E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.3489231168631E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0385390936700E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.3132705873929E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.0035459552866E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.8127701567824E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3232848293675E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.0035459497862E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.8127701569426E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3232848300410E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8848542238091E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.3040566798063E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0151300912066E+00
@@ -4951,15 +4992,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7073963366029E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4901468161263E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2993503434651E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3822495776705E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8179992664488E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8881282879094E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0827446581322E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2341541615524E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4203555698016E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3509695957653E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8639650825826E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0416373320297E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3822495776706E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8179992655583E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8881282894603E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0827446575556E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2341541615523E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4203555698015E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3509695952153E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8639650834303E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0416373336193E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -4988,90 +5029,90 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00954714826831E+00  1.09443701601822E+00
- cg2d: Sum(rhs),rhsMax =   3.01015881394652E+00  1.08987441563975E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.28221259418976E-01
+ cg2d: Sum(rhs),rhsMax =   3.00952076293090E+00  1.09443701601859E+00
+ cg2d: Sum(rhs),rhsMax =   3.01010771602368E+00  1.08987441582949E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.28473086345974E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   6.69337021238704E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.69607504112796E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471521608E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314453380621E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5364662501073E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4454859515923E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7483019062406E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760081224655E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988251860E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5186196113842E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978086562955E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6572910878485E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383032981572E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223637151955E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1562736860933E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960074967056E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7811177344688E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424525262055E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868902382E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.2797691781452E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260316684264E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3780614466758E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631424369E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0001593307139E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009524724E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365928991076E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0869857239319E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471521928E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314453382610E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5364403846083E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4454852651107E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7483026790981E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760081213183E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988279894E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5186196085965E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978086566634E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6572910900603E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383032981013E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223637152405E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1562736813687E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960074965250E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7811177324686E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424525285923E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868904485E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.2818582888828E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260316538124E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3780611499823E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631424366E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0001593307141E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009518545E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365928998053E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0869857026908E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711518357459E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8961657805396E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703732375E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856092276413E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6509679225318E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9794467896275E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3179159272962E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7075365927593E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1654217619638E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5803805470330E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8961657805293E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703732162E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856092320315E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6509682323450E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9794467896277E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3179159273002E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7074067471268E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1654130780129E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5806543029135E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9541285063768E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8461290378525E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8729322319224E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3130452179933E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.4421850521121E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0516332109262E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0917309206349E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8183928870224E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9541148557956E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8461250190406E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8783179209573E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3130452031322E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.4421850669735E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0480567301730E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0918537750155E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8189991699979E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0067009884579E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4060095265675E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0490259919454E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9665903872801E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0067009885666E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4060096026835E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0490259875497E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9665909347878E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3394247024139E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5328358122737E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8403459412690E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1326814537992E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.8034742902453E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976243324456E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3023530790552E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568857656E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646710482189E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2850688112189E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634433741E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453223747E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3811385154850E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.7437361580744E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1149709857678E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973281803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391231234595E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.1981391002581E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5328358122724E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8403449923289E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1326814405846E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.8034724706046E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976243317376E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3023530702677E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568856996E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646710474991E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2850688016394E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634433163E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453223086E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3811386461408E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.7437361580254E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1149709860373E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973281851E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391231235400E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.1981390999506E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543385089283E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535906636E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240318983536E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6371297402725E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0630754238578E-08
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535906555E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240318982584E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6376072016945E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0633284266797E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5082,29 +5123,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5746895119600E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884111830819E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1037699936179E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5746897669462E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884111815572E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1037699831530E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0042405262688E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554120352294E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1520815828861E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0042402658243E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554120367459E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1520815271363E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430113010524E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998447550046E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7078017095366E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430075899852E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998438386347E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7077994953342E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8235293926932E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3427462250105E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488305859350E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8581833188961E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4877998393975E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433312911020E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439874399523E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782653042696E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3427433002189E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488304304443E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8581844018852E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4877998393978E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433312911186E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439874399545E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782653063737E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5123,16 +5164,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131724910E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438470977E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5585280024873E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3838433360467E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1623631073163E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031817549E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660502969E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5928317875050E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7494025971264E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122954165254E-10
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131724913E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438470993E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5585294370659E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3838433597280E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1623633240638E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031817558E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660502970E-06
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5928315612465E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7494025972825E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122954168988E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -5149,15 +5190,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3025509150153E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202661456884E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8163263080133E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8529297469810E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0830016267931E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804660962391E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282754932826E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3512194953809E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8088798197690E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9447970717127E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202661345420E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8163262432227E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8529297631170E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0830016004131E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804660962400E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282754932850E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3512194727551E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8088798517979E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9447970494784E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -5186,90 +5227,90 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01196541850581E+00  1.08661842593485E+00
- cg2d: Sum(rhs),rhsMax =   3.01466105296437E+00  1.08470792382276E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.17394143621698E-01
+ cg2d: Sum(rhs),rhsMax =   3.01192469572586E+00  1.08661842821016E+00
+ cg2d: Sum(rhs),rhsMax =   3.01462770900199E+00  1.08470792313461E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.17374099729501E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      90
-(PID.TID 0000.0001)      cg2d_last_res =   6.39633113631616E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39602239428982E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2495279455692E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5239542498133E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5446938451216E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465726361317E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7074434587524E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9302832018785E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0431168074349E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5108841626746E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1962557184025E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5901183386867E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8517335904791E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3905847928075E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1749190448428E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3959148021332E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7076576313708E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.7923513347840E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2556007278704E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1105285408949E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0482045601991E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4250224768951E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2583502993898E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0002391947032E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906120998840E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366055495832E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0843747454629E-04
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711514283308E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8945377278657E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703788861E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856002770618E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6370278334129E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.3850754574047E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3637786810464E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5651716155540E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2175691601909E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5544975845796E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2495279453508E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5239542499886E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5446769662152E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465721639928E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7074464006865E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9302832012316E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0431167938449E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5108841558466E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1962557198571E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5901183325923E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8517335905280E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3905847931074E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1749190313834E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3959148031283E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7076576233731E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.7923515923219E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2556007279871E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1104512554318E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0482046626502E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4250247049883E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2583502993893E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0002391947026E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906120995684E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366055499151E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0843747744959E-04
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711514283309E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8945377278986E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703788722E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856002802343E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6370286275681E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.3850754574040E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3637786765804E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5652390899512E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2175714137784E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5548223201638E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0387328378441E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8882740742905E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.3408524317949E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2817018807192E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.6968193503846E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2035548347851E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0980612568084E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7339087218541E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0387395467986E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8882721926194E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.3463967814673E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2817019160123E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.6968193150914E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2046171929193E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0980457727257E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7339094392905E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9024782159049E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3738220530955E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0290459500348E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7377624093438E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9024782157289E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3738221177579E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0290459550931E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7377630121386E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3287254822510E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4863918790520E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6608927907615E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1433148596696E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.9208967035044E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3502695715477E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.7516397310336E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2863272372128E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4510703743253E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7340554451901E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3077142082591E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3170155967788E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3774733749214E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.8702649240123E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1115638450085E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973254250E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0302572444826E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8906854064008E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4863918790564E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6608919708786E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1433148502198E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.9208942182351E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3502695706801E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.7516397317001E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2863272368437E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4510703714343E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7340554415615E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3077142078902E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3170155964097E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3774735263864E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.8702649240708E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1115638501376E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973254323E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0302572444626E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8906854057034E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543365494191E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535941105E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240546636352E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -6.5030735426183E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.1951164304894E-08
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535940981E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240546634682E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -6.5030871480615E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.1951015167837E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5280,29 +5321,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.3028960303587E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8864806719580E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0451198176182E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.3028956642223E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8864806792543E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0451198317438E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.5536804829178E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9594551824587E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1063767944877E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.5536804496825E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9594551812187E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1063766761372E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9449829245414E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8011994079881E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6527070400737E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9449808077267E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8011988100066E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6527057990659E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8242204407701E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3437737295109E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0498252351181E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8171924648210E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.7221826846979E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3437718208934E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0498250105292E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8171961018788E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.7221826845866E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2406522132720E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1432620164863E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3072367778356E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2406522133480E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1432620165187E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3072367878312E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5321,16 +5362,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.5380229346511E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1672104366781E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.1371690064713E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2541554874781E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.5153462372486E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4955204091715E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.6814913516115E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5282593210098E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1320020669957E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2541554874779E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.5153462372464E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4955204380546E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.6814913563410E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5282598810553E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1320020669955E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.8234205269278E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.2230468613683E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.2805047528996E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5169848434427E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.2230468053015E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.2805047513983E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5169848424772E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.1230918947362E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.9974688084646E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9326776260964E+00
@@ -5347,15 +5388,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6636862312512E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4795752084831E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3057514779055E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3084955683007E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8149122724137E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8772666359886E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0934785771880E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3249128280817E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4056975836279E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3555623191610E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8152948218269E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0110238631641E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3084955682991E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8149122500617E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8772666139499E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0934784397245E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3249128280816E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4056975836246E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3555623135543E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8152948281965E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0110237713872E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.8643460198128E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -3.0412607572472E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7289237666874E-08
@@ -5384,75 +5425,75 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01804240094190E+00  1.08353190290192E+00
+ cg2d: Sum(rhs),rhsMax =   3.01800456702567E+00  1.08353189659444E+00
 (PID.TID 0000.0001) %CHECKPOINT         9 ckptA
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535127715106D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615584861922D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195179128379D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535141827244D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615578122221D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195182572231D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918150712577028D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150719949466D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631067333119D+06
-(PID.TID 0000.0001)  global fc =  0.918150712577028D+07
+(PID.TID 0000.0001)   local fc =  0.829631036828058D+06
+(PID.TID 0000.0001)  global fc =  0.918150719949466D+07
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00840705436739E+00  1.10672143503413E+00
- cg2d: Sum(rhs),rhsMax =   3.00818786780757E+00  1.10184321472204E+00
- cg2d: Sum(rhs),rhsMax =   3.00743589288945E+00  1.09718198214086E+00
- cg2d: Sum(rhs),rhsMax =   3.00656245075815E+00  1.09412541396105E+00
+ cg2d: Sum(rhs),rhsMax =   3.00842191351762E+00  1.10672143503417E+00
+ cg2d: Sum(rhs),rhsMax =   3.00819953367609E+00  1.10184320936097E+00
+ cg2d: Sum(rhs),rhsMax =   3.00743367211150E+00  1.09718198202948E+00
+ cg2d: Sum(rhs),rhsMax =   3.00652275487507E+00  1.09412541400144E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.00717773517553E+00  1.08957477517746E+00
- cg2d: Sum(rhs),rhsMax =   3.00899954257166E+00  1.08664118321235E+00
- cg2d: Sum(rhs),rhsMax =   3.01170580726396E+00  1.08473526941526E+00
- cg2d: Sum(rhs),rhsMax =   3.01507120917179E+00  1.08356391721091E+00
+ cg2d: Sum(rhs),rhsMax =   3.00711658859232E+00  1.08957477544055E+00
+ cg2d: Sum(rhs),rhsMax =   3.00891504157284E+00  1.08664118553174E+00
+ cg2d: Sum(rhs),rhsMax =   3.01161978494390E+00  1.08473526046755E+00
+ cg2d: Sum(rhs),rhsMax =   3.01500468671765E+00  1.08356391457870E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.00734686049247E+00  1.09018993351570E+00
- cg2d: Sum(rhs),rhsMax =   3.00914717667816E+00  1.08737102340724E+00
- cg2d: Sum(rhs),rhsMax =   3.01178093630015E+00  1.08546479077204E+00
- cg2d: Sum(rhs),rhsMax =   3.01509550876830E+00  1.08429744209200E+00
+ cg2d: Sum(rhs),rhsMax =   3.00728776804447E+00  1.09018993141914E+00
+ cg2d: Sum(rhs),rhsMax =   3.00906686178753E+00  1.08737102360704E+00
+ cg2d: Sum(rhs),rhsMax =   3.01170070298637E+00  1.08546477893354E+00
+ cg2d: Sum(rhs),rhsMax =   3.01499704102304E+00  1.08429744249609E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.01509555483511E+00  1.08429747486494E+00
+ cg2d: Sum(rhs),rhsMax =   3.01499700643986E+00  1.08429747738456E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.01509555483511E+00  1.08429747486494E+00
- cg2d: Sum(rhs),rhsMax =  -2.07353665487853E-18  1.83987548566083E-04
- cg2d: Sum(rhs),rhsMax =   3.01178085413478E+00  1.08546481106480E+00
- cg2d: Sum(rhs),rhsMax =   3.01178085413478E+00  1.08546481106480E+00
- cg2d: Sum(rhs),rhsMax =   4.11996825544492E-18  3.38460989603259E-04
- cg2d: Sum(rhs),rhsMax =   3.00914717962551E+00  1.08737105297827E+00
- cg2d: Sum(rhs),rhsMax =   3.00914717962551E+00  1.08737105297827E+00
- cg2d: Sum(rhs),rhsMax =   7.26415455565288E-18  8.84380111094525E-04
- cg2d: Sum(rhs),rhsMax =   3.00734686959595E+00  1.09018993704771E+00
- cg2d: Sum(rhs),rhsMax =   3.00734686959595E+00  1.09018993704771E+00
- cg2d: Sum(rhs),rhsMax =  -6.50521303491303E-18  1.57827888332213E-03
+ cg2d: Sum(rhs),rhsMax =   3.01499700643986E+00  1.08429747738456E+00
+ cg2d: Sum(rhs),rhsMax =  -1.62630325872826E-19  1.83987570340017E-04
+ cg2d: Sum(rhs),rhsMax =   3.01170045625167E+00  1.08546479272419E+00
+ cg2d: Sum(rhs),rhsMax =   3.01170045625167E+00  1.08546479272419E+00
+ cg2d: Sum(rhs),rhsMax =   1.00559751498031E-17  3.38461753710847E-04
+ cg2d: Sum(rhs),rhsMax =   3.00906676928987E+00  1.08737105386250E+00
+ cg2d: Sum(rhs),rhsMax =   3.00906676928987E+00  1.08737105386250E+00
+ cg2d: Sum(rhs),rhsMax =   3.57786716920216E-18  8.84381944522769E-04
+ cg2d: Sum(rhs),rhsMax =   3.00728777520035E+00  1.09018993420939E+00
+ cg2d: Sum(rhs),rhsMax =   3.00728777520035E+00  1.09018993420939E+00
+ cg2d: Sum(rhs),rhsMax =  -3.68628738645072E-18  1.57827982644850E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00830905126905E+00  1.10558523902381E+00
- cg2d: Sum(rhs),rhsMax =   3.00809280593794E+00  1.10067708164826E+00
- cg2d: Sum(rhs),rhsMax =   3.00734625623772E+00  1.09600516677972E+00
- cg2d: Sum(rhs),rhsMax =   3.00647583732843E+00  1.09411950941594E+00
- cg2d: Sum(rhs),rhsMax =   3.00647569703917E+00  1.09411952754395E+00
- cg2d: Sum(rhs),rhsMax =   3.00647569703917E+00  1.09411952754395E+00
- cg2d: Sum(rhs),rhsMax =  -2.43945488809238E-17  2.34151560003176E-03
- cg2d: Sum(rhs),rhsMax =   3.00734632585249E+00  1.09600518031304E+00
- cg2d: Sum(rhs),rhsMax =   3.00734632585249E+00  1.09600518031304E+00
- cg2d: Sum(rhs),rhsMax =   4.33680868994202E-18  3.09441236859051E-03
- cg2d: Sum(rhs),rhsMax =   3.00809290710180E+00  1.10067707597626E+00
- cg2d: Sum(rhs),rhsMax =   3.00809290710180E+00  1.10067707597626E+00
- cg2d: Sum(rhs),rhsMax =  -6.93889390390723E-17  3.75489876644609E-03
+ cg2d: Sum(rhs),rhsMax =   3.00830731873632E+00  1.10558523902381E+00
+ cg2d: Sum(rhs),rhsMax =   3.00808810778607E+00  1.10067707985369E+00
+ cg2d: Sum(rhs),rhsMax =   3.00733224418322E+00  1.09600516509505E+00
+ cg2d: Sum(rhs),rhsMax =   3.00644873275975E+00  1.09411950940615E+00
+ cg2d: Sum(rhs),rhsMax =   3.00644865983511E+00  1.09411952745416E+00
+ cg2d: Sum(rhs),rhsMax =   3.00644865983511E+00  1.09411952745416E+00
+ cg2d: Sum(rhs),rhsMax =   7.58941520739853E-19  2.34151580319266E-03
+ cg2d: Sum(rhs),rhsMax =   3.00733230963439E+00  1.09600517806422E+00
+ cg2d: Sum(rhs),rhsMax =   3.00733230963439E+00  1.09600517806422E+00
+ cg2d: Sum(rhs),rhsMax =   1.12757025938492E-17  3.09441259223194E-03
+ cg2d: Sum(rhs),rhsMax =   3.00808831195192E+00  1.10067707240537E+00
+ cg2d: Sum(rhs),rhsMax =   3.00808831195192E+00  1.10067707240537E+00
+ cg2d: Sum(rhs),rhsMax =   1.69135538907739E-17  3.75489953209580E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00830932092584E+00  1.10558523081109E+00
+ cg2d: Sum(rhs),rhsMax =   3.00830758841232E+00  1.10558523081109E+00
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00830932092584E+00  1.10558523081109E+00
- cg2d: Sum(rhs),rhsMax =   8.67361737988404E-19  4.38103713933802E-03
+ cg2d: Sum(rhs),rhsMax =   3.00830758841232E+00  1.10558523081109E+00
+ cg2d: Sum(rhs),rhsMax =  -6.93889390390723E-18  4.38103785980754E-03
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5513,7 +5554,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18150712577028E+06
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18150719949466E+06
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -5560,32 +5601,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457186E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420766479E+00  1.09717250746369E+00
- cg2d: Sum(rhs),rhsMax =   3.00953319369266E+00  1.09443701601849E+00
- cg2d: Sum(rhs),rhsMax =   3.01013532036708E+00  1.08987441579900E+00
- cg2d: Sum(rhs),rhsMax =   3.01194123513844E+00  1.08661842817741E+00
- cg2d: Sum(rhs),rhsMax =   3.01465283198335E+00  1.08470792588520E+00
- cg2d: Sum(rhs),rhsMax =   3.01804005647347E+00  1.08353189661932E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457185E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369144848E+00  1.09717250746367E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954029678110E+00  1.09443701601848E+00
+ cg2d: Sum(rhs),rhsMax =   3.01013965284874E+00  1.08987441590407E+00
+ cg2d: Sum(rhs),rhsMax =   3.01194543556768E+00  1.08661843559851E+00
+ cg2d: Sum(rhs),rhsMax =   3.01467153125705E+00  1.08470792679571E+00
+ cg2d: Sum(rhs),rhsMax =   3.01806892151590E+00  1.08353189415261E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535135010956D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615578217642D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195156519296D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535126763390D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615593984562D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195188328497D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150713238598D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150720757951D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829630980628112D+06
-(PID.TID 0000.0001)  global fc =  0.918150713238598D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150713238598E+06
+(PID.TID 0000.0001)   local fc =  0.829631082416069D+06
+(PID.TID 0000.0001)  global fc =  0.918150720757951D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150720757951E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5627,35 +5668,35 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457179E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420787296E+00  1.09717250746365E+00
- cg2d: Sum(rhs),rhsMax =   3.00953624754111E+00  1.09443701601829E+00
- cg2d: Sum(rhs),rhsMax =   3.01014443976088E+00  1.08987441577936E+00
- cg2d: Sum(rhs),rhsMax =   3.01195070399859E+00  1.08661843313501E+00
- cg2d: Sum(rhs),rhsMax =   3.01466015118001E+00  1.08470792284247E+00
- cg2d: Sum(rhs),rhsMax =   3.01803845732525E+00  1.08353189564298E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457167E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369165660E+00  1.09717250746366E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953151041656E+00  1.09443701601848E+00
+ cg2d: Sum(rhs),rhsMax =   3.01013099713124E+00  1.08987441584021E+00
+ cg2d: Sum(rhs),rhsMax =   3.01193160558597E+00  1.08661842415401E+00
+ cg2d: Sum(rhs),rhsMax =   3.01463375694487E+00  1.08470792617185E+00
+ cg2d: Sum(rhs),rhsMax =   3.01802411551798E+00  1.08353189522879E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535129045766D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615590874028D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195184077111D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535133376395D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615580174659D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195166795527D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150719929794D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150713561054D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631046608150D+06
-(PID.TID 0000.0001)  global fc =  0.918150719929794D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150719929794E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150712577028E+06
+(PID.TID 0000.0001)   local fc =  0.829631055461847D+06
+(PID.TID 0000.0001)  global fc =  0.918150713561054D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150713561054E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150719949466E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217221736908E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -3.34559837356210E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.59844882041216E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5700,32 +5741,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457183E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420767010E+00  1.09717250746367E+00
- cg2d: Sum(rhs),rhsMax =   3.00954916219844E+00  1.09443701601840E+00
- cg2d: Sum(rhs),rhsMax =   3.01016377702739E+00  1.08987441574209E+00
- cg2d: Sum(rhs),rhsMax =   3.01198439378596E+00  1.08661842949666E+00
- cg2d: Sum(rhs),rhsMax =   3.01471366951800E+00  1.08470792133427E+00
- cg2d: Sum(rhs),rhsMax =   3.01809140723281E+00  1.08353189051365E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457186E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369145335E+00  1.09717250746370E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953973212386E+00  1.09443701601854E+00
+ cg2d: Sum(rhs),rhsMax =   3.01015441869191E+00  1.08987441562577E+00
+ cg2d: Sum(rhs),rhsMax =   3.01196649460489E+00  1.08661843265323E+00
+ cg2d: Sum(rhs),rhsMax =   3.01465951843766E+00  1.08470792439815E+00
+ cg2d: Sum(rhs),rhsMax =   3.01803589066218E+00  1.08353189620803E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535105034810D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615617510615D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195204198679D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535126763236D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615601695989D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195195018310D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150722555425D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150728469225D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829630998229634D+06
-(PID.TID 0000.0001)  global fc =  0.918150722555425D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150722555425E+06
+(PID.TID 0000.0001)   local fc =  0.829631034967150D+06
+(PID.TID 0000.0001)  global fc =  0.918150728469225D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150728469225E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5767,35 +5808,35 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457177E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420786808E+00  1.09717250746359E+00
- cg2d: Sum(rhs),rhsMax =   3.00954916399175E+00  1.09443701601826E+00
- cg2d: Sum(rhs),rhsMax =   3.01016801757670E+00  1.08987441567278E+00
- cg2d: Sum(rhs),rhsMax =   3.01199687784304E+00  1.08661842410243E+00
- cg2d: Sum(rhs),rhsMax =   3.01470051933461E+00  1.08470792054337E+00
- cg2d: Sum(rhs),rhsMax =   3.01807073109081E+00  1.08353189630003E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457183E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369165141E+00  1.09717250746369E+00
+ cg2d: Sum(rhs),rhsMax =   3.00956737831286E+00  1.09443701601866E+00
+ cg2d: Sum(rhs),rhsMax =   3.01018299129108E+00  1.08987441577390E+00
+ cg2d: Sum(rhs),rhsMax =   3.01202860341036E+00  1.08661842523153E+00
+ cg2d: Sum(rhs),rhsMax =   3.01476102817506E+00  1.08470792825596E+00
+ cg2d: Sum(rhs),rhsMax =   3.01814830449719E+00  1.08353189312378E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535111665841D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615630011044D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195194803261D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535079869751D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615616508197D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195221504269D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150741686885D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150696387948D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631016484300D+06
-(PID.TID 0000.0001)  global fc =  0.918150741686885D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150741686885E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150712577028E+06
+(PID.TID 0000.0001)   local fc =  0.829630982342736D+06
+(PID.TID 0000.0001)  global fc =  0.918150696387948D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150696387948E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150719949466E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.85234248638153E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -9.56573039293289E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.60406389273703E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5840,32 +5881,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457204E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420767826E+00  1.09717250746366E+00
- cg2d: Sum(rhs),rhsMax =   3.00953821029926E+00  1.09443701601838E+00
- cg2d: Sum(rhs),rhsMax =   3.01015027057244E+00  1.08987441564355E+00
- cg2d: Sum(rhs),rhsMax =   3.01195383186870E+00  1.08661843497472E+00
- cg2d: Sum(rhs),rhsMax =   3.01465514649814E+00  1.08470792021937E+00
- cg2d: Sum(rhs),rhsMax =   3.01802655562261E+00  1.08353189726599E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457199E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369146169E+00  1.09717250746370E+00
+ cg2d: Sum(rhs),rhsMax =   3.00952343579519E+00  1.09443701601839E+00
+ cg2d: Sum(rhs),rhsMax =   3.01012515810822E+00  1.08987441565438E+00
+ cg2d: Sum(rhs),rhsMax =   3.01193045541636E+00  1.08661843045169E+00
+ cg2d: Sum(rhs),rhsMax =   3.01461849470513E+00  1.08470793034699E+00
+ cg2d: Sum(rhs),rhsMax =   3.01797915075635E+00  1.08353188865250E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535125488124D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615608239813D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195189773061D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535144492679D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615582966587D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195196542662D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150733737937D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150727469266D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631032854261D+06
-(PID.TID 0000.0001)  global fc =  0.918150733737937D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150733737937E+06
+(PID.TID 0000.0001)   local fc =  0.829631006088252D+06
+(PID.TID 0000.0001)  global fc =  0.918150727469266D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150727469266E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5908,34 +5949,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
  cg2d: Sum(rhs),rhsMax =   3.01104293457204E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420786029E+00  1.09717250746370E+00
- cg2d: Sum(rhs),rhsMax =   3.00954015010194E+00  1.09443701601844E+00
- cg2d: Sum(rhs),rhsMax =   3.01014528723312E+00  1.08987441582288E+00
- cg2d: Sum(rhs),rhsMax =   3.01195041985036E+00  1.08661843412468E+00
- cg2d: Sum(rhs),rhsMax =   3.01467052330967E+00  1.08470792911987E+00
- cg2d: Sum(rhs),rhsMax =   3.01804132998081E+00  1.08353189589352E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369164371E+00  1.09717250746376E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953174162152E+00  1.09443701601876E+00
+ cg2d: Sum(rhs),rhsMax =   3.01014222066402E+00  1.08987441571999E+00
+ cg2d: Sum(rhs),rhsMax =   3.01195848217231E+00  1.08661842969988E+00
+ cg2d: Sum(rhs),rhsMax =   3.01466115418183E+00  1.08470792248221E+00
+ cg2d: Sum(rhs),rhsMax =   3.01802547203514E+00  1.08353189259953E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535114959715D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615631631175D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195222564447D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535126493460D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615580723635D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195180218753D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150746600890D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150707227095D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631064349217D+06
-(PID.TID 0000.0001)  global fc =  0.918150746600890D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150746600890E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150712577028E+06
+(PID.TID 0000.0001)   local fc =  0.829631074393674D+06
+(PID.TID 0000.0001)  global fc =  0.918150707227095D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150707227095E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150719949466E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19272053241730E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -6.43147677183151E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.01210854947567E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5980,32 +6021,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457218E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420768814E+00  1.09717250746377E+00
- cg2d: Sum(rhs),rhsMax =   3.00954062480577E+00  1.09443701601831E+00
- cg2d: Sum(rhs),rhsMax =   3.01013557728696E+00  1.08987441573339E+00
- cg2d: Sum(rhs),rhsMax =   3.01194436593376E+00  1.08661842990945E+00
- cg2d: Sum(rhs),rhsMax =   3.01464498443145E+00  1.08470791967888E+00
- cg2d: Sum(rhs),rhsMax =   3.01800845921770E+00  1.08353189423292E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457202E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369147153E+00  1.09717250746371E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953405402125E+00  1.09443701601867E+00
+ cg2d: Sum(rhs),rhsMax =   3.01013971084574E+00  1.08987441566108E+00
+ cg2d: Sum(rhs),rhsMax =   3.01195290987368E+00  1.08661842613323E+00
+ cg2d: Sum(rhs),rhsMax =   3.01465446924417E+00  1.08470791530134E+00
+ cg2d: Sum(rhs),rhsMax =   3.01805419992695E+00  1.08353189204071E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535125676561D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615567186114D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195190099346D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535122145722D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615607717311D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195184882829D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150692872676D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150729873033D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631052462515D+06
-(PID.TID 0000.0001)  global fc =  0.918150692872676D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150692872676E+06
+(PID.TID 0000.0001)   local fc =  0.829631038218649D+06
+(PID.TID 0000.0001)  global fc =  0.918150729873033D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150729873033E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -6047,35 +6088,35 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.10672143507061E+00
- cg2d: Sum(rhs),rhsMax =   3.01104293457188E+00  1.10183783749381E+00
- cg2d: Sum(rhs),rhsMax =   3.01041420785018E+00  1.09717250746373E+00
- cg2d: Sum(rhs),rhsMax =   3.00954028050700E+00  1.09443701601825E+00
- cg2d: Sum(rhs),rhsMax =   3.01014885576494E+00  1.08987441555619E+00
- cg2d: Sum(rhs),rhsMax =   3.01195949539937E+00  1.08661842894817E+00
- cg2d: Sum(rhs),rhsMax =   3.01466118866906E+00  1.08470793374405E+00
- cg2d: Sum(rhs),rhsMax =   3.01803879407989E+00  1.08353189251431E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104293457198E+00  1.10183783749381E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041369163406E+00  1.09717250746387E+00
+ cg2d: Sum(rhs),rhsMax =   3.00957421282023E+00  1.09443701601870E+00
+ cg2d: Sum(rhs),rhsMax =   3.01019521803947E+00  1.08987441565303E+00
+ cg2d: Sum(rhs),rhsMax =   3.01202842612732E+00  1.08661843716180E+00
+ cg2d: Sum(rhs),rhsMax =   3.01474887855432E+00  1.08470793195884E+00
+ cg2d: Sum(rhs),rhsMax =   3.01814020012671E+00  1.08353189078697E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535115454928D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615559609010D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195211664226D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535074738770D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615572223820D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195210943472D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150675073938D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150646972590D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.829631041608322D+06
-(PID.TID 0000.0001)  global fc =  0.918150675073938D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150675073938E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150712577028E+06
+(PID.TID 0000.0001)   local fc =  0.829631016676787D+06
+(PID.TID 0000.0001)  global fc =  0.918150646972590D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150646972590E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150719949466E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455932617188E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  8.89936871826649E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.14502212777734E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6089,283 +6130,283 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1815071257703E+06  9.1815071323860E+06  9.1815071992979E+06
-(PID.TID 0000.0001) grdchk output (g):   1    -3.3455983735621E+00  7.3921722173691E-01  5.5258663829572E+00
+(PID.TID 0000.0001) grdchk output (c):   1  9.1815071994947E+06  9.1815072075795E+06  9.1815071356105E+06
+(PID.TID 0000.0001) grdchk output (g):   1     3.5984488204122E+00  7.3921722173691E-01 -3.8679180010945E+00
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   2  9.1815071257703E+06  9.1815072255542E+06  9.1815074168689E+06
-(PID.TID 0000.0001) grdchk output (g):   2    -9.5657303929329E+00  6.8523424863815E-01  1.4959796101762E+01
+(PID.TID 0000.0001) grdchk output (c):   2  9.1815071994947E+06  9.1815072846923E+06  9.1815069638795E+06
+(PID.TID 0000.0001) grdchk output (g):   2     1.6040638927370E+01  6.8523424863815E-01 -2.2408985991651E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1815071257703E+06  9.1815073373794E+06  9.1815074660089E+06
-(PID.TID 0000.0001) grdchk output (g):   3    -6.4314767718315E+00  6.1927205324173E-01  1.1385543378172E+01
+(PID.TID 0000.0001) grdchk output (c):   3  9.1815071994947E+06  9.1815072746927E+06  9.1815070722710E+06
+(PID.TID 0000.0001) grdchk output (g):   3     1.0121085494757E+01  6.1927205324173E-01 -1.5343520496001E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   4  9.1815071257703E+06  9.1815069287268E+06  9.1815067507394E+06
-(PID.TID 0000.0001) grdchk output (g):   4     8.8993687182665E+00  5.4545593261719E-01 -1.5315467824442E+01
+(PID.TID 0000.0001) grdchk output (c):   4  9.1815071994947E+06  9.1815072987303E+06  9.1815064697259E+06
+(PID.TID 0000.0001) grdchk output (g):   4     4.1450221277773E+01  5.4545593261719E-01 -7.4991879085242E+01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.2435079929240E+01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.9925959577648E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4365.0303167775273
-(PID.TID 0000.0001)         System time:   278.15472369641066
-(PID.TID 0000.0001)     Wall clock time:   4873.5010461807251
+(PID.TID 0000.0001)           User time:   4621.2673377841711
+(PID.TID 0000.0001)         System time:   247.33440287411213
+(PID.TID 0000.0001)     Wall clock time:   5081.1988959312439
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.064710088074207
-(PID.TID 0000.0001)         System time:   1.1858200356364250
-(PID.TID 0000.0001)     Wall clock time:   34.128399133682251
+(PID.TID 0000.0001)           User time:   17.718305572867393
+(PID.TID 0000.0001)         System time:   1.4577790051698685
+(PID.TID 0000.0001)     Wall clock time:   46.541150093078613
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1915.6128234863281
-(PID.TID 0000.0001)         System time:   131.68698227405548
-(PID.TID 0000.0001)     Wall clock time:   2198.5914039611816
+(PID.TID 0000.0001)           User time:   2015.6015224456787
+(PID.TID 0000.0001)         System time:   122.73934054374695
+(PID.TID 0000.0001)     Wall clock time:   2264.2674131393433
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   482.59764099121094
-(PID.TID 0000.0001)         System time:   26.293025970458984
-(PID.TID 0000.0001)     Wall clock time:   597.95155096054077
+(PID.TID 0000.0001)           User time:   553.72869873046875
+(PID.TID 0000.0001)         System time:   13.651920318603516
+(PID.TID 0000.0001)     Wall clock time:   655.82038664817810
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.6804046630859375
-(PID.TID 0000.0001)         System time:  1.98364257812500000E-003
-(PID.TID 0000.0001)     Wall clock time:   5.6845030784606934
+(PID.TID 0000.0001)           User time:   6.7507019042968750
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.7619223594665527
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.163528442382813
-(PID.TID 0000.0001)         System time:   7.0579414367675781
-(PID.TID 0000.0001)     Wall clock time:   23.702352046966553
+(PID.TID 0000.0001)           User time:   14.951416015625000
+(PID.TID 0000.0001)         System time:   4.5722694396972656
+(PID.TID 0000.0001)     Wall clock time:   20.140209674835205
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   12.899047851562500
-(PID.TID 0000.0001)         System time:   5.1402130126953125
-(PID.TID 0000.0001)     Wall clock time:   18.179875612258911
+(PID.TID 0000.0001)           User time:   12.315277099609375
+(PID.TID 0000.0001)         System time:   3.5944271087646484
+(PID.TID 0000.0001)     Wall clock time:   16.154248476028442
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.27768516540527344E-003
+(PID.TID 0000.0001)     Wall clock time:  1.39260292053222656E-003
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3237609863281250
-(PID.TID 0000.0001)         System time:  0.12707138061523438
-(PID.TID 0000.0001)     Wall clock time:   1.4459824562072754
+(PID.TID 0000.0001)           User time:   1.3815307617187500
+(PID.TID 0000.0001)         System time:  7.30094909667968750E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4588868618011475
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18122863769531250
+(PID.TID 0000.0001)           User time:  0.19851684570312500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.21795177459716797
+(PID.TID 0000.0001)     Wall clock time:  0.23234796524047852
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   112.91577148437500
-(PID.TID 0000.0001)         System time:   6.2469863891601563
-(PID.TID 0000.0001)     Wall clock time:   119.33282208442688
+(PID.TID 0000.0001)           User time:   116.85290527343750
+(PID.TID 0000.0001)         System time:   3.1635189056396484
+(PID.TID 0000.0001)     Wall clock time:   120.17358565330505
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   38.751342773437500
-(PID.TID 0000.0001)         System time:   2.7495422363281250
-(PID.TID 0000.0001)     Wall clock time:   41.535198688507080
+(PID.TID 0000.0001)           User time:   39.510986328125000
+(PID.TID 0000.0001)         System time:   1.7896566390991211
+(PID.TID 0000.0001)     Wall clock time:   41.318140506744385
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   36.403274536132813
-(PID.TID 0000.0001)         System time:   2.3556251525878906
-(PID.TID 0000.0001)     Wall clock time:   38.833218336105347
+(PID.TID 0000.0001)           User time:   37.132141113281250
+(PID.TID 0000.0001)         System time:   1.5386800765991211
+(PID.TID 0000.0001)     Wall clock time:   38.733898162841797
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   27.191528320312500
-(PID.TID 0000.0001)         System time:  6.01196289062500000E-003
-(PID.TID 0000.0001)     Wall clock time:   27.214163541793823
+(PID.TID 0000.0001)           User time:   29.549957275390625
+(PID.TID 0000.0001)         System time:  4.00638580322265625E-003
+(PID.TID 0000.0001)     Wall clock time:   29.576834440231323
 (PID.TID 0000.0001)          No. starts:         352
 (PID.TID 0000.0001)           No. stops:         352
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   87.205673217773438
-(PID.TID 0000.0001)         System time:  1.79748535156250000E-002
-(PID.TID 0000.0001)     Wall clock time:   87.301151752471924
+(PID.TID 0000.0001)           User time:   98.767486572265625
+(PID.TID 0000.0001)         System time:  7.00473785400390625E-003
+(PID.TID 0000.0001)     Wall clock time:   99.101181268692017
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1259765625000000
-(PID.TID 0000.0001)         System time:   4.5012931823730469
-(PID.TID 0000.0001)     Wall clock time:   12.620497226715088
+(PID.TID 0000.0001)           User time:   3.6700134277343750
+(PID.TID 0000.0001)         System time:   1.3778228759765625
+(PID.TID 0000.0001)     Wall clock time:   5.0476126670837402
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.3722839355468750
-(PID.TID 0000.0001)         System time:  0.80486679077148438
-(PID.TID 0000.0001)     Wall clock time:   10.163773298263550
+(PID.TID 0000.0001)           User time:   10.179870605468750
+(PID.TID 0000.0001)         System time:  0.62780570983886719
+(PID.TID 0000.0001)     Wall clock time:   10.830012559890747
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3308105468750000
-(PID.TID 0000.0001)         System time:  1.00708007812500000E-003
-(PID.TID 0000.0001)     Wall clock time:   1.3673419952392578
+(PID.TID 0000.0001)           User time:   2.2119750976562500
+(PID.TID 0000.0001)         System time:  9.91821289062500000E-004
+(PID.TID 0000.0001)     Wall clock time:   2.2356173992156982
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3042907714843750
-(PID.TID 0000.0001)         System time:  0.25995635986328125
-(PID.TID 0000.0001)     Wall clock time:   4.5414690971374512
+(PID.TID 0000.0001)           User time:   4.0165710449218750
+(PID.TID 0000.0001)         System time:  3.19776535034179688E-002
+(PID.TID 0000.0001)     Wall clock time:   4.0498754978179932
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.19154357910156250
-(PID.TID 0000.0001)         System time:  1.90429687500000000E-002
-(PID.TID 0000.0001)     Wall clock time:  0.23105263710021973
+(PID.TID 0000.0001)           User time:  0.21252441406250000
+(PID.TID 0000.0001)         System time:  9.02748107910156250E-003
+(PID.TID 0000.0001)     Wall clock time:  0.24496388435363770
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.762954711914063
-(PID.TID 0000.0001)         System time:   5.2032279968261719
-(PID.TID 0000.0001)     Wall clock time:   17.016991615295410
+(PID.TID 0000.0001)           User time:   8.5904846191406250
+(PID.TID 0000.0001)         System time:   2.5195884704589844
+(PID.TID 0000.0001)     Wall clock time:   11.149705886840820
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   92.411422729492188
-(PID.TID 0000.0001)         System time:  0.42290496826171875
-(PID.TID 0000.0001)     Wall clock time:   92.909795999526978
+(PID.TID 0000.0001)           User time:   101.01766967773438
+(PID.TID 0000.0001)         System time:  4.40006256103515625E-002
+(PID.TID 0000.0001)     Wall clock time:   101.37361812591553
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.92968750000000000E-003
+(PID.TID 0000.0001)           User time:  9.76562500000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.20854377746582031E-003
+(PID.TID 0000.0001)     Wall clock time:  1.36566162109375000E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  3.90625000000000000E-003
+(PID.TID 0000.0001)           User time:  9.76562500000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.17230415344238281E-003
+(PID.TID 0000.0001)     Wall clock time:  1.25336647033691406E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2577667236328125
-(PID.TID 0000.0001)         System time:  0.13697433471679688
-(PID.TID 0000.0001)     Wall clock time:   1.3951590061187744
+(PID.TID 0000.0001)           User time:   1.1168212890625000
+(PID.TID 0000.0001)         System time:  4.69913482666015625E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1639850139617920
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.19726562500000000E-003
+(PID.TID 0000.0001)           User time:  1.95312500000000000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.14798545837402344E-003
+(PID.TID 0000.0001)     Wall clock time:  1.26338005065917969E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1774749755859375
-(PID.TID 0000.0001)         System time:  0.60091018676757813
-(PID.TID 0000.0001)     Wall clock time:   6.9546847343444824
+(PID.TID 0000.0001)           User time:   3.2015380859375000
+(PID.TID 0000.0001)         System time:  0.45993041992187500
+(PID.TID 0000.0001)     Wall clock time:   81.568384408950806
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1103515625000000
-(PID.TID 0000.0001)         System time:  0.63390350341796875
-(PID.TID 0000.0001)     Wall clock time:   89.633215665817261
+(PID.TID 0000.0001)           User time:   4.2763366699218750
+(PID.TID 0000.0001)         System time:  0.61990737915039063
+(PID.TID 0000.0001)     Wall clock time:   13.711632728576660
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   38.738555908203125
-(PID.TID 0000.0001)         System time:   1.2698135375976563
-(PID.TID 0000.0001)     Wall clock time:   52.405408143997192
+(PID.TID 0000.0001)           User time:   45.568725585937500
+(PID.TID 0000.0001)         System time:   1.4457683563232422
+(PID.TID 0000.0001)     Wall clock time:   57.856806278228760
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   10.554901123046875
-(PID.TID 0000.0001)         System time:  0.23398208618164063
-(PID.TID 0000.0001)     Wall clock time:   10.825085878372192
+(PID.TID 0000.0001)           User time:   10.991790771484375
+(PID.TID 0000.0001)         System time:  0.29795455932617188
+(PID.TID 0000.0001)     Wall clock time:   11.325424194335938
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:  9.76562500000000000E-004
+(PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.95059585571289063E-004
+(PID.TID 0000.0001)     Wall clock time:  4.27722930908203125E-004
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4.4293212890625000
-(PID.TID 0000.0001)         System time:  0.65690612792968750
-(PID.TID 0000.0001)     Wall clock time:   5.9299349784851074
+(PID.TID 0000.0001)           User time:   5.7302246093750000
+(PID.TID 0000.0001)         System time:  0.58491516113281250
+(PID.TID 0000.0001)     Wall clock time:   7.1885910034179688
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4.5753173828125000
-(PID.TID 0000.0001)         System time:  0.13796997070312500
-(PID.TID 0000.0001)     Wall clock time:   5.3839600086212158
+(PID.TID 0000.0001)           User time:   5.4431152343750000
+(PID.TID 0000.0001)         System time:  0.19496917724609375
+(PID.TID 0000.0001)     Wall clock time:   6.4570789337158203
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2425.3481445312500
-(PID.TID 0000.0001)         System time:   144.48704528808594
-(PID.TID 0000.0001)     Wall clock time:   2629.4672400951385
+(PID.TID 0000.0001)           User time:   2576.7741699218750
+(PID.TID 0000.0001)         System time:   122.35739898681641
+(PID.TID 0000.0001)     Wall clock time:   2756.7445490360260
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1968.2158203125000
-(PID.TID 0000.0001)         System time:   123.90513610839844
-(PID.TID 0000.0001)     Wall clock time:   2122.7768499851227
+(PID.TID 0000.0001)           User time:   2055.9760742187500
+(PID.TID 0000.0001)         System time:   110.71019744873047
+(PID.TID 0000.0001)     Wall clock time:   2196.8292050361633
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   443.23852539062500
-(PID.TID 0000.0001)         System time:   19.958999633789063
-(PID.TID 0000.0001)     Wall clock time:   484.67184424400330
+(PID.TID 0000.0001)           User time:   506.53979492187500
+(PID.TID 0000.0001)         System time:   11.016265869140625
+(PID.TID 0000.0001)     Wall clock time:   537.05884003639221
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   9.4052734375000000
-(PID.TID 0000.0001)         System time:  3.00598144531250000E-003
-(PID.TID 0000.0001)     Wall clock time:   9.4146432876586914
+(PID.TID 0000.0001)           User time:   10.239746093750000
+(PID.TID 0000.0001)         System time:  9.91821289062500000E-004
+(PID.TID 0000.0001)     Wall clock time:   10.251995563507080
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  1.51367187500000000E-002
+(PID.TID 0000.0001)           User time:  2.07519531250000000E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.81312561035156250E-002
+(PID.TID 0000.0001)     Wall clock time:  2.31914520263671875E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   381.21289062500000
-(PID.TID 0000.0001)         System time:   17.466369628906250
-(PID.TID 0000.0001)     Wall clock time:   399.16104149818420
+(PID.TID 0000.0001)           User time:   436.49145507812500
+(PID.TID 0000.0001)         System time:   8.7136688232421875
+(PID.TID 0000.0001)     Wall clock time:   446.29557371139526
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   8.6115722656250000
-(PID.TID 0000.0001)         System time:   1.1787872314453125
-(PID.TID 0000.0001)     Wall clock time:   19.495852947235107
+(PID.TID 0000.0001)           User time:   9.6069335937500000
+(PID.TID 0000.0001)         System time:  0.78686523437500000
+(PID.TID 0000.0001)     Wall clock time:   19.115613698959351
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  1.22070312500000000E-003
+(PID.TID 0000.0001)           User time:  9.76562500000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.59256362915039063E-003
+(PID.TID 0000.0001)     Wall clock time:  3.11851501464843750E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   43.517333984375000
-(PID.TID 0000.0001)         System time:   1.2838287353515625
-(PID.TID 0000.0001)     Wall clock time:   55.887224912643433
+(PID.TID 0000.0001)           User time:   49.684570312500000
+(PID.TID 0000.0001)         System time:   1.4917602539062500
+(PID.TID 0000.0001)     Wall clock time:   60.802570581436157
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  2.31933593750000000E-002
-(PID.TID 0000.0001)         System time:  1.20086669921875000E-002
-(PID.TID 0000.0001)     Wall clock time:  0.22932291030883789
+(PID.TID 0000.0001)           User time:  3.63769531250000000E-002
+(PID.TID 0000.0001)         System time:  1.29699707031250000E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10397601127624512
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6416,9 +6457,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =        1028962
+(PID.TID 0000.0001) //            No. barriers =        1028452
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =        1028962
+(PID.TID 0000.0001) //     Total barrier spins =        1028452
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.txt
+++ b/global_oce_llc90/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint66d
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67l
 (PID.TID 0000.0001) // Build user:        gforget
-(PID.TID 0000.0001) // Build host:        GLACIER2.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Mon Mar  6 11:42:40 EST 2017
+(PID.TID 0000.0001) // Build host:        GLACIER3.MIT.EDU
+(PID.TID 0000.0001) // Build date:        Fri Aug 30 05:39:32 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -19,7 +19,6 @@
 (PID.TID 0000.0001) ># nTy - No. threads per process in Y
 (PID.TID 0000.0001) > &EEPARMS
 (PID.TID 0000.0001) > useCubedSphereExchange=.TRUE.,
-(PID.TID 0000.0001) >#debugMode=.TRUE.,
 (PID.TID 0000.0001) > nTx=1,
 (PID.TID 0000.0001) > nTy=1,
 (PID.TID 0000.0001) > /
@@ -53,12 +52,14 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER2.MIT.EDU
+(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER3.MIT.EDU
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 23,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -225,7 +226,6 @@
 (PID.TID 0000.0001) > readBinaryPrec=32,
 (PID.TID 0000.0001) > writeBinaryPrec=32,
 (PID.TID 0000.0001) > debugLevel=1,
-(PID.TID 0000.0001) >#debugLevel=4,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Elliptic solver parameters
@@ -1128,6 +1128,9 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
@@ -1280,6 +1283,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Zonal wind forcing starts at                  -31568400.
 (PID.TID 0000.0001)    Zonal wind forcing period is                      21600.
+(PID.TID 0000.0001)    Zonal wind forcing repeat-cycle is             31536000.
 (PID.TID 0000.0001)    Zonal wind forcing is read from file:
 (PID.TID 0000.0001)    >> CORE2_u10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "uwind" (method= 12 ):
@@ -1288,6 +1292,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Meridional wind forcing starts at             -31568400.
 (PID.TID 0000.0001)    Meridional wind forcing period is                 21600.
+(PID.TID 0000.0001)    Meridional wind forcing repeat-cycle is        31536000.
 (PID.TID 0000.0001)    Meridional wind forcing is read from file:
 (PID.TID 0000.0001)    >> CORE2_v10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "vwind" (method= 22 ):
@@ -1297,6 +1302,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Atmospheric temperature starts at             -31568400.
 (PID.TID 0000.0001)    Atmospheric temperature period is                 21600.
+(PID.TID 0000.0001)    Atmospheric temperature repeat-cycle is        31536000.
 (PID.TID 0000.0001)    Atmospheric temperature is read from file:
 (PID.TID 0000.0001)    >> CORE2_tmp10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "atemp" (method=  1 ):
@@ -1305,6 +1311,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Atmospheric specific humidity starts at       -31568400.
 (PID.TID 0000.0001)    Atmospheric specific humidity period is           21600.
+(PID.TID 0000.0001)    Atmospheric specific humidity rep-cycle is     31536000.
 (PID.TID 0000.0001)    Atmospheric specific humidity is read from file:
 (PID.TID 0000.0001)    >> CORE2_spfh10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "aqh" (method=  1 ):
@@ -1316,6 +1323,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Precipitation data starts at                  -30326400.
 (PID.TID 0000.0001)    Precipitation data period is                    2628000.
+(PID.TID 0000.0001)    Precipitation data repeat-cycle is             31536000.
 (PID.TID 0000.0001)    Precipitation data is read from file:
 (PID.TID 0000.0001)    >> CORE2_rain_monthly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "precip" (method=  1 ):
@@ -1323,26 +1331,29 @@
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_RUNOFF:                       defined
-(PID.TID 0000.0001)    Runoff starts at       -30326400.
-(PID.TID 0000.0001)    Runoff period is         2628000.
-(PID.TID 0000.0001)    Runoff is read from file:
+(PID.TID 0000.0001)    Runoff data starts at                         -30326400.
+(PID.TID 0000.0001)    Runoff data period is                           2628000.
+(PID.TID 0000.0001)    Runoff data repeat-cycle is                    31536000.
+(PID.TID 0000.0001)    Runoff data is read from file:
 (PID.TID 0000.0001)    >> CORE2_daitren_runoff_monthly_clim_r2-SMOOTH.bin <<
 (PID.TID 0000.0001)    assume "runoff" on model-grid (no interpolation)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_RUNOFTEMP:                NOT defined
 (PID.TID 0000.0001) // ALLOW_SALTFLX:                      defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Downward shortwave flux forcing starts at        -31536000.
-(PID.TID 0000.0001)    Downward shortwave flux forcing period is            86400.
-(PID.TID 0000.0001)    Downward shortwave flux forcing is read from file:
+(PID.TID 0000.0001)    Downward shortwave flux starts at             -31536000.
+(PID.TID 0000.0001)    Downward shortwave flux period is                 86400.
+(PID.TID 0000.0001)    Downward shortwave flux repeat-cycle is        31536000.
+(PID.TID 0000.0001)    Downward shortwave flux is read from file:
 (PID.TID 0000.0001)    >> CORE2_dsw_daily_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "swdown" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Downward longwave flux forcing starts at         -31536000.
-(PID.TID 0000.0001)    Downward longwave flux forcing period is             86400.
-(PID.TID 0000.0001)    Downward longwave flux forcing is read from file:
+(PID.TID 0000.0001)    Downward longwave flux starts at              -31536000.
+(PID.TID 0000.0001)    Downward longwave flux period is                  86400.
+(PID.TID 0000.0001)    Downward longwave flux repeat-cycle is         31536000.
+(PID.TID 0000.0001)    Downward longwave flux is read from file:
 (PID.TID 0000.0001)    >> CORE2_dlw_daily_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "lwdown" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
@@ -1356,8 +1367,7 @@
 (PID.TID 0000.0001)    climsst relaxation is NOT used
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:           defined
-(PID.TID 0000.0001)    Climatological SSS starts at                   0.
-(PID.TID 0000.0001)    Climatological SSS period is                 -12.
+(PID.TID 0000.0001)    Climatological SSS period is                        -12.
 (PID.TID 0000.0001)    Climatological SSS is read from file:
 (PID.TID 0000.0001)    >> SSS_WPv1_M_eccollc_90x50_pm05atl.bin <<
 (PID.TID 0000.0001)    assume "climsss" on model-grid (no interpolation)
@@ -2033,6 +2043,9 @@
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -2298,14 +2311,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -2317,6 +2328,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -2331,6 +2345,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -2391,7 +2408,7 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -2407,6 +2424,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
@@ -2425,6 +2451,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -2532,9 +2561,6 @@
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -2585,6 +2611,18 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -3668,10 +3706,10 @@
 (PID.TID 0000.0001) whio : write lev 3 rec   1
 (PID.TID 0000.0001) whio : create lev 2 rec   9
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
 (PID.TID 0000.0001)      cg2d_init_res =   1.22148821513950E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.78869245112670E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.78869245111023E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3679,7 +3717,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1616272928930E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5632311414229E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440442E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3674527568470E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.0334245256094E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1326590590623E+00
@@ -3694,7 +3732,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.0636045013020E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3288676833589E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.3490354978249E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7796643494041E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7796643494042E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.3807874800551E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.7619267971331E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2666699632929E+01
@@ -3749,8 +3787,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543458906719E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535714105E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239363346735E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.3033290200951E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.8746142561283E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.3033290200908E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.8746142558316E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3847,11 +3885,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.75379551365041E-01
-(PID.TID 0000.0001)      cg2d_init_res =   6.28801875362235E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.75379551365031E-01
+(PID.TID 0000.0001)      cg2d_init_res =   6.28801875360193E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     121
-(PID.TID 0000.0001)      cg2d_last_res =   6.65038540959436E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.65038540952272E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3861,22 +3899,22 @@
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.3208169933073E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440442E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.2643349862668E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.7354026962289E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.7354026962283E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.3682979763509E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6814774016473E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9549263003086E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3177685700846E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8265997321464E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.2249835641981E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.2249835641980E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.4934238020287E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2092972249349E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5309567047573E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9597308398963E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3901063713108E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3901063713115E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.2163198881573E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2793074776434E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.2793074776629E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4369725312714E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.5360428770515E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.5360428770517E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2658118475194E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.2359216717155E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905861931584E+00
@@ -3897,9 +3935,9 @@
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8673930185382E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.0885111945776E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.2133672947167E-03
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.4011168379276E-04
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.4011168379277E-04
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.9930591610638E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.3141689534532E-21
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.3485444980554E-21
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   4.3210548690154E-05
 (PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.4066260708736E-08
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7369357655474E+00
@@ -3917,7 +3955,7 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0672220725885E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.3368718363257E-01
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.0277770005130E-01
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0552397946223E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0552397946222E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0672220725885E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.9414801056026E-04
 (PID.TID 0000.0001) %MON ke_max                       =   2.5656396459420E+00
@@ -3930,7 +3968,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760537756917E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240627643711E-05
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.4232869195189E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0849664770431E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0849664769113E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3951,7 +3989,7 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2458717780101E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0414476451705E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9916376419181E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   8.3645072702476E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   8.3645072702477E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.8249872115906E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.8417735406484E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.3763558539030E-07
@@ -3986,7 +4024,7 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4922282378209E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3760272956810E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0532044329824E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.9404854934797E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.9404854934796E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.8369197465842E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4379744348907E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.7007173392460E-07
@@ -4027,11 +4065,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.71568653333839E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.70652790809635E-01
-(PID.TID 0000.0001)      cg2d_init_res =   3.37342106292012E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.71568653334023E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.70652790809499E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.37342106287277E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     108
-(PID.TID 0000.0001)      cg2d_last_res =   6.59366614153203E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.59366614157133E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4041,22 +4079,22 @@
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.0955001231975E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1922425939213E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5960358219728E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5960358219730E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.2237458663701E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.9165482483796E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9327410995683E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9327410995684E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4228317408850E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7716142253438E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.8543299632761E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0756754444551E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0756754444552E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2476635694276E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.6235008224959E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9044916101952E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6163746037430E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2570710624203E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.9754074982169E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6163746037427E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2570710624204E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.9754074982168E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4876302211339E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6956544527080E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6956544527087E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2655996931402E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.4065403486480E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905822687441E+00
@@ -4066,10 +4104,10 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8988613743811E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704117247E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856189031571E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6828366164309E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.0486147161698E+03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6828366164308E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.0486147161697E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.9762792792903E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =   7.5054963156044E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   7.5054963156045E+00
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.8127120036075E+02
 (PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2535554098227E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =  -0.0000000000000E+00
@@ -4079,7 +4117,7 @@
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   6.9831888012059E-03
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2679798178772E-04
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.9878145678678E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.2444901386376E-21
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -6.6802898746265E-21
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   4.2641173999150E-05
 (PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.1174118035987E-08
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.3740203159704E+00
@@ -4100,7 +4138,7 @@
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0626951300454E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2316132728442E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.8043877041817E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3640342964724E+00
+(PID.TID 0000.0001) %MON ke_max                       =   5.3640342964725E+00
 (PID.TID 0000.0001) %MON ke_mean                      =   6.1748987547396E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -6.9024268539164E-05
@@ -4109,8 +4147,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543504116559E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538335594E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7241198119272E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2774828151952E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.0040936313087E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2774828151965E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.0040936314769E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4129,12 +4167,12 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.4264001186409E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3353715044872E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5175907766062E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0832069069779E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0832069069778E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9611186781055E+02
 (PID.TID 0000.0001) %MON exf_hflux_mean               =   7.3629828089869E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.8075660796408E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7804083367673E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.2503800159640E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.2503800159641E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9808795909156E-06
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   4.3971588017597E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2527219935006E-08
@@ -4169,7 +4207,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.9418327762871E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.8292998875729E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4314312876697E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6195603882307E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6195603882304E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1061570556299E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   4.2480032878281E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   3.0032937027672E-08
@@ -4207,36 +4245,36 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.69703285582864E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411907E+00  1.68835099835592E-01
-(PID.TID 0000.0001)      cg2d_init_res =   2.80209522959693E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.69703285582886E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.68835099835374E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.80209522961840E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     113
-(PID.TID 0000.0001)      cg2d_last_res =   6.39470144461722E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39470144539159E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2116115063604E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.0015473361327E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.0015473361326E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440444E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1531019419973E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5679360276870E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5679360276872E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.3098085731785E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.9472693840299E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8690944000118E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.5138637563354E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7470083396258E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.8574867724710E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9742937628890E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.8574867724709E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.9742937628889E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.3302508061681E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.6787498210879E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8753877287891E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9871701537877E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9871701537882E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.9323157091033E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.5086990119685E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6166068650262E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.1152626689858E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.5086990119682E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6166068650263E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.1152626689869E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2654624336484E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.5736467460449E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905781486876E+00
@@ -4247,9 +4285,9 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704085182E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856211348433E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6821818561130E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.1170234475508E+03
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.1170234475506E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.9462001501841E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =   7.9632565710432E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =   7.9632565710431E+00
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.8092570297844E+02
 (PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2453376045741E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =  -0.0000000000000E+00
@@ -4257,11 +4295,11 @@
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8677305866349E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.0820601362220E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   6.8081557976012E-03
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1445678786574E-04
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1445678786573E-04
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.9827931981786E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.7148158432063E-21
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -5.2526640634135E-21
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   4.2487541704271E-05
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.1004744990950E-08
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   3.1004744990949E-08
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2405309848290E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7209187015914E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9548668924840E-03
@@ -4280,7 +4318,7 @@
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1873223106560E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3549500485332E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.7305297126478E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3145383422038E+00
+(PID.TID 0000.0001) %MON ke_max                       =   7.3145383422039E+00
 (PID.TID 0000.0001) %MON ke_mean                      =   6.5326970449666E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -6.2021057978984E-05
@@ -4289,8 +4327,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543517775691E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538716440E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7241793903985E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7969896680300E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6683060349897E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.7969896680264E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6683060345912E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4309,12 +4347,12 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =  -3.9639169922327E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4284093121341E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0251808815859E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1513509411023E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1513509411022E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9315403404785E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   9.2805430883494E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   9.2805430883493E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.8179313165593E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7986590299493E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1322754144298E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1322754144297E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9753812601106E-06
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   4.9670167659031E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2551813198807E-08
@@ -4349,7 +4387,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.9432578839794E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.8221578690260E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4254752790357E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.8072621672306E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.8072621672302E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.8748294615011E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   4.3049388738381E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   3.0371300461141E-08
@@ -4387,13 +4425,13 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411907E+00  1.68580769322894E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.68580769322813E-01
 (PID.TID 0000.0001) %CHECKPOINT         9 ckptA
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427619379551429D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427619379551427D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490911667429045D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4401,60 +4439,60 @@
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918531046980475D+07
+(PID.TID 0000.0001)  --> fc               = 0.918531046980472D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.829786714064328D+06
-(PID.TID 0000.0001)  global fc =  0.918531046980475D+07
+(PID.TID 0000.0001)  global fc =  0.918531046980472D+07
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00378020371992E+00  1.73700015025699E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371977E+00  1.78237451821794E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371973E+00  1.75379603205396E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371965E+00  1.71568757909516E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371994E+00  1.73700015025699E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371986E+00  1.78237451821768E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371959E+00  1.75379603205378E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371990E+00  1.71568757909497E-01
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.00378020371951E+00  1.70652952668613E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371963E+00  1.69703500007588E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371979E+00  1.68835368135374E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371980E+00  1.68581092213186E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371957E+00  1.70652952668558E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020372010E+00  1.69703500007668E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371972E+00  1.68835368135269E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371967E+00  1.68581092213310E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.00378026546645E+00  1.70650732696744E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026546666E+00  1.69702018863459E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026546633E+00  1.68833750182909E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026546651E+00  1.68580031021394E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546647E+00  1.70650732696744E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546616E+00  1.69702018864769E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546654E+00  1.68833750183537E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546651E+00  1.68580031022155E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.00378036323338E+00  1.68580031551603E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378036228024E+00  1.68580031551603E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.00378036323338E+00  1.68580031551603E-01
- cg2d: Sum(rhs),rhsMax =   1.92445885616177E-18  1.84310236564167E-04
- cg2d: Sum(rhs),rhsMax =   3.00378024531367E+00  1.68833753085718E-01
- cg2d: Sum(rhs),rhsMax =   3.00378024531367E+00  1.68833753085718E-01
- cg2d: Sum(rhs),rhsMax =  -5.42101086242752E-18  3.42764117929351E-04
- cg2d: Sum(rhs),rhsMax =   3.00378018434214E+00  1.69702024385912E-01
- cg2d: Sum(rhs),rhsMax =   3.00378018434214E+00  1.69702024385912E-01
- cg2d: Sum(rhs),rhsMax =  -8.56519716263549E-18  9.00253675463612E-04
- cg2d: Sum(rhs),rhsMax =   3.00378026551563E+00  1.70650733721647E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026551563E+00  1.70650733721647E-01
- cg2d: Sum(rhs),rhsMax =  -3.67544536472586E-17  1.61101310101140E-03
+ cg2d: Sum(rhs),rhsMax =   3.00378036228024E+00  1.68580031551603E-01
+ cg2d: Sum(rhs),rhsMax =  -6.91178884959509E-19  1.84310236564170E-04
+ cg2d: Sum(rhs),rhsMax =   3.00378024524415E+00  1.68833753085718E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378024524415E+00  1.68833753085718E-01
+ cg2d: Sum(rhs),rhsMax =  -2.52077005102880E-18  3.42764117925935E-04
+ cg2d: Sum(rhs),rhsMax =   3.00378018404821E+00  1.69702024385912E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378018404821E+00  1.69702024385912E-01
+ cg2d: Sum(rhs),rhsMax =  -8.51098705401121E-18  9.00253675460871E-04
+ cg2d: Sum(rhs),rhsMax =   3.00378026551562E+00  1.70650733721647E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026551562E+00  1.70650733721647E-01
+ cg2d: Sum(rhs),rhsMax =  -1.71303943252710E-17  1.61101310100910E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00378020371992E+00  1.73700015025699E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371958E+00  1.78237890372920E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371975E+00  1.75379982249195E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371976E+00  1.71566769593565E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993610050E+00  1.71566764765776E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993610050E+00  1.71566764765776E-01
- cg2d: Sum(rhs),rhsMax =  -2.53703308361608E-17  2.39860108378439E-03
- cg2d: Sum(rhs),rhsMax =   3.00378002282771E+00  1.75379977756282E-01
- cg2d: Sum(rhs),rhsMax =   3.00378002282771E+00  1.75379977756282E-01
- cg2d: Sum(rhs),rhsMax =  -2.21177243187043E-17  3.19300175639515E-03
- cg2d: Sum(rhs),rhsMax =   3.00378018422827E+00  1.78237893692699E-01
- cg2d: Sum(rhs),rhsMax =   3.00378018422827E+00  1.78237893692699E-01
- cg2d: Sum(rhs),rhsMax =   2.16840434497101E-18  3.95263986219632E-03
+ cg2d: Sum(rhs),rhsMax =   3.00378020371994E+00  1.73700015025699E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371951E+00  1.78237890373011E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371959E+00  1.75379982249284E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371961E+00  1.71566769593594E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993610046E+00  1.71566764765776E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993610046E+00  1.71566764765776E-01
+ cg2d: Sum(rhs),rhsMax =  -3.20923843055709E-17  2.39860108378763E-03
+ cg2d: Sum(rhs),rhsMax =   3.00378002282770E+00  1.75379977756282E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378002282770E+00  1.75379977756282E-01
+ cg2d: Sum(rhs),rhsMax =  -3.31765864780564E-17  3.19300175642089E-03
+ cg2d: Sum(rhs),rhsMax =   3.00378018422830E+00  1.78237893692699E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378018422830E+00  1.78237893692699E-01
+ cg2d: Sum(rhs),rhsMax =  -1.01047642475649E-16  3.95263986378509E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00378020377713E+00  1.73700014741903E-01
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00378020377713E+00  1.73700014741903E-01
- cg2d: Sum(rhs),rhsMax =  -2.77555756156289E-17  4.61196489623110E-03
+ cg2d: Sum(rhs),rhsMax =   6.93889390390723E-18  4.61196489724511E-03
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -4500,7 +4538,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18531046980475E+06
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18531046980472E+06
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -4531,14 +4569,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.75379551365074E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.71568653334046E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.70652790809586E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.69703285583162E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.68835099835350E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.68580769322861E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.75379551365051E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.71568653334013E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.70652790809443E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.69703285582957E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.68835099835348E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.68580769322842E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4582,20 +4620,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.75379551365094E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.71568653333956E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411905E+00  1.70652790809607E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411944E+00  1.69703285582823E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.68835099835384E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411888E+00  1.68580769322843E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.75379551364948E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.71568653333874E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411904E+00  1.70652790809493E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.69703285582771E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.68835099835432E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.68580769322723E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427619379456650D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427619379456647D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490911667429045D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4603,14 +4641,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918531046885695D+07
+(PID.TID 0000.0001)  --> fc               = 0.918531046885693D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.829786714064328D+06
-(PID.TID 0000.0001)  global fc =  0.918531046885695D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046885695E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980475E+06
+(PID.TID 0000.0001)  global fc =  0.918531046885693D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046885693E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  9.69491004943848E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  9.42393206059933E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  9.42405313253403E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -4639,14 +4677,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.75379551365065E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411908E+00  1.71568653333884E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.70652790809531E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69703285582991E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411908E+00  1.68835099835417E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.68580769322739E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.75379551365021E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.71568653333889E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411908E+00  1.70652790809442E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.69703285582873E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.68835099835410E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411913E+00  1.68580769322884E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4690,14 +4728,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411908E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.75379551365062E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.71568653333866E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.70652790809620E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.69703285582846E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.68835099835416E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.68580769322887E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.75379551365006E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.71568653334017E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.70652790809462E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.69703285582795E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.68835099835433E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.68580769322779E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4716,7 +4754,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)   local fc =  0.829786714064328D+06
 (PID.TID 0000.0001)  global fc =  0.918531046877543D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046877543E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980475E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.02185703814030E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.01514346897602E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
@@ -4747,20 +4785,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.75379551365031E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.71568653333855E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.70652790809628E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411907E+00  1.69703285582918E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.68835099835519E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.68580769322828E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.75379551365025E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.71568653334090E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.70652790809471E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.69703285582848E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.68835099835464E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.68580769322814E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427619379658825D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427619379658826D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490911667429045D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4798,14 +4836,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411906E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.75379551365058E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.71568653334041E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.70652790809572E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.69703285582993E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.68835099835326E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.68580769322736E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411944E+00  1.75379551365007E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.71568653334087E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.70652790809506E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.69703285582865E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.68835099835321E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.68580769322820E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4824,9 +4862,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001)   local fc =  0.829786714064328D+06
 (PID.TID 0000.0001)  global fc =  0.918531046870745D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046870745E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980475E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.09075762331486E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.08562782406807E-01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.08562968671322E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -4855,14 +4893,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.75379551365051E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71568653333912E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.70652790809649E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.69703285583082E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.68835099835306E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.68580769322839E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.75379551364979E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411901E+00  1.71568653334013E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.70652790809570E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.69703285582768E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.68835099835366E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.68580769322819E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4876,11 +4914,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918531047098381D+07
+(PID.TID 0000.0001)  --> fc               = 0.918531047098382D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.829786714064328D+06
-(PID.TID 0000.0001)  global fc =  0.918531047098381D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18531047098381E+06
+(PID.TID 0000.0001)  global fc =  0.918531047098382D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18531047098382E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -4906,14 +4944,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411959E+00  1.73700750724295E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411900E+00  1.78237496760368E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.75379551365058E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.71568653333972E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411919E+00  1.70652790809580E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.69703285582955E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.68835099835369E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.68580769322793E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.75379551365019E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.71568653333922E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.70652790809542E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.69703285582826E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.68835099835367E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.68580769322835E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4932,9 +4970,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001)   local fc =  0.829786714064328D+06
 (PID.TID 0000.0001)  global fc =  0.918531046860141D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046860141E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980475E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.20151713490486E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.19120068848133E-01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.19120441377163E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -4948,265 +4986,265 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1853104698047E+06  9.1853104707417E+06  9.1853104688570E+06
-(PID.TID 0000.0001) grdchk output (g):   1     9.4239320605993E-02  9.6949100494385E-02  2.7950541826311E-02
+(PID.TID 0000.0001) grdchk output (c):   1  9.1853104698047E+06  9.1853104707417E+06  9.1853104688569E+06
+(PID.TID 0000.0001) grdchk output (g):   1     9.4240531325340E-02  9.6949100494385E-02  2.7938053630538E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   2  9.1853104698047E+06  9.1853104708057E+06  9.1853104687754E+06
 (PID.TID 0000.0001) grdchk output (g):   2     1.0151434689760E-01  1.0218570381403E-01  6.5699690990966E-03
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1853104698047E+06  9.1853104708787E+06  9.1853104687075E+06
-(PID.TID 0000.0001) grdchk output (g):   3     1.0856278240681E-01  1.0907576233149E-01  4.7029689613338E-03
+(PID.TID 0000.0001) grdchk output (c):   3  9.1853104698047E+06  9.1853104708787E+06  9.1853104687074E+06
+(PID.TID 0000.0001) grdchk output (g):   3     1.0856296867132E-01  1.0907576233149E-01  4.7012612995129E-03
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   4  9.1853104698047E+06  9.1853104709838E+06  9.1853104686014E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.1912006884813E-01  1.2015171349049E-01  8.5861833542203E-03
+(PID.TID 0000.0001) grdchk output (g):   4     1.1912044137716E-01  1.2015171349049E-01  8.5830828655212E-03
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.5167710308341E-02
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.5161386017681E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11582.133646816015
-(PID.TID 0000.0001)         System time:   554.97561603039503
-(PID.TID 0000.0001)     Wall clock time:   12322.333781003952
+(PID.TID 0000.0001)           User time:   3972.6540655791759
+(PID.TID 0000.0001)         System time:   195.36229690909386
+(PID.TID 0000.0001)     Wall clock time:   4342.9234440326691
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   18.620169490575790
-(PID.TID 0000.0001)         System time:   1.1358279511332512
-(PID.TID 0000.0001)     Wall clock time:   44.004052877426147
+(PID.TID 0000.0001)           User time:   15.153695553541183
+(PID.TID 0000.0001)         System time:   1.4157839715480804
+(PID.TID 0000.0001)     Wall clock time:   40.553339004516602
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   4533.3357429504395
-(PID.TID 0000.0001)         System time:   222.36620104312897
-(PID.TID 0000.0001)     Wall clock time:   4842.2445819377899
+(PID.TID 0000.0001)           User time:   1473.4570350646973
+(PID.TID 0000.0001)         System time:   74.424685239791870
+(PID.TID 0000.0001)     Wall clock time:   1646.5052349567413
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   682.26562500000000
-(PID.TID 0000.0001)         System time:   23.395515441894531
-(PID.TID 0000.0001)     Wall clock time:   757.66777062416077
+(PID.TID 0000.0001)           User time:   416.54544067382813
+(PID.TID 0000.0001)         System time:   14.644796371459961
+(PID.TID 0000.0001)     Wall clock time:   481.87311768531799
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   20.688903808593750
-(PID.TID 0000.0001)         System time:  5.02014160156250000E-003
-(PID.TID 0000.0001)     Wall clock time:   20.707029581069946
+(PID.TID 0000.0001)           User time:   6.4624938964843750
+(PID.TID 0000.0001)         System time:  1.19895935058593750E-002
+(PID.TID 0000.0001)     Wall clock time:   6.4940526485443115
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   10.336853027343750
-(PID.TID 0000.0001)         System time:   1.6328430175781250
-(PID.TID 0000.0001)     Wall clock time:   50.411206960678101
+(PID.TID 0000.0001)           User time:   13.987152099609375
+(PID.TID 0000.0001)         System time:   6.3780517578125000
+(PID.TID 0000.0001)     Wall clock time:   20.709386110305786
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   8.8404541015625000
-(PID.TID 0000.0001)         System time:   1.2877349853515625
-(PID.TID 0000.0001)     Wall clock time:   10.228560447692871
+(PID.TID 0000.0001)           User time:   10.492095947265625
+(PID.TID 0000.0001)         System time:   4.5383434295654297
+(PID.TID 0000.0001)     Wall clock time:   15.108074665069580
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.68704986572265625E-003
+(PID.TID 0000.0001)     Wall clock time:  1.39141082763671875E-003
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.1663818359375000
-(PID.TID 0000.0001)         System time:  0.12493133544921875
-(PID.TID 0000.0001)     Wall clock time:   2.3017389774322510
+(PID.TID 0000.0001)           User time:   1.3791198730468750
+(PID.TID 0000.0001)         System time:  8.19988250732421875E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4689483642578125
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.55902099609375000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.57553625106811523
+(PID.TID 0000.0001)           User time:  0.19714355468750000
+(PID.TID 0000.0001)         System time:  1.00135803222656250E-003
+(PID.TID 0000.0001)     Wall clock time:  0.22994661331176758
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   31.729858398437500
-(PID.TID 0000.0001)         System time:  5.19027709960937500E-002
-(PID.TID 0000.0001)     Wall clock time:   31.795039653778076
+(PID.TID 0000.0001)           User time:   13.964660644531250
+(PID.TID 0000.0001)         System time:  6.39934539794921875E-002
+(PID.TID 0000.0001)     Wall clock time:   14.087677478790283
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   274.45587158203125
-(PID.TID 0000.0001)         System time:  4.00085449218750000E-002
-(PID.TID 0000.0001)     Wall clock time:   274.56180429458618
+(PID.TID 0000.0001)           User time:   97.327178955078125
+(PID.TID 0000.0001)         System time:  6.02722167968750000E-003
+(PID.TID 0000.0001)     Wall clock time:   97.461176156997681
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   18.861145019531250
-(PID.TID 0000.0001)         System time:   10.294517517089844
-(PID.TID 0000.0001)     Wall clock time:   29.227482318878174
+(PID.TID 0000.0001)           User time:   4.4780578613281250
+(PID.TID 0000.0001)         System time:   2.3496284484863281
+(PID.TID 0000.0001)     Wall clock time:   6.8227925300598145
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   40.162109375000000
-(PID.TID 0000.0001)         System time:   1.3868179321289063
-(PID.TID 0000.0001)     Wall clock time:   41.548757314682007
+(PID.TID 0000.0001)           User time:   12.159118652343750
+(PID.TID 0000.0001)         System time:   1.0248336791992188
+(PID.TID 0000.0001)     Wall clock time:   13.195768356323242
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1218261718750000
+(PID.TID 0000.0001)           User time:   2.1877441406250000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.1313226222991943
+(PID.TID 0000.0001)     Wall clock time:   2.2177057266235352
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.034667968750000
-(PID.TID 0000.0001)         System time:  0.31693267822265625
-(PID.TID 0000.0001)     Wall clock time:   13.404495716094971
+(PID.TID 0000.0001)           User time:   4.0115356445312500
+(PID.TID 0000.0001)         System time:  6.20079040527343750E-002
+(PID.TID 0000.0001)     Wall clock time:   4.0580341815948486
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.64770507812500000
-(PID.TID 0000.0001)         System time:  7.09228515625000000E-002
-(PID.TID 0000.0001)     Wall clock time:  0.76409411430358887
+(PID.TID 0000.0001)           User time:  0.22509765625000000
+(PID.TID 0000.0001)         System time:  1.99813842773437500E-002
+(PID.TID 0000.0001)     Wall clock time:  0.26449728012084961
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   19.114196777343750
-(PID.TID 0000.0001)         System time:   8.1917266845703125
-(PID.TID 0000.0001)     Wall clock time:   27.368913888931274
+(PID.TID 0000.0001)           User time:   8.1496887207031250
+(PID.TID 0000.0001)         System time:   2.9795551300048828
+(PID.TID 0000.0001)     Wall clock time:   11.154902696609497
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   198.29187011718750
-(PID.TID 0000.0001)         System time:  0.18602752685546875
-(PID.TID 0000.0001)     Wall clock time:   198.54479050636292
+(PID.TID 0000.0001)           User time:   73.266662597656250
+(PID.TID 0000.0001)         System time:  7.99865722656250000E-002
+(PID.TID 0000.0001)     Wall clock time:   73.473677873611450
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:  1.95312500000000000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.55997276306152344E-003
+(PID.TID 0000.0001)     Wall clock time:  1.29389762878417969E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.95312500000000000E-003
+(PID.TID 0000.0001)           User time:  9.76562500000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.57237052917480469E-003
+(PID.TID 0000.0001)     Wall clock time:  1.25956535339355469E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.5343627929687500
-(PID.TID 0000.0001)         System time:  0.12397766113281250
-(PID.TID 0000.0001)     Wall clock time:   3.6553471088409424
+(PID.TID 0000.0001)           User time:   1.0977478027343750
+(PID.TID 0000.0001)         System time:  3.89919281005859375E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1334934234619141
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.92968750000000000E-003
+(PID.TID 0000.0001)           User time:  9.76562500000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.55615806579589844E-003
+(PID.TID 0000.0001)     Wall clock time:  1.23357772827148438E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4954833984375000
-(PID.TID 0000.0001)         System time:  0.17498016357421875
-(PID.TID 0000.0001)     Wall clock time:   7.8233792781829834
+(PID.TID 0000.0001)           User time:   2.9835205078125000
+(PID.TID 0000.0001)         System time:  0.28696441650390625
+(PID.TID 0000.0001)     Wall clock time:   6.3204026222229004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8790893554687500
-(PID.TID 0000.0001)         System time:  0.51591491699218750
-(PID.TID 0000.0001)     Wall clock time:   14.377142906188965
+(PID.TID 0000.0001)           User time:   4.0423583984375000
+(PID.TID 0000.0001)         System time:  0.65690040588378906
+(PID.TID 0000.0001)     Wall clock time:   50.699107646942139
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   44.225646972656250
-(PID.TID 0000.0001)         System time:   1.0409011840820313
-(PID.TID 0000.0001)     Wall clock time:   59.801189899444580
+(PID.TID 0000.0001)           User time:   34.978576660156250
+(PID.TID 0000.0001)         System time:   1.1208324432373047
+(PID.TID 0000.0001)     Wall clock time:   46.259369373321533
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   15.442932128906250
-(PID.TID 0000.0001)         System time:  0.24693298339843750
-(PID.TID 0000.0001)     Wall clock time:   15.762294054031372
+(PID.TID 0000.0001)           User time:   12.810089111328125
+(PID.TID 0000.0001)         System time:  0.30695533752441406
+(PID.TID 0000.0001)     Wall clock time:   13.152333259582520
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:  9.99450683593750000E-004
-(PID.TID 0000.0001)     Wall clock time:  5.04493713378906250E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  4.13656234741210938E-004
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   6.6948242187500000
-(PID.TID 0000.0001)         System time:  0.14596557617187500
-(PID.TID 0000.0001)     Wall clock time:   8.4052340984344482
+(PID.TID 0000.0001)           User time:   5.5380859375000000
+(PID.TID 0000.0001)         System time:  0.36894226074218750
+(PID.TID 0000.0001)     Wall clock time:   6.9478480815887451
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
 (PID.TID 0000.0001)           User time:   5.4052734375000000
-(PID.TID 0000.0001)         System time:  0.14498901367187500
-(PID.TID 0000.0001)     Wall clock time:   7.0853428840637207
+(PID.TID 0000.0001)         System time:  0.18697357177734375
+(PID.TID 0000.0001)     Wall clock time:   6.3547520637512207
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   7018.0776367187500
-(PID.TID 0000.0001)         System time:   331.18263244628906
-(PID.TID 0000.0001)     Wall clock time:   7420.5943350791931
+(PID.TID 0000.0001)           User time:   2473.0999755859375
+(PID.TID 0000.0001)         System time:   118.96591186523438
+(PID.TID 0000.0001)     Wall clock time:   2642.5621480941772
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6403.0341796875000
-(PID.TID 0000.0001)         System time:   312.60543823242188
-(PID.TID 0000.0001)     Wall clock time:   6759.9628152847290
+(PID.TID 0000.0001)           User time:   2082.6575927734375
+(PID.TID 0000.0001)         System time:   105.95487976074219
+(PID.TID 0000.0001)     Wall clock time:   2219.9250519275665
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   614.51562500000000
-(PID.TID 0000.0001)         System time:   18.506195068359375
-(PID.TID 0000.0001)     Wall clock time:   659.00757503509521
+(PID.TID 0000.0001)           User time:   390.08349609375000
+(PID.TID 0000.0001)         System time:   12.984016418457031
+(PID.TID 0000.0001)     Wall clock time:   421.82290768623352
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   11.612304687500000
+(PID.TID 0000.0001)           User time:   10.647460937500000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   11.620298862457275
+(PID.TID 0000.0001)     Wall clock time:   10.658125400543213
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  4.49218750000000000E-002
+(PID.TID 0000.0001)           User time:  1.98974609375000000E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  4.17361259460449219E-002
+(PID.TID 0000.0001)     Wall clock time:  2.03168392181396484E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   537.87402343750000
-(PID.TID 0000.0001)         System time:   16.794525146484375
-(PID.TID 0000.0001)     Wall clock time:   555.18797636032104
+(PID.TID 0000.0001)           User time:   326.42712402343750
+(PID.TID 0000.0001)         System time:   10.584411621093750
+(PID.TID 0000.0001)     Wall clock time:   337.78984904289246
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   10.696289062500000
-(PID.TID 0000.0001)         System time:  0.56692504882812500
-(PID.TID 0000.0001)     Wall clock time:   23.141053915023804
+(PID.TID 0000.0001)           User time:   10.077514648437500
+(PID.TID 0000.0001)         System time:   1.1468124389648438
+(PID.TID 0000.0001)     Wall clock time:   20.030594110488892
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  1.95312500000000000E-003
+(PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.38897514343261719E-003
+(PID.TID 0000.0001)     Wall clock time:  3.11088562011718750E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   52.912597656250000
-(PID.TID 0000.0001)         System time:   1.1138610839843750
-(PID.TID 0000.0001)     Wall clock time:   67.351733207702637
+(PID.TID 0000.0001)           User time:   42.433471679687500
+(PID.TID 0000.0001)         System time:   1.2338180541992188
+(PID.TID 0000.0001)     Wall clock time:   52.780191659927368
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  3.02734375000000000E-002
-(PID.TID 0000.0001)         System time:  1.39465332031250000E-002
-(PID.TID 0000.0001)     Wall clock time:  0.30095553398132324
+(PID.TID 0000.0001)           User time:  2.99072265625000000E-002
+(PID.TID 0000.0001)         System time:  1.19781494140625000E-002
+(PID.TID 0000.0001)     Wall clock time:  9.07356739044189453E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -5257,9 +5295,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         896156
+(PID.TID 0000.0001) //            No. barriers =         896798
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         896156
+(PID.TID 0000.0001) //     Total barrier spins =         896798
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm_contrib/verification_other"
     =================================================================
 
+  - update output of exp. global_oce_llc90 (all 4 FWD and 2 ADM)
+    after merging PR #219 on Aug 15.
+
 checkpoint67l (2019/08/29) synchronised with main MITgcm code.
   - update output of exp. shelfice_remeshing after merging PR #219 on Aug 15.
   - add (TAF) Adjoint set-up to experiment global_oce_biogeo_bling


### PR DESCRIPTION
```
< Y Y Y Y> 6<16 16 12 12 16 16 13 11 13 12 11 12 12 14 11 11  .  .  .  . FAIL  global_oce_llc90
< Y Y Y Y> 9<16 16 12 12 16 16 14 11 14 13 12 13 13 14 11 12  .  . .  . FAIL  global_oce_llc90.core2
< Y Y Y Y> 4<12 14 10 10 11 16 11  9  9 10  8  9 11 11  8  9  .  .  .   .  . FAIL  global_oce_llc90.ecco_v4
< Y Y Y Y> 7<16 13 12 12 12 13 14 11 10 13 10 11 11 11 10 11  .  .  . .  . FAIL  global_oce_llc90.ecmwf
---
> Y Y Y Y>16<16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16  . .  .  . pass  global_oce_llc90
> Y Y Y Y>16<16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16  .   .   . pass  global_oce_llc90.core2
> Y Y Y Y>16<16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16  .   .   . pass  global_oce_llc90.ecco_v4
> Y Y Y Y>16<16 16 16 16 16 16 16 16 16 16 16 16 16 16 16 16  .    .  . pass  global_oce_llc90.ecmwf
```

and

```
< Y Y Y Y 14>16< 5 pass  global_oce_llc90  (e=0, w=48)
< Y Y Y Y  8>16< 0 pass  global_oce_llc90.ecco_v4
---
> Y Y Y Y 16>16< 5 pass  global_oce_llc90  (e=0, w=48)
> Y Y Y Y 16>16<16 pass  global_oce_llc90.ecco_v4
```

