### PR TITLE
Update gm k3d output

### DIFF
--- a/global_ocean.gm_k3d/results/output.txt
+++ b/global_ocean.gm_k3d/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65z
-(PID.TID 0000.0001) // Build user:        jmc
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Thu Oct  6 11:57:35 EDT 2016
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67m
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Thu Oct 17 17:58:43 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -52,6 +52,8 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -689,7 +691,7 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   246
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   251
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
@@ -705,14 +707,14 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    64 RHOAnoma
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 CONVADJ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   199 GM_Kwx
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   200 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   201 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   204 GM_Kwx
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   205 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   206 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all diagnostics:     185 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   199  GM_Kwx   , Parms: UM      LR , mate:   200
-(PID.TID 0000.0001)   set mate pointer for diag #   200  GM_Kwy   , Parms: VM      LR , mate:   199
+(PID.TID 0000.0001)   set mate pointer for diag #   204  GM_Kwx   , Parms: UM      LR , mate:   205
+(PID.TID 0000.0001)   set mate pointer for diag #   205  GM_Kwy   , Parms: VM      LR , mate:   204
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
@@ -934,7 +936,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -1025,8 +1027,9 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implBottomFriction= /* Implicit bottom friction on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1047,39 +1050,17 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectVortScheme= /* V.I Scheme selector for Vorticity-Term */
-(PID.TID 0000.0001)               123456789
-(PID.TID 0000.0001)    = 0 : enstrophy (Shallow-Water Eq.) conserving scheme by Sadourny, JAS 75
-(PID.TID 0000.0001)    = 1 : same as 0 with modified hFac
-(PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
-(PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
-(PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) highOrderVorticity= /* V.I High order vort. advect. flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindShear= /* V.I Upwind vertical Shear advection flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectKEscheme= /* V.I Kinetic Energy scheme selector */
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1145,6 +1126,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1162,6 +1149,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1269,9 +1259,6 @@
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1322,6 +1309,18 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -1954,6 +1953,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_useK3D =     /* if TRUE => use K3D for diffusivity */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -2022,9 +2024,9 @@ listId=    3 ; file name: oceDiag
     64 |RHOAnoma|     96 |      0 |  15 |       0 |
     78 |DRHODR  |    111 |      0 |  15 |       0 |
     79 |CONVADJ |    126 |      0 |  15 |       0 |
-   199 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
-   200 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
-   201 |GM_Kwz  |    171 |      0 |  15 |       0 |
+   204 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
+   205 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
+   206 |GM_Kwz  |    171 |      0 |  15 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     2
 ------------------------------------------------------------------------
@@ -2240,25 +2242,25 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.23143674320514E-03  2.62871826285150E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.71016562818691E-01
+ cg2d: Sum(rhs),rhsMax =   7.23143674320303E-03  2.62871826285150E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.71016562818689E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.44179059658943E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.44179052767172E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0241303990160E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158211969346E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248849E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0241303990159E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158211969345E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248847E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4259975233385E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5884830845482E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5884830845481E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1565903465634E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2646663818193E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3937623148597E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3841560537884E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3833801561302E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3833801561301E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5610441198593E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.2886623782510E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2472133325878E-04
@@ -2266,7 +2268,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.3735946623178E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0664208920472E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6357590858581E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9092337390591E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9092337390590E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1766506945356E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6740699728739E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9721893777139E+01
@@ -2278,7 +2280,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755744670981E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518209E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606680953194E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0172924604266E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0172924604267E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2693899536133E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8655982259115E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6687693382567E+01
@@ -2322,28 +2324,28 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642652839E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162947612555E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8467307941364E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9395699253742E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9395699253759E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.20257556889191E-02  2.38591222805680E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.02553793424165E-01
+ cg2d: Sum(rhs),rhsMax =   1.20257556889282E-02  2.38591222805680E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.02553793420934E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.26712029601039E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.26712035552508E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9396931613912E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9396931613914E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5797230816683E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231134E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231135E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2997656271079E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4327834373656E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4327834373657E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9945393137865E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.6365753253841E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2245757620178E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.6365753253838E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2245757620177E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4689467074603E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6570533193842E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0472824416430E-02
@@ -2353,7 +2355,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1330630354886E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4682484425225E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2763101027838E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9215283188972E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9215283188984E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6116218731806E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2646003329411E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9715429146768E+01
@@ -2391,10 +2393,10 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2178105886956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5379778517573E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6013891322863E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7666010230264E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6013891323037E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7666010230290E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6463721489025E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6413872620666E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6413872620667E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2042977985712E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.5751900059169E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.1765340085672E-02
@@ -2403,46 +2405,46 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON ke_mean                      =   2.1094281661530E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781986628E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.3766243634023E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0005208399009E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0005208399008E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209470E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604169478535E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640495892E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163345343232E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3820417159294E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2632356801627E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3820417159293E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2632356801531E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.75443264042617E-02  2.19411333207643E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96158677583631E-01
+ cg2d: Sum(rhs),rhsMax =   1.75443264042487E-02  2.19411333207641E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96158677581082E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.31456607135837E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.31456618540805E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7380645073921E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7380645073925E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6005564984329E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451989E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451978E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5717446179891E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3355402720434E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3355402720433E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9918905345807E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8241171080328E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8241171080327E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4724078482376E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6233099652712E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7084318787733E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7084318787732E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2357847871439E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8050949061560E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8050949061559E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6184581358311E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2036017304269E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6231442972437E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.7897339924016E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5122907414752E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2402359869292E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2402359869565E-10
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9652495667370E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7142474632775E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7142474632774E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9709600745555E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9021686776813E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199346677320E+00
@@ -2480,31 +2482,31 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2842568613977E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2331806837759E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1446306747654E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2621994902385E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1446306747648E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2621994902384E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5164047615935E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.6023988330894E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.3389469389557E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9724983413977E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5865031634417E-03
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.3389469389556E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9724983413976E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.5865031634416E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.3475388787460E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6078924665633E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2148938274259E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6078924665632E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2148938274260E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807116958E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185083200E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649846246E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163575796847E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0524735734646E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2041897460463E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0524735734647E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2041897461590E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.43569073237436E-02  1.98772930972417E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.59224069420949E-01
+ cg2d: Sum(rhs),rhsMax =   2.43569073237434E-02  1.98772930972416E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.59224069423956E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.95467299933703E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.95467297405077E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2512,22 +2514,22 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8749683987969E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5495198767890E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911404E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911418E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5655596374140E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2452045736314E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0303779879271E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7791736281361E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0303779879270E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7791736281359E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8557839979727E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8619449082207E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5348749382686E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3352166839268E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.1860669476199E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5348749382685E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3352166839267E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.1860669476202E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6777392739004E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.3918536708254E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8039299171560E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0129629821496E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6637864378615E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.9805427444323E-12
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.9805427451135E-12
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2270249464528E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0095533248124E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9704985059217E+01
@@ -2565,33 +2567,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1963113185778E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.1539133940739E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8039972698183E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1963113185771E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.1539133940452E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8039972697842E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8820497539900E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7847054811212E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7847054811213E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.3442398262591E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1784761546841E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.9636843905522E-04
 (PID.TID 0000.0001) %MON ke_max                       =   5.3696420420017E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   4.7473174541937E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5043565481899E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.1269231656151E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5043565481898E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.1269231656152E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807042577E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217470123E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661335593E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163652312754E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1132021589802E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0244095888325E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1132021589800E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0244095887814E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.30747488200533E-02  1.76734499829915E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.10879448285076E-01
+ cg2d: Sum(rhs),rhsMax =   3.30747488200575E-02  1.76734499829915E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.10879448289940E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.86766775527389E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.86766775200671E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2601,21 +2603,21 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5010404568214E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609403E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4675058438298E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1547211630820E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1547211630819E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1016213681757E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4986070562917E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4986070562912E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8039080507189E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1636608857097E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1622991047566E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2142255558565E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2142255558564E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0289750180636E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.0586423409485E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.0586423409644E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.2932401258513E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6570647403341E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1277751506900E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7225965441455E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6292689639641E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3934341338833E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6292689639638E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3934341338834E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1527489373715E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701395031882E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035501777690E+00
@@ -2653,57 +2655,57 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5694062143202E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9584369949691E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6578935094661E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5377168761708E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9584369949914E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6578935095062E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5377168761701E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9991334323453E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8967149911106E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8028440014140E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8967149911110E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8028440014145E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.8252514049921E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.2967708476681E-03
+(PID.TID 0000.0001) %MON ke_max                       =   7.2967708476682E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   6.2192140924784E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3968329660797E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0959823672676E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3968329660798E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0959823672679E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806999737E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257540058E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668390582E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163639437998E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0688335351079E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1895113244141E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0688335351081E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1895113245628E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.44560032753945E-02  1.54338886443048E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.23897036632379E+00
+ cg2d: Sum(rhs),rhsMax =   4.44560032754202E-02  1.54338886443046E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.23897036633481E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.21985478807791E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.21985479023295E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0915183556910E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4651145203690E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545969E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4651145203689E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545970E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3600171476095E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0619262127648E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0619262127650E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2871661932850E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.9615259514299E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5902284574486E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.9615259514295E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5902284574487E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.4916064372816E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.6289007348714E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8194516428530E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.6289007348716E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8194516428529E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1014260540729E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9249500165579E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9035404608701E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0185815323951E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1433695426611E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7970751042103E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8001630694672E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1433695426613E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7970751042104E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8001630694666E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4673688579648E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1606572603468E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1606572603471E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9698435752515E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042873467983E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201590182655E+00
@@ -2714,7 +2716,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009480822E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601929180949E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0061653164514E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164063E+02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164062E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8422400970459E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6625133603452E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1159198929743E+02
@@ -2740,57 +2742,57 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5372778511734E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0573616661579E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5177974671016E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0055214224753E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1398941755622E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2337880616019E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1842772131232E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0573616661583E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5177974671015E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0055214224741E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1398941755621E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2337880616024E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1842772131238E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.6763253494411E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.2667877127656E-03
+(PID.TID 0000.0001) %MON ke_max                       =   9.2667877127657E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   7.6839048320028E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.5109617161929E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2590573683772E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2590573683777E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807004774E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298834835E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669476551E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163594703642E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7374769787370E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9857631555858E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7374769787363E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9857631554533E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.93586546730545E-02  1.32904232014372E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.15969046839028E+00
+ cg2d: Sum(rhs),rhsMax =   5.93586546730636E-02  1.32904232014373E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.15969046839840E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.51471800040110E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.51471814989828E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0692512581933E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4349678167737E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721101E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4349678167736E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721105E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2802894452365E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9649167519610E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4532763696255E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1670607490617E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.2844497650577E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4532763696254E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1670607490608E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.2844497650590E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8036872236543E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9638096715902E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1518161868301E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9638096715905E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1518161868300E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1346893599129E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9448557987145E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9448557987144E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0235463080457E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0409209210175E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1560997765233E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8934548485621E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1327784540806E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1560997765236E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8934548485622E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1327784540815E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4579054319834E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0408994395809E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0408994395813E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695900836394E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050606949647E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202227262679E+00
@@ -2826,33 +2828,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1188657319929E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1313546287234E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3609744911601E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4095603319056E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1188657319981E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1313546288932E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3609744911655E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4095603319057E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2045194440164E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3321806779490E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2956762373053E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3321806779500E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2956762373065E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5677726263037E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1186850487197E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.1186850487196E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   9.0738489236163E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9192942792240E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9192942792242E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.4490586374895E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807049542E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336527106E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665710523E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550425311E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2627731018037E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5011728442762E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2627731018030E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5011728442032E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.09734945337921E-02  1.25802292290140E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.01715226727884E-01
+ cg2d: Sum(rhs),rhsMax =   7.09734945338001E-02  1.25802292290124E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.01715226729949E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.03907772634205E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.03907776018266E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2860,29 +2862,29 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8794535779039E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4072287016797E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134807E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2465417890214E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8831148383207E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134814E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2465417890215E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8831148383208E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5947008362394E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1786119181266E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5175182957586E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1786119181262E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5175182957585E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1058054855736E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2238828084839E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2238828084844E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2206254919485E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1558891340569E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1263845737976E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0317090748433E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0374047055930E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1015984626124E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9352108175456E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1305114802915E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3821320807014E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8340595242772E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1015984626125E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9352108175458E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1305114802918E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3821320807015E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8340595242778E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9693801471938E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9094741500506E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202839555410E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164656008136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0749257258288E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0749257258287E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7421370403561E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748371975122E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010178649E+01
@@ -2913,63 +2915,63 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4230715337838E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5754250486728E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3652289931378E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7336181835392E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4230715338717E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5754250484847E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3652289932255E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7336181835394E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2457072051432E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2187502829437E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1674217586193E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2187502829441E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1674217586198E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5223144668864E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.2977893773821E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.0339489386570E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3150520670572E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3150520670574E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.6470059174604E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807118275E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367332823E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658705840E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518730363E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3340926688951E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6114652967271E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3340926688974E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6114652969032E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   8.75632178576917E-02  1.13976232941186E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.47106204339321E-01
+ cg2d: Sum(rhs),rhsMax =   8.75632178577046E-02  1.13976232941194E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.47106204337942E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.73903255878823E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.73903254763222E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7913928325838E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7913928325839E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3831732002078E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787088E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787087E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2620642348123E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8153601991956E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7072697560531E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5482618030531E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1501243178307E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7072697560530E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5482618030530E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1501243178306E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2214578559985E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4424213091708E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2340161228929E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1439171676769E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013120257133E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4424213091713E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2340161228925E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1439171676768E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013120257132E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0191454584766E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0138569713469E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9860005175566E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9224362203584E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4909172629448E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2591060738349E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5738799112857E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9860005175565E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9224362203585E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4909172629450E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2591060738351E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5738799112864E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9692275456364E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9126646128593E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203439485971E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164323552420E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0215432204057E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0215432204056E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7421214360396E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9747839031067E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010368756E+01
@@ -3002,23 +3004,23 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8718566161612E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3055808467527E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3519576392669E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9491225357586E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2224475945394E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9073291790506E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8151510956847E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3519576393126E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9491225357588E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2224475945393E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9073291790504E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8151510956845E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5431888100801E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.4576318646582E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1448969998272E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6423883779826E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6423883779831E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.8355065101862E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807182702E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389885733E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649899831E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163500444933E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1232145588269E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7854695757910E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1232145588277E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7854695759269E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3038,168 +3040,168 @@ listId=   2 ; file name: oceStDiag
  Computing Diagnostic #     64  RHOAnoma     Counter:      10   Parms: SMR     MR      
  Computing Diagnostic #     78  DRHODR       Counter:      10   Parms: SM      LR      
  Computing Diagnostic #     79  CONVADJ      Counter:      10   Parms: SMR     LR      
- Computing Diagnostic #    199  GM_Kwx       Counter:      10   Parms: UM      LR      
-           Vector  Mate for  GM_Kwx       Diagnostic #    200  GM_Kwy   exists 
- Computing Diagnostic #    200  GM_Kwy       Counter:      10   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    199  GM_Kwx   exists 
- Computing Diagnostic #    201  GM_Kwz       Counter:      10   Parms: WM P    LR      
+ Computing Diagnostic #    204  GM_Kwx       Counter:      10   Parms: UM      LR      
+           Vector  Mate for  GM_Kwx       Diagnostic #    205  GM_Kwy   exists 
+ Computing Diagnostic #    205  GM_Kwy       Counter:      10   Parms: VM      LR      
+           Vector  Mate for  GM_Kwy       Diagnostic #    204  GM_Kwx   exists 
+ Computing Diagnostic #    206  GM_Kwz       Counter:      10   Parms: WM P    LR      
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   26.521967804990709
-(PID.TID 0000.0001)         System time:  0.18497199285775423
-(PID.TID 0000.0001)     Wall clock time:   26.842462062835693
+(PID.TID 0000.0001)           User time:   14.945272466167808
+(PID.TID 0000.0001)         System time:  0.28411799669265747
+(PID.TID 0000.0001)     Wall clock time:   15.242517948150635
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.24096400197595358
-(PID.TID 0000.0001)         System time:  3.99939985945820808E-002
-(PID.TID 0000.0001)     Wall clock time:  0.30036211013793945
+(PID.TID 0000.0001)           User time:  0.15977300237864256
+(PID.TID 0000.0001)         System time:   8.1949003040790558E-002
+(PID.TID 0000.0001)     Wall clock time:  0.24954080581665039
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   26.281003803014755
-(PID.TID 0000.0001)         System time:  0.14497799426317215
-(PID.TID 0000.0001)     Wall clock time:   26.542063951492310
+(PID.TID 0000.0001)           User time:   14.785430833697319
+(PID.TID 0000.0001)         System time:  0.20216500014066696
+(PID.TID 0000.0001)     Wall clock time:   14.992926120758057
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2208139598369598
-(PID.TID 0000.0001)         System time:  5.09920045733451843E-002
-(PID.TID 0000.0001)     Wall clock time:   1.2766919136047363
+(PID.TID 0000.0001)           User time:  0.86239005625247955
+(PID.TID 0000.0001)         System time:   9.9186003208160400E-002
+(PID.TID 0000.0001)     Wall clock time:  0.96608614921569824
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   25.060189843177795
-(PID.TID 0000.0001)         System time:  9.39859896898269653E-002
-(PID.TID 0000.0001)     Wall clock time:   25.265342950820923
+(PID.TID 0000.0001)           User time:   13.923017144203186
+(PID.TID 0000.0001)         System time:  0.10297399759292603
+(PID.TID 0000.0001)     Wall clock time:   14.026813030242920
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   25.059190392494202
-(PID.TID 0000.0001)         System time:  9.39859896898269653E-002
-(PID.TID 0000.0001)     Wall clock time:   25.265243291854858
+(PID.TID 0000.0001)           User time:   13.922942638397217
+(PID.TID 0000.0001)         System time:  0.10297101736068726
+(PID.TID 0000.0001)     Wall clock time:   14.026734352111816
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   25.059190392494202
-(PID.TID 0000.0001)         System time:  9.39859896898269653E-002
-(PID.TID 0000.0001)     Wall clock time:   25.265061855316162
+(PID.TID 0000.0001)           User time:   13.922802448272705
+(PID.TID 0000.0001)         System time:  0.10296902060508728
+(PID.TID 0000.0001)     Wall clock time:   14.026593685150146
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.47492563724517822
+(PID.TID 0000.0001)           User time:  0.29842746257781982
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.47662401199340820
+(PID.TID 0000.0001)     Wall clock time:  0.29851174354553223
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.46392738819122314
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.46428585052490234
+(PID.TID 0000.0001)           User time:  0.27395308017730713
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
+(PID.TID 0000.0001)     Wall clock time:  0.27398467063903809
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.79974937438964844E-002
-(PID.TID 0000.0001)         System time:  9.99994575977325439E-004
-(PID.TID 0000.0001)     Wall clock time:  3.00486087799072266E-002
+(PID.TID 0000.0001)           User time:   1.9920468330383301E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.9921064376831055E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  2.79974937438964844E-002
-(PID.TID 0000.0001)         System time:  9.99994575977325439E-004
-(PID.TID 0000.0001)     Wall clock time:  2.98616886138916016E-002
+(PID.TID 0000.0001)           User time:   1.9764065742492676E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.9775629043579102E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   8.0823898315429688E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  9.44137573242187500E-005
+(PID.TID 0000.0001)     Wall clock time:   8.0585479736328125E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6866787672042847
-(PID.TID 0000.0001)         System time:  2.29969993233680725E-002
-(PID.TID 0000.0001)     Wall clock time:   8.7803692817687988
+(PID.TID 0000.0001)           User time:   4.5693395137786865
+(PID.TID 0000.0001)         System time:   1.1421009898185730E-002
+(PID.TID 0000.0001)     Wall clock time:   4.5810973644256592
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GMREDI_K3D      [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   6.3660529851913452
-(PID.TID 0000.0001)         System time:  1.79969966411590576E-002
-(PID.TID 0000.0001)     Wall clock time:   6.4560184478759766
+(PID.TID 0000.0001)           User time:   3.2350434064865112
+(PID.TID 0000.0001)         System time:   1.1421009898185730E-002
+(PID.TID 0000.0001)     Wall clock time:   3.2468154430389404
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.0943760871887207
-(PID.TID 0000.0001)         System time:  1.99900567531585693E-003
-(PID.TID 0000.0001)     Wall clock time:   4.1055319309234619
+(PID.TID 0000.0001)           User time:   2.3812036514282227
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.3813111782073975
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5880026817321777
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.6057643890380859
+(PID.TID 0000.0001)           User time:   3.6564526557922363
+(PID.TID 0000.0001)         System time:   3.8300007581710815E-003
+(PID.TID 0000.0001)     Wall clock time:   3.6604356765747070
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  7.99865722656250000E-002
+(PID.TID 0000.0001)           User time:   4.6439170837402344E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  8.00583362579345703E-002
+(PID.TID 0000.0001)     Wall clock time:   4.6448230743408203E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4766263961791992
+(PID.TID 0000.0001)           User time:   1.4051601886749268
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.4804716110229492
+(PID.TID 0000.0001)     Wall clock time:   1.4052274227142334
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11198091506958008
+(PID.TID 0000.0001)           User time:   8.6803436279296875E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.11645722389221191
+(PID.TID 0000.0001)     Wall clock time:   8.6813688278198242E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.22796821594238281
+(PID.TID 0000.0001)           User time:  0.12460064888000488
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.22640395164489746
+(PID.TID 0000.0001)     Wall clock time:  0.12462353706359863
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  4.99920845031738281E-002
+(PID.TID 0000.0001)           User time:   3.0597209930419922E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.13498783111572266E-002
+(PID.TID 0000.0001)     Wall clock time:   3.0609369277954102E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   7.4148178100585938E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.00135803222656250E-004
+(PID.TID 0000.0001)     Wall clock time:   7.3194503784179688E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.58891153335571289
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.58931469917297363
+(PID.TID 0000.0001)           User time:  0.32238864898681641
+(PID.TID 0000.0001)         System time:   3.7930011749267578E-003
+(PID.TID 0000.0001)     Wall clock time:  0.32622337341308594
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.90986108779907227
-(PID.TID 0000.0001)         System time:  1.00000202655792236E-003
-(PID.TID 0000.0001)     Wall clock time:  0.91516542434692383
+(PID.TID 0000.0001)           User time:  0.56157016754150391
+(PID.TID 0000.0001)         System time:   4.5999884605407715E-005
+(PID.TID 0000.0001)     Wall clock time:  0.56167078018188477
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11098289489746094
-(PID.TID 0000.0001)         System time:  3.89939993619918823E-002
-(PID.TID 0000.0001)     Wall clock time:  0.14999842643737793
+(PID.TID 0000.0001)           User time:   6.4804077148437500E-002
+(PID.TID 0000.0001)         System time:   3.5812988877296448E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10072159767150879
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16097450256347656
-(PID.TID 0000.0001)         System time:  2.79959887266159058E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18997216224670410
+(PID.TID 0000.0001)           User time:   7.8414201736450195E-002
+(PID.TID 0000.0001)         System time:   4.8057019710540771E-002
+(PID.TID 0000.0001)     Wall clock time:  0.12652134895324707
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================

--- a/global_ocean.gm_res/code/CPP_OPTIONS.h
+++ b/global_ocean.gm_res/code/CPP_OPTIONS.h
@@ -98,7 +98,7 @@ C o Include/exclude nonHydrostatic code
 #undef ALLOW_NONHYDROSTATIC
 
 C o Include/exclude GM-like eddy stress in momentum code
-#undef ALLOW_EDDYPSI
+#define ALLOW_EDDYPSI
 
 C-- Algorithm options:
 

--- a/global_ocean.gm_res/results/output.txt
+++ b/global_ocean.gm_res/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65p
-(PID.TID 0000.0001) // Build user:        dfer
-(PID.TID 0000.0001) // Build host:        baudelaire
-(PID.TID 0000.0001) // Build date:        Fri Oct 30 09:08:52 EDT 2015
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67m
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Thu Oct 17 18:01:16 EDT 2019
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -53,6 +53,8 @@
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
 (PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
@@ -491,6 +493,17 @@
 (PID.TID 0000.0001) %MON AngleSN_min                  =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON AngleSN_mean                 =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON AngleSN_sd                   =   0.0000000000000E+00
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) FIND_HYD_PRESS_1D: Start to iterate (MaxIter=  150 ) until P(rho(P))
+(PID.TID 0000.0001) FIND_HYD_PRESS_1D:  converges ; critera (x  5) on Rho diff= 1.035000E-11
+(PID.TID 0000.0001)  iter    1, RMS-diff=  3.067292373321E-02, Max-diff= -4.865992464306E-02
+(PID.TID 0000.0001)  iter    2, RMS-diff=  3.008677774568E-04, Max-diff= -5.940271378222E-04
+(PID.TID 0000.0001)  iter    3, RMS-diff=  2.137566369311E-06, Max-diff= -5.763074113929E-06
+(PID.TID 0000.0001)  iter    4, RMS-diff=  1.105374630434E-08, Max-diff= -3.385775926290E-08
+(PID.TID 0000.0001)  iter    5, RMS-diff=  4.540984940442E-11, Max-diff= -1.493845047662E-10
+(PID.TID 0000.0001)  iter    6, RMS-diff=  2.033691978340E-13, Max-diff= -6.821210263297E-13
+(PID.TID 0000.0001)  iter    7, RMS-diff=  0.000000000000E+00, Max-diff=  0.000000000000E+00
+(PID.TID 0000.0001) FIND_HYD_PRESS_1D: converged after    7 iters (nUnderCrit=  2 )
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: bathymetry.bin
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Field Model R_low (ini_masks_etc)
@@ -678,7 +691,7 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   251
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   257
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
@@ -692,16 +705,16 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    38 WVELSQ
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    64 RHOAnoma
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    77 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 CONVADJ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   202 GM_Kwx
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   203 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   204 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   208 GM_Kwx
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   209 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   210 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all diagnostics:     185 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   202  GM_Kwx   , Parms: UM      LR , mate:   203
-(PID.TID 0000.0001)   set mate pointer for diag #   203  GM_Kwy   , Parms: VM      LR , mate:   202
+(PID.TID 0000.0001)   set mate pointer for diag #   208  GM_Kwx   , Parms: UM      LR , mate:   209
+(PID.TID 0000.0001)   set mate pointer for diag #   209  GM_Kwy   , Parms: VM      LR , mate:   208
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
@@ -722,8 +735,8 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    38 WVELSQ
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    64 RHOAnoma
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    77 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    78 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    78 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    79 CONVADJ
 (PID.TID 0000.0001)   space allocated for all stats-diags:     138 levels
 (PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -862,6 +875,10 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95P'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
 (PID.TID 0000.0001)     ;
@@ -885,6 +902,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gBaro =   /* Barotropic gravity ( m/s^2 ) */
 (PID.TID 0000.0001)                 9.810000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacC = /* gravity factor (vs surf.) @ cell-Center (-) */
+(PID.TID 0000.0001)    15 @  1.000000000000000E+00              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) gravFacF = /* gravity factor (vs surf.) @ W-Interface (-) */
+(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotationPeriod =   /* Rotation Period ( s ) */
 (PID.TID 0000.0001)                 8.616400000000000E+04
@@ -913,7 +936,7 @@
 (PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
@@ -1004,8 +1027,9 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implBottomFriction= /* Implicit bottom friction on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1026,39 +1050,17 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectVortScheme= /* V.I Scheme selector for Vorticity-Term */
-(PID.TID 0000.0001)               123456789
-(PID.TID 0000.0001)    = 0 : enstrophy (Shallow-Water Eq.) conserving scheme by Sadourny, JAS 75
-(PID.TID 0000.0001)    = 1 : same as 0 with modified hFac
-(PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
-(PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
-(PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) highOrderVorticity= /* V.I High order vort. advect. flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) upwindShear= /* V.I Upwind vertical Shear advection flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectKEscheme= /* V.I Kinetic Energy scheme selector */
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -1124,6 +1126,12 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1141,6 +1149,9 @@
 (PID.TID 0000.0001)    debLevD =  4 ; /* level of enhanced debug prt (add DEBUG_STATS prt) */
 (PID.TID 0000.0001)    debLevE =  5 ; /* level of extensive debug printing */
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
@@ -1203,6 +1214,9 @@
 (PID.TID 0000.0001) abEps =   /* Adams-Bashforth-2 stabilizing weight */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) applyExchUV_early = /* Apply EXCH to U,V earlier in time-step */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tauCD =   /* CD coupling time-scale ( s ) */
 (PID.TID 0000.0001)                 3.214280000000000E+05
 (PID.TID 0000.0001)     ;
@@ -1244,9 +1258,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -1299,11 +1310,20 @@
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) Ro_SeaLevel = /* r(1) ( units of r ==  m ) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rSigmaBnd = /* r/sigma transition ( units of r ==  m ) */
 (PID.TID 0000.0001)                 1.234567000000000E+05
@@ -1313,6 +1333,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) gravitySign = /* gravity orientation relative to vertical coordinate */
 (PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) seaLev_Z =  /* reference height of sea-level [m] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) top_Pres =  /* reference pressure at the top [Pa] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mass2rUnit = /* convert mass per unit area [kg/m2] to r-units [m] */
 (PID.TID 0000.0001)                 9.661835748792270E-04
@@ -1927,6 +1953,9 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_useK3D =     /* if TRUE => use K3D for diffusivity */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1993,11 +2022,11 @@ listId=    3 ; file name: oceDiag
  levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
     64 |RHOAnoma|     96 |      0 |  15 |       0 |
-    77 |DRHODR  |    111 |      0 |  15 |       0 |
-    78 |CONVADJ |    126 |      0 |  15 |       0 |
-   202 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
-   203 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
-   204 |GM_Kwz  |    171 |      0 |  15 |       0 |
+    78 |DRHODR  |    111 |      0 |  15 |       0 |
+    79 |CONVADJ |    126 |      0 |  15 |       0 |
+   208 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
+   209 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
+   210 |GM_Kwz  |    171 |      0 |  15 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     2
 ------------------------------------------------------------------------
@@ -2022,8 +2051,8 @@ listId=   2 ; file name: oceStDiag
  Regions:   0
  diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
     64 |RHOAnoma|     94 |      0 | 0.00000E+00 |
-    77 |DRHODR  |    109 |      0 | 0.00000E+00 |
-    78 |CONVADJ |    124 |      0 | 0.00000E+00 |
+    78 |DRHODR  |    109 |      0 | 0.00000E+00 |
+    79 |CONVADJ |    124 |      0 | 0.00000E+00 |
 ------------------------------------------------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
@@ -2089,6 +2118,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2588977395051E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.8248606070107E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.9948324922575E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   0.0000000000000E+00
@@ -2123,18 +2155,18 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sss.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sss.bin
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.67591829168581E-03  2.56950143267917E+00
+ cg2d: Sum(rhs),rhsMax =   3.67591829168393E-03  2.56950143267917E+00
 (PID.TID 0000.0001)      cg2d_init_res =   6.15969088495369E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     142
-(PID.TID 0000.0001)      cg2d_last_res =   9.15031861179149E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.15031803252077E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.6379351160096E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.1361300215677E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.4811745051418E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.6379351160100E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.1361300215674E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.4811745051382E-05
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.6150815675587E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5421386549167E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5129685984542E-02
@@ -2148,7 +2180,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5054224114479E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3347101154764E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.3463062352325E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.5525837366267E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.5525837366268E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6947689214721E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.5029438102793E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2636831152799E-08
@@ -2187,8 +2219,11 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.3653356424172E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5157892194461E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4595114894327E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.6106864467594E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1608781214939E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1608781214940E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1904135602154E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.5815588388253E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   8.7508795481285E-05
@@ -2202,39 +2237,39 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655729977E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162543798019E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1143966576494E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7418309150472E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7418309150460E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.20105170699414E-03  2.63981021203469E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.62477520481282E-01
+ cg2d: Sum(rhs),rhsMax =   7.20105170698304E-03  2.63981021203448E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.62477520481611E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.32198246474712E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.32198240220861E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0268334580362E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152444704755E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248846E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0268334580353E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152444704753E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248848E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4260892007711E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5959472152083E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1619027110697E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2710042598576E-02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5959472152084E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1619027110699E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2710042598445E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3920346530214E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4045790768333E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6172173583266E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.3106101622389E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.1717269870147E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4045790768332E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6172173583263E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.3106101622334E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.1717269869998E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2475349551489E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2863969560559E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.5985151296454E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0803557023620E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6925214928711E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2863969560558E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.5985151296448E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0803557023619E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6925214928716E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9075118110869E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1870746798784E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1870746798785E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6910260392476E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722407113785E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9010309865361E+00
@@ -2245,7 +2280,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755451076570E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518369E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606632352842E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0178531155344E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0178531155343E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2693899536133E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8655982259115E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6687693382567E+01
@@ -2271,30 +2306,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2915731155564E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5261152700224E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4588571962377E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1343383365953E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1990675709764E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3878494822512E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9933635800786E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0253748153421E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.1326311151428E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.9022012496607E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1343383365941E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1990675709735E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3878494822509E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9933635800782E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   2.5068108723285E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0552064899322E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1579274348585E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.0552064899227E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1579274348584E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782213082E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2626447074259E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6230322620481E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2626447074182E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6230322620484E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807293106E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185659491E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642660483E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162954511392E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8463761229331E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9401861374183E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8463761229330E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9401861374064E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.18796489446811E-02  2.41525635003415E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.93472727326318E-01
+ cg2d: Sum(rhs),rhsMax =   1.18796489446844E-02  2.41525635003443E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.93472727326641E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.45955564772559E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.45955552440319E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2302,22 +2340,22 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9378701473966E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5754117247190E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231133E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2998879652829E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4539601812798E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231129E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2998879652828E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4539601812796E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8737420890063E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4601558487827E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2236489934309E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4170570985828E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8738667558196E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4601558487825E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2236489934308E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4170570985827E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8738667558191E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0967857539844E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4154642374793E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324026100015E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8933564455618E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3203673200990E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324026100014E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8933564455617E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3203673200983E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4712670365302E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2866766659303E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9441869106181E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9441869106166E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6291272117083E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2894914731653E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716232297187E+01
@@ -2355,53 +2393,56 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2178105886956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5379778517573E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5385567873854E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1347137413781E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2925335621268E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.5060079007765E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5385567873840E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2464218096661E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6307800213698E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2391886856413E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6307800213699E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2391886856415E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5943027330117E-04
 (PID.TID 0000.0001) %MON ke_max                       =   2.0605949308474E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1580722560781E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1580722560780E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781986628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6676666545086E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9188158311676E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6676666545078E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.9188158311692E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807223896E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604170387934E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640527640E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163353031084E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3809574564482E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2639819561892E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3809574564481E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2639819561803E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.73192181660685E-02  2.22263153548680E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.41965258018623E-01
+ cg2d: Sum(rhs),rhsMax =   1.73192181660697E-02  2.22263153548672E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.41965258017129E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   8.72195887367628E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.72195885764484E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7516700506904E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7516700506905E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5953833277408E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451980E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451982E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5713688213057E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3594947288492E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8522475792041E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7320227471202E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7320227471201E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4738381297775E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4971847429928E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9807683833012E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3146267325296E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.1176921415749E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6179185552362E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4971847429929E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9807683833009E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3146267325299E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.1176921415685E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6179185552363E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.4068010096486E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8591066180185E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8006078538949E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8591066180182E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8006078538948E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5278737063014E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1059621950102E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1059621950175E-10
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9950068862130E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7558791827647E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9710632503336E+01
@@ -2413,7 +2454,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754920512899E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005961994E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9604081912156E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0132697411274E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0132697411275E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2903536987305E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8562549743652E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6662669470921E+01
@@ -2439,55 +2480,58 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1440480618348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8125590149223E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5771373909785E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8260609532364E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5914224419345E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9719624945043E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5977530453140E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.5389519193384E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3433914989091E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.7766934379197E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8125590149214E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5771373909773E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8260609532365E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5914224419346E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9719624945044E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.5977530453139E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.4285700442680E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0892901270126E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2322392802166E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0892901270118E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2322392802153E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807135569E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604186087813E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649853576E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163586594108E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0503044248883E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2081278259821E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0503044248886E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2081278263157E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.39759924927683E-02  2.01930904825904E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.32014742919623E-01
+ cg2d: Sum(rhs),rhsMax =   2.39759924927668E-02  2.01930904825835E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.32014742920628E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.58521676123887E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.58521673427395E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8766307347238E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5429796423387E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911397E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5429796423388E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911406E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5646041049067E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2723046423358E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8817756647726E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7516912706733E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7516912706740E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8598751045100E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.6934219516806E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8596665674493E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4156380758948E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3746428784326E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6781609532747E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.6679489189214E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0896788141975E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0311055332457E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7152068885956E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2561188741534E-11
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2667861834643E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0626019789194E-07
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.6934219516807E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8596665674488E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4156380758950E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3746428784328E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6781609532746E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.6679489189220E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0896788141996E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0311055332455E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7152068885953E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2561188739766E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2667861834644E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0626019789193E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9706188006461E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028523435558E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200186253277E+00
@@ -2497,7 +2541,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753896021032E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007473181E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9602895770436E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0100018054632E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0100018054631E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3008355712891E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8515833485921E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6650157515098E+01
@@ -2523,30 +2567,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.2657838292465E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8129818781861E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6222938138637E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.5705626759539E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.2657838292442E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8213427600838E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8113834923807E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.7062033171123E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8113834923805E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.7062033171121E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.9623234841723E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3837054743556E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8703321124823E-05
+(PID.TID 0000.0001) %MON ke_max                       =   5.3837054743557E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8703321124828E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.3362440137527E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.3274663535756E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.3362440139926E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.3274663538211E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807069682E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604218355944E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661337472E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163668735828E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0818321635283E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0207007919353E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0818321635273E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0207007921604E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.24731638324998E-02  1.80008613261827E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.45991003985371E-01
+ cg2d: Sum(rhs),rhsMax =   3.24731638325079E-02  1.80008613261788E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.45991003985998E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   9.79500774368442E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.79500747584976E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2556,22 +2603,22 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4933148746564E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609402E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4660503096510E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1811801941738E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1811801941737E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0873295321938E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5211989800636E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5211989798538E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8115640639145E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.9492057488738E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5441106669755E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3780746870209E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0638264999453E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5696040636478E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531382386120E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0001953506498E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.9492057488732E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5441106669746E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3780746870206E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0638264999547E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5696040636167E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531382386141E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0001953506501E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2223149991387E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8154063334260E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6327060397227E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4425433336522E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2156986767516E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8154063334264E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6327060397258E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4425433336523E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2156986767515E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9702754301253E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035192610541E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200939135040E+00
@@ -2607,30 +2654,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9965230081132E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9676665912608E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0668442721358E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.2661153146501E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7708339313014E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4451756093320E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9676665912652E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0668442721539E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.5586600763377E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.5517208429636E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.8232149956272E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3148762425673E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.3878706558556E-05
+(PID.TID 0000.0001) %MON ke_max                       =   7.3148762425676E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.3878706558570E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1072519953142E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.0975474710524E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1072519953079E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.0975474710439E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807029370E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604258285896E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668353707E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163653866742E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0974547715465E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1887783567441E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0974547715499E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1887783568877E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.35517550753659E-02  1.57543364885335E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.55403301334826E-01
+ cg2d: Sum(rhs),rhsMax =   4.35517550753373E-02  1.57543364885418E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.55403301334096E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   9.75868994716815E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.75868994722174E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2638,24 +2688,24 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0917845119341E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4562388543413E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545958E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545968E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3582120686418E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0853780497341E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2742174785767E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9053560824206E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9053560823687E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.6028531419524E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2616984171988E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0248450892790E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0476432835189E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1288828659619E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9243540430829E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2616984171994E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0248450892775E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0476432835185E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1288828659618E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9243540430830E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0332767076131E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0555909997916E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3457395799973E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8990202451868E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8183609593058E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5235244148220E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2221378572610E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0555909997915E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3457395799974E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8990202451855E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8183609593037E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5235244148221E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2221378572609E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699949761774E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042457536336E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201626507336E+00
@@ -2666,7 +2716,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009435849E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601746136468E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0060127980704E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164063E+02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164062E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8422400970459E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6625133603452E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.1159198929743E+02
@@ -2691,30 +2741,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9227604812524E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0586724081527E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9684041930024E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9763233007328E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8331052900755E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0586724081232E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1932383575192E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0452549528686E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1023311277943E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0452549528689E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1023311277946E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.6738496353302E-04
 (PID.TID 0000.0001) %MON ke_max                       =   9.2883523099455E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8988960342694E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8988960342704E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0215495476855E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.4638979294274E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0215495476828E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.4638979294144E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807037561E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604299350296E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669417794E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163608746225E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7605489775311E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9843234233588E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7605489775277E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9843234230561E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.80565565447806E-02  1.35885021128328E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.77059921565186E-01
+ cg2d: Sum(rhs),rhsMax =   5.80565565447622E-02  1.35885021128368E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.77059921564391E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.31143674620410E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.31143674450455E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2722,29 +2775,29 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0696389413342E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4250003337957E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721101E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2783539194406E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9919445956778E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721100E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2783539194405E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9919445956779E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4424962478009E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1563112500360E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4570732402995E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5880936974404E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4104687424096E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4484126810458E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1563112500209E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4570732402991E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5880936974405E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4104687424120E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4484126810460E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1678246436671E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9441242276415E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0727435716817E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0860904365595E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9441242276416E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0727435716819E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0860904365607E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3935760444528E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9235235864487E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1562692250664E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5205589881690E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1081207281431E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5205589881691E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1081207281433E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697556873107E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050355926985E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202270793713E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165070798884E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1573434437644E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1573434437643E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7432118086740E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750122052199E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009863289E+01
@@ -2775,55 +2828,58 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5684064305308E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2688959860902E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2907302481128E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3801486788349E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0596105705785E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1232918666922E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2060121428374E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5684064304449E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2688959860901E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2907302481127E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3801486788347E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5651575260764E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.1211853198764E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   9.3469210630872E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   9.3469210630888E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3391079511697E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7832431286197E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3391079511809E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.7832431286262E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807082224E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336695383E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665622298E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163561336646E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2797442144693E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4933622524778E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2797442144704E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4933622524876E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.62383743774089E-02  1.17114620781285E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.84765613763360E-01
+ cg2d: Sum(rhs),rhsMax =   7.62383743773936E-02  1.17114620781290E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.84765613765906E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.50859462234673E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.50859462508934E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8854257556397E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3964404488776E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134802E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8854257556392E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3964404488755E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134810E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2446130453753E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9092919086459E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9092919086456E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5868226074399E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4052707831649E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.4969513197224E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0878556092206E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7362960912151E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5953642889255E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4052707831557E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.4969513197219E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0878556092207E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7362960912174E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5953642889254E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1856430954683E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1260220072253E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0857889409479E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0885454657306E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3545543659660E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9708566397551E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1326119155879E-08
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0857889409481E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0885454657314E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3545543659662E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9708566397557E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1326119155871E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4474856500271E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9018620201282E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9018620201280E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695585563507E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9132355269702E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202890358025E+00
@@ -2833,7 +2889,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749442744153E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010094946E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601303009336E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0039950069045E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0039950069044E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3427630615234E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8328968454997E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6600109691805E+01
@@ -2859,55 +2915,58 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9826168330455E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3035143802038E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2588619359859E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3441891565525E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5197251865900E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5696244402404E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1965400930724E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4259510374108E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9826168329933E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3035143802039E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2588619359865E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3441891565531E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5197251865899E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.3006362308662E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0674674206111E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0674674206113E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7098226348124E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.1347689031151E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7098226348329E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.1347689031199E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807149695E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367360970E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658603570E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163527785477E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3456920630915E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5991497208184E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3456920630921E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5991497208630E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   9.04844671182614E-02  1.10296562862942E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.85033306637507E-01
+ cg2d: Sum(rhs),rhsMax =   9.04844671184248E-02  1.10296562862766E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.85033306637952E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.71434902219963E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.71434903505793E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8001942960472E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3720030608779E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787088E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8001942960471E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3720030608762E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787083E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2602190562437E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8411634091153E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7028921716191E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5782853235941E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1269829507823E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2092050802129E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0292595044646E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7635129721541E-02
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8411634091154E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7028921716190E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5782853235867E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1269829507815E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2092050802130E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0292595044734E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7635129721526E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1795668451818E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013576728471E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0765090778226E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0685938097792E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2474512591901E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9622128569588E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4953168280029E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3241089984674E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6412908861110E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013576728468E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0765090778227E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0685938097797E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2474512591898E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9622128569589E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4953168280028E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3241089984675E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6412908861112E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694172359614E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9134999683955E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203497131851E+00
@@ -2943,22 +3002,25 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.9654229934931E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2917092004106E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0111694679673E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.0640457845141E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.9840964719868E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2300451571834E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3974830822712E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.9654229934513E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2917092004107E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0111694679662E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.0640457845128E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5407043635096E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.4608149803361E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1853294553275E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.4608149803360E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1853294553277E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2441590781378E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.3848072431862E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2441590781459E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.3848072432102E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209146E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389536174E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649773334E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163505237410E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1325577127930E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7730807665758E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1325577127933E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7730807667185E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2976,170 +3038,170 @@ listId=   2 ; file name: oceStDiag
  Computing Diagnostic #     27  SALT         Counter:      10   Parms: SMR     MR      
  Computing Diagnostic #     38  WVELSQ       Counter:      10   Parms: WM P    LR      
  Computing Diagnostic #     64  RHOAnoma     Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     77  DRHODR       Counter:      10   Parms: SM      LR      
- Computing Diagnostic #     78  CONVADJ      Counter:      10   Parms: SMR     LR      
- Computing Diagnostic #    202  GM_Kwx       Counter:      10   Parms: UM      LR      
-           Vector  Mate for  GM_Kwx       Diagnostic #    203  GM_Kwy   exists 
- Computing Diagnostic #    203  GM_Kwy       Counter:      10   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    202  GM_Kwx   exists 
- Computing Diagnostic #    204  GM_Kwz       Counter:      10   Parms: WM P    LR      
+ Computing Diagnostic #     78  DRHODR       Counter:      10   Parms: SM      LR      
+ Computing Diagnostic #     79  CONVADJ      Counter:      10   Parms: SMR     LR      
+ Computing Diagnostic #    208  GM_Kwx       Counter:      10   Parms: UM      LR      
+           Vector  Mate for  GM_Kwx       Diagnostic #    209  GM_Kwy   exists 
+ Computing Diagnostic #    209  GM_Kwy       Counter:      10   Parms: VM      LR      
+           Vector  Mate for  GM_Kwy       Diagnostic #    208  GM_Kwx   exists 
+ Computing Diagnostic #    210  GM_Kwz       Counter:      10   Parms: WM P    LR      
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   12.710000000000001
-(PID.TID 0000.0001)         System time:  0.44000000000000000
-(PID.TID 0000.0001)     Wall clock time:   27.924978971481323
+(PID.TID 0000.0001)           User time:   16.625472436193377
+(PID.TID 0000.0001)         System time:  0.23200699500739574
+(PID.TID 0000.0001)     Wall clock time:   16.876699924468994
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20999999999999999
-(PID.TID 0000.0001)         System time:  0.14000000000000001
-(PID.TID 0000.0001)     Wall clock time:   4.8055429458618164
+(PID.TID 0000.0001)           User time:  0.19874800508841872
+(PID.TID 0000.0001)         System time:   4.3822000501677394E-002
+(PID.TID 0000.0001)     Wall clock time:  0.24351000785827637
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   12.500000000000000
-(PID.TID 0000.0001)         System time:  0.29999999999999999
-(PID.TID 0000.0001)     Wall clock time:   23.119408845901489
+(PID.TID 0000.0001)           User time:   16.426673710346222
+(PID.TID 0000.0001)         System time:  0.18816499412059784
+(PID.TID 0000.0001)     Wall clock time:   16.633141040802002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.60000000000000009
-(PID.TID 0000.0001)         System time:  6.99999999999999789E-002
-(PID.TID 0000.0001)     Wall clock time:   2.6091990470886230
+(PID.TID 0000.0001)           User time:  0.79467599093914032
+(PID.TID 0000.0001)         System time:   5.1677998155355453E-002
+(PID.TID 0000.0001)     Wall clock time:  0.85483002662658691
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   11.900000000000000
-(PID.TID 0000.0001)         System time:  0.23000000000000001
-(PID.TID 0000.0001)     Wall clock time:   20.510184049606323
+(PID.TID 0000.0001)           User time:   15.631974101066589
+(PID.TID 0000.0001)         System time:  0.13648399710655212
+(PID.TID 0000.0001)     Wall clock time:   15.778285980224609
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   11.899999999999999
-(PID.TID 0000.0001)         System time:  0.23000000000000001
-(PID.TID 0000.0001)     Wall clock time:   20.510086536407471
+(PID.TID 0000.0001)           User time:   15.631896495819092
+(PID.TID 0000.0001)         System time:  0.13648399710655212
+(PID.TID 0000.0001)     Wall clock time:   15.778206825256348
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   11.899999999999999
-(PID.TID 0000.0001)         System time:  0.23000000000000001
-(PID.TID 0000.0001)     Wall clock time:   20.509915590286255
+(PID.TID 0000.0001)           User time:   15.631747484207153
+(PID.TID 0000.0001)         System time:  0.13648299872875214
+(PID.TID 0000.0001)     Wall clock time:   15.778054952621460
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.19999999999999929
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.19580698013305664
+(PID.TID 0000.0001)           User time:  0.32427668571472168
+(PID.TID 0000.0001)         System time:   1.8700212240219116E-004
+(PID.TID 0000.0001)     Wall clock time:  0.32451605796813965
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18999999999999773
-(PID.TID 0000.0001)         System time:  1.00000000000000089E-002
-(PID.TID 0000.0001)     Wall clock time:  0.20386791229248047
+(PID.TID 0000.0001)           User time:  0.30497729778289795
+(PID.TID 0000.0001)         System time:   4.0079876780509949E-003
+(PID.TID 0000.0001)     Wall clock time:  0.30919194221496582
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999978684E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.98805332183837891E-002
+(PID.TID 0000.0001)           User time:   1.8623232841491699E-002
+(PID.TID 0000.0001)         System time:   3.7997961044311523E-005
+(PID.TID 0000.0001)     Wall clock time:   1.8657207489013672E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  9.99999999999978684E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.97067260742187500E-002
+(PID.TID 0000.0001)           User time:   1.8443107604980469E-002
+(PID.TID 0000.0001)         System time:   3.6001205444335938E-005
+(PID.TID 0000.0001)     Wall clock time:   1.8490791320800781E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   8.2612037658691406E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  9.22679901123046875E-005
+(PID.TID 0000.0001)     Wall clock time:   8.1777572631835938E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0300000000000029
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.0573761463165283
+(PID.TID 0000.0001)           User time:   5.3165640830993652
+(PID.TID 0000.0001)         System time:   5.1988996565341949E-002
+(PID.TID 0000.0001)     Wall clock time:   5.3775517940521240
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GMREDI_K3D      [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.7300000000000040
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8037054538726807
+(PID.TID 0000.0001)           User time:   3.6601834297180176
+(PID.TID 0000.0001)         System time:   5.1511973142623901E-002
+(PID.TID 0000.0001)     Wall clock time:   3.7205548286437988
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4999999999999982
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.5008809566497803
+(PID.TID 0000.0001)           User time:   2.5511908531188965
+(PID.TID 0000.0001)         System time:   3.9994716644287109E-005
+(PID.TID 0000.0001)     Wall clock time:   2.5514178276062012
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7500000000000018
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.7795419692993164
+(PID.TID 0000.0001)           User time:   3.9744770526885986
+(PID.TID 0000.0001)         System time:   5.9008598327636719E-005
+(PID.TID 0000.0001)     Wall clock time:   3.9747858047485352
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  4.00000000000009237E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.22039127349853516E-002
+(PID.TID 0000.0001)           User time:   5.3229570388793945E-002
+(PID.TID 0000.0001)         System time:   8.3997845649719238E-005
+(PID.TID 0000.0001)     Wall clock time:   5.3328990936279297E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0299999999999994
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0120780467987061
+(PID.TID 0000.0001)           User time:   1.6553158760070801
+(PID.TID 0000.0001)         System time:   1.6003847122192383E-005
+(PID.TID 0000.0001)     Wall clock time:   1.6554391384124756
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  4.00000000000009237E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  5.24668693542480469E-002
+(PID.TID 0000.0001)           User time:   9.4555139541625977E-002
+(PID.TID 0000.0001)         System time:   6.1020255088806152E-005
+(PID.TID 0000.0001)     Wall clock time:   9.4657421112060547E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  8.99999999999998579E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  8.79056453704833984E-002
+(PID.TID 0000.0001)           User time:  0.13781404495239258
+(PID.TID 0000.0001)         System time:   3.0994415283203125E-005
+(PID.TID 0000.0001)     Wall clock time:  0.13791108131408691
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.99999999999978684E-003
+(PID.TID 0000.0001)           User time:   3.4235239028930664E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  2.67031192779541016E-002
+(PID.TID 0000.0001)     Wall clock time:   3.4244298934936523E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   8.2254409790039062E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  9.20295715332031250E-005
+(PID.TID 0000.0001)     Wall clock time:   8.0108642578125000E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.38999999999999879
+(PID.TID 0000.0001)           User time:  0.35938382148742676
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.38412022590637207
+(PID.TID 0000.0001)     Wall clock time:  0.35940766334533691
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.39000000000000234
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.35716843605041504
+(PID.TID 0000.0001)           User time:  0.60471987724304199
+(PID.TID 0000.0001)         System time:   3.9930045604705811E-003
+(PID.TID 0000.0001)     Wall clock time:  0.60877394676208496
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  8.00000000000000711E-002
-(PID.TID 0000.0001)         System time:  0.11000000000000001
-(PID.TID 0000.0001)     Wall clock time:   4.1601877212524414
+(PID.TID 0000.0001)           User time:   7.7423572540283203E-002
+(PID.TID 0000.0001)         System time:   4.3948993086814880E-002
+(PID.TID 0000.0001)     Wall clock time:  0.12144327163696289
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14000000000000057
-(PID.TID 0000.0001)         System time:  0.10999999999999999
-(PID.TID 0000.0001)     Wall clock time:   4.6371362209320068
+(PID.TID 0000.0001)           User time:  0.12194728851318359
+(PID.TID 0000.0001)         System time:   3.2005995512008667E-002
+(PID.TID 0000.0001)     Wall clock time:  0.15400767326354980
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -3542,9 +3604,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          17110
+(PID.TID 0000.0001) //            No. barriers =          17434
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          17110
+(PID.TID 0000.0001) //     Total barrier spins =          17434
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm_contrib/verification_other"
     =================================================================
 
+  - new output (generated on new ref. machine "villon") for the 2 GM-K3D
+    experiments: global_ocean.gm_k3d & gm_res
+
 checkpoint67m (2019/10/16) synchronised with main MITgcm code.
   - update output of exp. global_oce_llc90 (all 4 FWD and 2 ADM)
     after merging PR #219 on Aug 15.


### PR DESCRIPTION
Update output of the two experiments that use GM K3D after switching to new reference machine "villon.mit.edu". Also fix an old issue in gm_res experiment where ALLOW_EDDYPSI was turned
accidentally to undef in Nov 2017.