### PR TITLE
Fix global_oce_llc90 AD experiment by comment out "viscFacInAd=2."

### DIFF
--- a/global_oce_llc90/input/data.autodiff
+++ b/global_oce_llc90/input/data.autodiff
@@ -10,5 +10,6 @@
 # useGMRediInAdMode = .FALSE.,
  useGGL90inAdMode = .FALSE.,
  useSALT_PLUMEinAdMode = .FALSE.,
- viscFacInAd = 2.,
+#- viscFacInAd is not used since 3D horiz. viscosity files are unset
+# viscFacInAd = 2.,
  &

--- a/update_history
+++ b/update_history
@@ -1,6 +1,10 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - global_oce_llc90 Adjoint experiment: comment out "viscFacInAd=2." in
+    data.autodiff since it's not currently used (no 3D horiz. viscosity loaded
+    from file) but after PR #384 got merged-in, it prevents to run this AD
+    experiment since new option AUTODIFF_ALLOW_VISCFACADJ is #undef here.
   - update output of experiment "shelfice_remeshing" following changes in
     solve_pentadiagonal.F (-> affects results @ machine trunc. level), PR #410.
 


### PR DESCRIPTION
1) viscFacInAd is not used since 3D horiz. viscosity files are unset
2) if one wants to use it, would need to define AUTODIFF_ALLOW_VISCFACADJ in AUTODIFF_OPTIONS.h
   otherwise, with current code, will stop in S/R AUTODIFF_READPARMS.