### PR TITLE
Update 2 ref. output after merging-in PR #433

### DIFF
--- a/global_ocean.gm_k3d/code/DIAGNOSTICS_SIZE.h
+++ b/global_ocean.gm_k3d/code/DIAGNOSTICS_SIZE.h
@@ -22,7 +22,6 @@ C  and "diagSt_size" (statistics-diags) since values here are deliberately small
       PARAMETER( nRegions = 0 , sizRegMsk = 1 , nStats = 4 )
       PARAMETER( diagSt_size = 20*Nr )
 
-
 CEH3 ;;; Local Variables: ***
 CEH3 ;;; mode:fortran ***
 CEH3 ;;; End: ***

--- a/global_ocean.gm_k3d/input/data.exch2.mpi
+++ b/global_ocean.gm_k3d/input/data.exch2.mpi
@@ -14,7 +14,7 @@
 #  W2_mapIO      :: global map IO selector (-1 = old type ; 0 = 1 long line in X
 #                :: 1 = compact, mostly in Y dir)
 #  W2_printMsg   :: option for information messages printing
-#                :: <0 : write to log file ; =0 : minimum print ; 
+#                :: <0 : write to log file ; =0 : minimum print ;
 #                :: =1 : no duplicated print ; =2 : all processes do print
 #--------------------
  &W2_EXCH2_PARM01

--- a/global_ocean.gm_k3d/input/data.gmredi
+++ b/global_ocean.gm_k3d/input/data.gmredi
@@ -1,6 +1,5 @@
 # GM+Redi package parameters:
 
-#-from MOM :
 # GM_background_K: 	G & Mc.W  diffusion coefficient
 # GM_maxSlope    :	max slope of isopycnals
 # GM_Scrit       :	transition for scaling diffusion coefficient

--- a/global_ocean.gm_k3d/results/output.txt
+++ b/global_ocean.gm_k3d/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67v
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Oct 17 17:58:43 EDT 2019
+(PID.TID 0000.0001) // Build date:        Tue Feb 23 12:12:20 EST 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -50,7 +50,7 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
 (PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
@@ -691,7 +691,7 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   251
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   252
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
@@ -707,14 +707,14 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    64 RHOAnoma
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 CONVADJ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   204 GM_Kwx
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   205 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   206 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   205 GM_Kwx
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   206 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   207 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all diagnostics:     185 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   204  GM_Kwx   , Parms: UM      LR , mate:   205
-(PID.TID 0000.0001)   set mate pointer for diag #   205  GM_Kwy   , Parms: VM      LR , mate:   204
+(PID.TID 0000.0001)   set mate pointer for diag #   205  GM_Kwx   , Parms: UM      LR , mate:   206
+(PID.TID 0000.0001)   set mate pointer for diag #   206  GM_Kwy   , Parms: VM      LR , mate:   205
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
@@ -875,9 +875,15 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95P'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -2024,9 +2030,9 @@ listId=    3 ; file name: oceDiag
     64 |RHOAnoma|     96 |      0 |  15 |       0 |
     78 |DRHODR  |    111 |      0 |  15 |       0 |
     79 |CONVADJ |    126 |      0 |  15 |       0 |
-   204 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
-   205 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
-   206 |GM_Kwz  |    171 |      0 |  15 |       0 |
+   205 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
+   206 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
+   207 |GM_Kwz  |    171 |      0 |  15 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     2
 ------------------------------------------------------------------------
@@ -2242,18 +2248,18 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.23143674320303E-03  2.62871826285150E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.71016562818689E-01
+ cg2d: Sum(rhs),rhsMax =   7.23143674319682E-03  2.62871826285151E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.71016562818688E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.44179052767172E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.44179059320920E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0241303990159E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158211969345E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248847E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0241303990167E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158211969346E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248844E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4259975233385E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5884830845481E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1565903465634E-02
@@ -2310,9 +2316,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7465638782618E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1103846822596E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0787791575930E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.3321831821898E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3231493168663E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9170994977907E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.3321831821899E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3231493168664E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9170994977908E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   2.5067070264391E-04
 (PID.TID 0000.0001) %MON ke_max                       =   8.8790095187195E-04
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1181430938528E-05
@@ -2323,16 +2329,16 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604184711149E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642652839E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162947612555E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8467307941364E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9395699253759E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8467307941363E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9395699253734E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.20257556889282E-02  2.38591222805680E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.02553793420934E-01
+ cg2d: Sum(rhs),rhsMax =   1.20257556889298E-02  2.38591222805679E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.02553793424193E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.26712035552508E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.26712078780864E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2340,7 +2346,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9396931613914E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5797230816683E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231135E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231134E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2997656271079E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4327834373657E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9945393137865E-02
@@ -2348,14 +2354,14 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2245757620177E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4689467074603E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6570533193842E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0472824416430E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0472824416429E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.1986475189151E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1325711143129E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.7694317921413E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1330630354886E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4682484425225E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2763101027838E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9215283188984E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9215283188978E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6116218731806E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2646003329411E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9715429146768E+01
@@ -2411,38 +2417,38 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640495892E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163345343232E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3820417159293E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2632356801531E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2632356801453E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.75443264042487E-02  2.19411333207641E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96158677581082E-01
+ cg2d: Sum(rhs),rhsMax =   1.75443264042620E-02  2.19411333207644E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96158677583093E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.31456618540805E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.31456612958773E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7380645073925E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6005564984329E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451978E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7380645073917E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6005564984330E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451986E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5717446179891E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3355402720433E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9918905345807E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8241171080327E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4724078482376E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4724078482375E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6233099652712E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7084318787732E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2357847871439E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8050949061559E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8050949061560E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6184581358311E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2036017304269E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6231442972437E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.7897339924016E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5122907414752E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2402359869565E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5122907414753E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2402359869247E-10
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9652495667370E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7142474632774E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9709600745555E+01
@@ -2481,32 +2487,32 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2842568613977E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2331806837759E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1446306747648E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2331806837760E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1446306747659E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2621994902384E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5164047615935E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.6023988330894E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.3389469389556E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9724983413976E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9724983413977E-04
 (PID.TID 0000.0001) %MON ke_max                       =   3.5865031634416E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.3475388787460E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6078924665632E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2148938274260E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6078924665633E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2148938274259E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807116958E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185083200E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649846246E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163575796847E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0524735734647E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2041897461590E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0524735734648E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2041897463481E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.43569073237434E-02  1.98772930972416E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.59224069423956E-01
+ cg2d: Sum(rhs),rhsMax =   2.43569073237546E-02  1.98772930972416E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.59224069422513E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.95467297405077E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.95467300373602E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2514,24 +2520,24 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8749683987969E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5495198767890E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911418E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911403E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5655596374140E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2452045736314E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0303779879270E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7791736281359E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8557839979727E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0303779879271E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7791736281360E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8557839979726E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8619449082207E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5348749382685E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3352166839267E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.1860669476202E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3352166839268E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.1860669476201E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6777392739004E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.3918536708254E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8039299171560E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0129629821496E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6637864378615E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.9805427451135E-12
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.9805427457183E-12
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2270249464528E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0095533248124E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0095533248123E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9704985059217E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028472867347E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200164832083E+00
@@ -2567,33 +2573,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1963113185771E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.1539133940452E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1963113185773E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.1539133940451E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8039972697842E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8820497539900E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7847054811213E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7847054811212E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.3442398262591E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1784761546841E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.9636843905522E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3696420420017E-03
+(PID.TID 0000.0001) %MON ke_max                       =   5.3696420420016E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   4.7473174541937E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5043565481898E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5043565481899E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.1269231656152E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807042577E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217470123E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661335593E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163652312754E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1132021589800E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0244095887814E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1132021589801E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0244095888932E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.30747488200575E-02  1.76734499829915E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.10879448289940E-01
+ cg2d: Sum(rhs),rhsMax =   3.30747488200570E-02  1.76734499829913E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.10879448287311E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.86766775200671E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.86766775465879E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2601,23 +2607,23 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0320923349703E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5010404568214E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609403E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4675058438298E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609404E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4675058438299E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1547211630819E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1016213681757E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4986070562912E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8039080507189E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8039080507187E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1636608857097E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1622991047566E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2142255558564E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0289750180636E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.0586423409644E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.0586423409731E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.2932401258513E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6570647403341E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1277751506900E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7225965441455E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6292689639638E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3934341338834E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6292689639645E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3934341338833E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1527489373715E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701395031882E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035501777690E+00
@@ -2655,32 +2661,32 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5694062143202E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9584369949914E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6578935095062E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5377168761701E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9584369949913E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6578935095081E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5377168761703E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9991334323453E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8967149911110E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8028440014145E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8967149911111E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8028440014146E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.8252514049921E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.2967708476682E-03
+(PID.TID 0000.0001) %MON ke_max                       =   7.2967708476681E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   6.2192140924784E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3968329660798E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0959823672679E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3968329660796E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0959823672680E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806999737E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257540058E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668390582E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163639437998E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0688335351081E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1895113245628E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0688335351071E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1895113244920E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.44560032754202E-02  1.54338886443046E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.23897036633481E+00
+ cg2d: Sum(rhs),rhsMax =   4.44560032753996E-02  1.54338886443047E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.23897036633637E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.21985479023295E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.21985479323610E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2688,24 +2694,24 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0915183556910E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4651145203689E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545970E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545968E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3600171476095E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0619262127650E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0619262127649E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2871661932850E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.9615259514295E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5902284574487E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5902284574485E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.4916064372816E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.6289007348716E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8194516428529E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1014260540729E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9249500165579E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9249500165580E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9035404608701E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0185815323951E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1433695426613E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7970751042104E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8001630694666E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8001630694655E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4673688579648E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1606572603471E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1606572603469E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9698435752515E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042873467983E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201590182655E+00
@@ -2744,30 +2750,30 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5372778511734E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0573616661583E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5177974671015E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0055214224741E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0055214224746E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1398941755621E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2337880616024E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2337880616025E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1842772131238E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.6763253494411E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.2667877127657E-03
+(PID.TID 0000.0001) %MON ke_max                       =   9.2667877127656E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   7.6839048320028E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.5109617161929E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2590573683777E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2590573683775E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807004774E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298834835E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669476551E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163594703642E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7374769787363E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9857631554533E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7374769787380E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9857631556324E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.93586546730636E-02  1.32904232014373E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.15969046839840E+00
+ cg2d: Sum(rhs),rhsMax =   5.93586546730505E-02  1.32904232014372E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.15969046839452E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.51471814989828E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.51471795899749E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2775,24 +2781,24 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0692512581933E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4349678167736E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721105E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721104E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2802894452365E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9649167519610E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4532763696254E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1670607490608E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.2844497650590E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8036872236543E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9638096715905E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9649167519611E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4532763696255E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1670607490609E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.2844497650562E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8036872236544E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9638096715906E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1518161868300E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1346893599129E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9448557987144E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9448557987145E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0235463080457E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0409209210175E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1560997765236E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8934548485622E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1327784540815E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1327784540819E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4579054319834E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0408994395813E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0408994395812E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695900836394E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050606949647E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202227262679E+00
@@ -2828,63 +2834,63 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1188657319981E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1313546288932E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3609744911655E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1188657319977E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1313546288958E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3609744911650E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4095603319057E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2045194440164E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3321806779500E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3321806779501E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2956762373065E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5677726263037E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.1186850487196E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   9.0738489236163E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9192942792242E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.4490586374895E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9192942792244E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.4490586374896E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807049542E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336527106E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665710523E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550425311E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2627731018030E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5011728442032E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2627731018025E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5011728440784E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.09734945338001E-02  1.25802292290124E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.01715226729949E-01
+ cg2d: Sum(rhs),rhsMax =   7.09734945337948E-02  1.25802292290124E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.01715226730099E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.03907776018266E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.03907775559674E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8794535779039E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4072287016797E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134814E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4072287016798E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134808E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2465417890215E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8831148383208E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5947008362394E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1786119181262E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5175182957585E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5175182957589E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1058054855736E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2238828084844E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2238828084843E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2206254919485E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1558891340569E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1263845737976E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0317090748433E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0374047055930E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1015984626125E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1015984626126E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9352108175458E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1305114802918E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1305114802916E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3821320807015E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8340595242778E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8340595242776E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9693801471938E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9094741500506E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202839555410E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164656008136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0749257258287E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0749257258288E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7421370403561E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748371975122E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010178649E+01
@@ -2915,33 +2921,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4230715338717E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5754250484847E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3652289932255E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4230715338667E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5754250486253E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3652289932205E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7336181835394E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2457072051432E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2187502829441E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1674217586198E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1674217586199E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5223144668864E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.2977893773821E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.0339489386570E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3150520670574E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3150520670578E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.6470059174604E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807118275E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367332823E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658705840E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518730363E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3340926688974E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6114652969032E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3340926688955E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6114652967107E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   8.75632178577046E-02  1.13976232941194E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.47106204337942E-01
+ cg2d: Sum(rhs),rhsMax =   8.75632178576957E-02  1.13976232941195E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.47106204337716E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.73903254763222E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.73903253850862E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2949,29 +2955,29 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7913928325839E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3831732002078E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787087E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787091E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2620642348123E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8153601991956E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7072697560530E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5482618030530E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1501243178306E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7072697560531E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5482618030531E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1501243178309E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2214578559985E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4424213091713E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2340161228925E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4424213091712E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2340161228926E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1439171676768E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013120257132E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013120257133E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0191454584766E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0138569713469E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9860005175565E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9860005175566E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9224362203585E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4909172629450E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2591060738351E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5738799112864E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4909172629448E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2591060738350E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5738799112862E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9692275456364E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9126646128593E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203439485971E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164323552420E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0215432204056E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0215432204057E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7421214360396E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9747839031067E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010368756E+01
@@ -3002,25 +3008,25 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8718566161612E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8718566161637E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3055808467527E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3519576393126E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9491225357588E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3519576394434E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9491225357587E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2224475945393E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9073291790504E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8151510956845E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9073291790505E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8151510956846E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5431888100801E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.4576318646582E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1448969998272E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6423883779831E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6423883779834E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.8355065101862E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807182702E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389885733E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649899831E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163500444933E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1232145588277E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7854695759269E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1232145588311E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7854695762269E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3040,168 +3046,168 @@ listId=   2 ; file name: oceStDiag
  Computing Diagnostic #     64  RHOAnoma     Counter:      10   Parms: SMR     MR      
  Computing Diagnostic #     78  DRHODR       Counter:      10   Parms: SM      LR      
  Computing Diagnostic #     79  CONVADJ      Counter:      10   Parms: SMR     LR      
- Computing Diagnostic #    204  GM_Kwx       Counter:      10   Parms: UM      LR      
-           Vector  Mate for  GM_Kwx       Diagnostic #    205  GM_Kwy   exists 
- Computing Diagnostic #    205  GM_Kwy       Counter:      10   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    204  GM_Kwx   exists 
- Computing Diagnostic #    206  GM_Kwz       Counter:      10   Parms: WM P    LR      
+ Computing Diagnostic #    205  GM_Kwx       Counter:      10   Parms: UM      LR      
+           Vector  Mate for  GM_Kwx       Diagnostic #    206  GM_Kwy   exists 
+ Computing Diagnostic #    206  GM_Kwy       Counter:      10   Parms: VM      LR      
+           Vector  Mate for  GM_Kwy       Diagnostic #    205  GM_Kwx   exists 
+ Computing Diagnostic #    207  GM_Kwz       Counter:      10   Parms: WM P    LR      
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   14.945272466167808
-(PID.TID 0000.0001)         System time:  0.28411799669265747
-(PID.TID 0000.0001)     Wall clock time:   15.242517948150635
+(PID.TID 0000.0001)           User time:   15.633345791604370
+(PID.TID 0000.0001)         System time:  0.39606700232252479
+(PID.TID 0000.0001)     Wall clock time:   16.397298097610474
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.15977300237864256
-(PID.TID 0000.0001)         System time:   8.1949003040790558E-002
-(PID.TID 0000.0001)     Wall clock time:  0.24954080581665039
+(PID.TID 0000.0001)           User time:  0.21049400628544390
+(PID.TID 0000.0001)         System time:   6.8917999276891351E-002
+(PID.TID 0000.0001)     Wall clock time:  0.29262804985046387
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   14.785430833697319
-(PID.TID 0000.0001)         System time:  0.20216500014066696
-(PID.TID 0000.0001)     Wall clock time:   14.992926120758057
+(PID.TID 0000.0001)           User time:   15.422812119126320
+(PID.TID 0000.0001)         System time:  0.32712600380182266
+(PID.TID 0000.0001)     Wall clock time:   16.104622840881348
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.86239005625247955
-(PID.TID 0000.0001)         System time:   9.9186003208160400E-002
-(PID.TID 0000.0001)     Wall clock time:  0.96608614921569824
+(PID.TID 0000.0001)           User time:  0.88581405580043793
+(PID.TID 0000.0001)         System time:  0.14245000481605530
+(PID.TID 0000.0001)     Wall clock time:   1.3227539062500000
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   13.923017144203186
-(PID.TID 0000.0001)         System time:  0.10297399759292603
-(PID.TID 0000.0001)     Wall clock time:   14.026813030242920
+(PID.TID 0000.0001)           User time:   14.536968469619751
+(PID.TID 0000.0001)         System time:  0.18466798961162567
+(PID.TID 0000.0001)     Wall clock time:   14.781835079193115
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   13.922942638397217
-(PID.TID 0000.0001)         System time:  0.10297101736068726
-(PID.TID 0000.0001)     Wall clock time:   14.026734352111816
+(PID.TID 0000.0001)           User time:   14.536875367164612
+(PID.TID 0000.0001)         System time:  0.18466699123382568
+(PID.TID 0000.0001)     Wall clock time:   14.781735897064209
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   13.922802448272705
-(PID.TID 0000.0001)         System time:  0.10296902060508728
-(PID.TID 0000.0001)     Wall clock time:   14.026593685150146
+(PID.TID 0000.0001)           User time:   14.536718606948853
+(PID.TID 0000.0001)         System time:  0.18466299772262573
+(PID.TID 0000.0001)     Wall clock time:   14.781579256057739
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.29842746257781982
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.29851174354553223
+(PID.TID 0000.0001)           User time:  0.32389879226684570
+(PID.TID 0000.0001)         System time:   6.5982341766357422E-005
+(PID.TID 0000.0001)     Wall clock time:  0.32450532913208008
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.27395308017730713
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:  0.27398467063903809
+(PID.TID 0000.0001)           User time:  0.29888427257537842
+(PID.TID 0000.0001)         System time:   3.8370192050933838E-003
+(PID.TID 0000.0001)     Wall clock time:  0.30322480201721191
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9920468330383301E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9921064376831055E-002
+(PID.TID 0000.0001)           User time:   1.7266035079956055E-002
+(PID.TID 0000.0001)         System time:   1.6055002808570862E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8122415542602539E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.9764065742492676E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9775629043579102E-002
+(PID.TID 0000.0001)           User time:   1.7076373100280762E-002
+(PID.TID 0000.0001)         System time:   1.6051009297370911E-002
+(PID.TID 0000.0001)     Wall clock time:   3.7934303283691406E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0823898315429688E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.0585479736328125E-005
+(PID.TID 0000.0001)           User time:   7.5936317443847656E-005
+(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
+(PID.TID 0000.0001)     Wall clock time:   7.7009201049804688E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.5693395137786865
-(PID.TID 0000.0001)         System time:   1.1421009898185730E-002
-(PID.TID 0000.0001)     Wall clock time:   4.5810973644256592
+(PID.TID 0000.0001)           User time:   4.6837918758392334
+(PID.TID 0000.0001)         System time:   2.8633996844291687E-002
+(PID.TID 0000.0001)     Wall clock time:   4.7639827728271484
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GMREDI_K3D      [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.2350434064865112
-(PID.TID 0000.0001)         System time:   1.1421009898185730E-002
-(PID.TID 0000.0001)     Wall clock time:   3.2468154430389404
+(PID.TID 0000.0001)           User time:   3.2789925336837769
+(PID.TID 0000.0001)         System time:   2.8453037142753601E-002
+(PID.TID 0000.0001)     Wall clock time:   3.3586397171020508
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3812036514282227
+(PID.TID 0000.0001)           User time:   2.4579827785491943
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.3813111782073975
+(PID.TID 0000.0001)     Wall clock time:   2.4581987857818604
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6564526557922363
-(PID.TID 0000.0001)         System time:   3.8300007581710815E-003
-(PID.TID 0000.0001)     Wall clock time:   3.6604356765747070
+(PID.TID 0000.0001)           User time:   3.7936480045318604
+(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
+(PID.TID 0000.0001)     Wall clock time:   3.7941207885742188
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.6439170837402344E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.6448230743408203E-002
+(PID.TID 0000.0001)           User time:   4.1279077529907227E-002
+(PID.TID 0000.0001)         System time:   7.8530013561248779E-003
+(PID.TID 0000.0001)     Wall clock time:   4.9139738082885742E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4051601886749268
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.4052274227142334
+(PID.TID 0000.0001)           User time:   1.5150001049041748
+(PID.TID 0000.0001)         System time:   6.9975852966308594E-005
+(PID.TID 0000.0001)     Wall clock time:   1.5166797637939453
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6803436279296875E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.6813688278198242E-002
+(PID.TID 0000.0001)           User time:   9.1698646545410156E-002
+(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
+(PID.TID 0000.0001)     Wall clock time:   9.1719150543212891E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12460064888000488
+(PID.TID 0000.0001)           User time:  0.13556599617004395
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.12462353706359863
+(PID.TID 0000.0001)     Wall clock time:  0.13559007644653320
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0597209930419922E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.0609369277954102E-002
+(PID.TID 0000.0001)           User time:   3.3052206039428711E-002
+(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
+(PID.TID 0000.0001)     Wall clock time:   3.3075094223022461E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.4148178100585938E-005
+(PID.TID 0000.0001)           User time:   8.6069107055664062E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.3194503784179688E-005
+(PID.TID 0000.0001)     Wall clock time:   8.9168548583984375E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32238864898681641
-(PID.TID 0000.0001)         System time:   3.7930011749267578E-003
-(PID.TID 0000.0001)     Wall clock time:  0.32622337341308594
+(PID.TID 0000.0001)           User time:  0.34493684768676758
+(PID.TID 0000.0001)         System time:   8.0059766769409180E-003
+(PID.TID 0000.0001)     Wall clock time:  0.35296320915222168
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56157016754150391
-(PID.TID 0000.0001)         System time:   4.5999884605407715E-005
-(PID.TID 0000.0001)     Wall clock time:  0.56167078018188477
+(PID.TID 0000.0001)           User time:  0.60165905952453613
+(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
+(PID.TID 0000.0001)     Wall clock time:  0.60179305076599121
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.4804077148437500E-002
-(PID.TID 0000.0001)         System time:   3.5812988877296448E-002
-(PID.TID 0000.0001)     Wall clock time:  0.10072159767150879
+(PID.TID 0000.0001)           User time:   8.6256980895996094E-002
+(PID.TID 0000.0001)         System time:   8.0016970634460449E-002
+(PID.TID 0000.0001)     Wall clock time:  0.16663575172424316
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.8414201736450195E-002
-(PID.TID 0000.0001)         System time:   4.8057019710540771E-002
-(PID.TID 0000.0001)     Wall clock time:  0.12652134895324707
+(PID.TID 0000.0001)           User time:  0.10884213447570801
+(PID.TID 0000.0001)         System time:   4.0012001991271973E-002
+(PID.TID 0000.0001)     Wall clock time:  0.14907121658325195
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================

--- a/global_ocean.gm_res/results/output.txt
+++ b/global_ocean.gm_res/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67v
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Oct 17 18:01:16 EDT 2019
+(PID.TID 0000.0001) // Build date:        Tue Feb 23 12:14:11 EST 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -51,7 +51,7 @@
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
 (PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
@@ -691,7 +691,7 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   257
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   258
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
@@ -707,14 +707,14 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    64 RHOAnoma
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 CONVADJ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   208 GM_Kwx
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   209 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   210 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   209 GM_Kwx
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   210 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   211 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all diagnostics:     185 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   208  GM_Kwx   , Parms: UM      LR , mate:   209
-(PID.TID 0000.0001)   set mate pointer for diag #   209  GM_Kwy   , Parms: VM      LR , mate:   208
+(PID.TID 0000.0001)   set mate pointer for diag #   209  GM_Kwx   , Parms: UM      LR , mate:   210
+(PID.TID 0000.0001)   set mate pointer for diag #   210  GM_Kwy   , Parms: VM      LR , mate:   209
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
@@ -875,9 +875,15 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95P'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -2024,9 +2030,9 @@ listId=    3 ; file name: oceDiag
     64 |RHOAnoma|     96 |      0 |  15 |       0 |
     78 |DRHODR  |    111 |      0 |  15 |       0 |
     79 |CONVADJ |    126 |      0 |  15 |       0 |
-   208 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
-   209 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
-   210 |GM_Kwz  |    171 |      0 |  15 |       0 |
+   209 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
+   210 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
+   211 |GM_Kwz  |    171 |      0 |  15 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     2
 ------------------------------------------------------------------------
@@ -2242,20 +2248,20 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.20105170698304E-03  2.63981021203448E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.62477520481611E-01
+ cg2d: Sum(rhs),rhsMax =   7.20105170697860E-03  2.63981021203451E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.62477520481604E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.32198240220861E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.32198249842894E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0268334580353E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152444704753E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0268334580360E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152444704755E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248848E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4260892007711E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5959472152084E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5959472152083E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1619027110699E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2710042598445E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3920346530214E-04
@@ -2267,7 +2273,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2863969560558E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.5985151296448E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0803557023619E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6925214928716E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6925214928717E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9075118110869E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1870746798785E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6910260392476E-07
@@ -2312,7 +2318,7 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1343383365941E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1990675709735E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3878494822509E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9933635800782E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9933635800783E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   2.5068108723285E-04
 (PID.TID 0000.0001) %MON ke_max                       =   2.0552064899227E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1579274348584E-05
@@ -2323,16 +2329,16 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185659491E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642660483E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162954511392E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8463761229330E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9401861374064E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8463761229331E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9401861374103E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.18796489446844E-02  2.41525635003443E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.93472727326641E-01
+ cg2d: Sum(rhs),rhsMax =   1.18796489446772E-02  2.41525635003442E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.93472727325549E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.45955552440319E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.45955549167620E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2340,22 +2346,22 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9378701473966E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5754117247190E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231129E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2998879652828E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231135E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2998879652829E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4539601812796E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8737420890063E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8737420890064E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4601558487825E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2236489934308E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4170570985827E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8738667558191E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0967857539844E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4154642374793E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324026100014E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324026100015E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8933564455617E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3203673200983E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4712670365302E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2866766659303E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9441869106166E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9441869106175E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6291272117083E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2894914731653E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716232297187E+01
@@ -2395,8 +2401,8 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1347137413781E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2925335621268E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.5060079007765E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5385567873840E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.5060079007766E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5385567873841E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2464218096661E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6307800213699E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2391886856415E-02
@@ -2410,39 +2416,39 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604170387934E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640527640E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163353031084E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3809574564481E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2639819561803E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3809574564479E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2639819561686E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.73192181660697E-02  2.22263153548672E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.41965258017129E-01
+ cg2d: Sum(rhs),rhsMax =   1.73192181660686E-02  2.22263153548671E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.41965258018700E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   8.72195885764484E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.72195886026120E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7516700506905E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7516700506906E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5953833277408E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451982E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451985E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5713688213057E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3594947288492E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3594947288493E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8522475792041E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7320227471201E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4738381297775E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4738381297774E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4971847429929E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9807683833009E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3146267325299E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.1176921415685E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.1176921415684E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6179185552363E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.4068010096486E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8591066180182E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8591066180183E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8006078538948E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5278737063014E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1059621950175E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1059621950294E-10
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9950068862130E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7558791827647E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9710632503336E+01
@@ -2480,56 +2486,56 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1440480618348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.5389519193384E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.5389519193385E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3433914989091E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.7766934379197E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8125590149214E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5771373909773E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8125590149216E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5771373909772E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8260609532365E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5914224419346E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.9719624945044E-04
 (PID.TID 0000.0001) %MON ke_max                       =   3.5977530453139E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   3.4285700442680E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0892901270118E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2322392802153E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0892901270117E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2322392802152E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807135569E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604186087813E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649853576E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163586594108E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0503044248886E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2081278263157E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0503044248888E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2081278264924E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.39759924927668E-02  2.01930904825835E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.32014742920628E-01
+ cg2d: Sum(rhs),rhsMax =   2.39759924927766E-02  2.01930904825837E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.32014742921132E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.58521673427395E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.58521672385087E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8766307347238E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5429796423388E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911406E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8766307347237E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5429796423387E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911410E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5646041049067E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2723046423358E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8817756647726E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7516912706740E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7516912706741E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8598751045100E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.6934219516807E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8596665674488E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8596665674487E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4156380758950E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3746428784328E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6781609532746E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6781609532747E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.6679489189220E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0896788141996E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0311055332455E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7152068885953E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2561188739766E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7152068885952E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2561188739872E-11
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2667861834644E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0626019789193E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9706188006461E+01
@@ -2567,33 +2573,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8129818781861E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6222938138637E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8129818781863E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6222938138638E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.5705626759539E-02
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.2657838292442E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8213427600838E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8113834923805E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.7062033171121E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9623234841723E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9623234841724E-04
 (PID.TID 0000.0001) %MON ke_max                       =   5.3837054743557E-03
 (PID.TID 0000.0001) %MON ke_mean                      =   4.8703321124828E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.3362440139926E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.3274663538211E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.3362440139835E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.3274663538121E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807069682E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604218355944E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661337472E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163668735828E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0818321635273E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0207007921604E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0818321635243E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0207007922397E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.24731638325079E-02  1.80008613261788E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.45991003985998E-01
+ cg2d: Sum(rhs),rhsMax =   3.24731638324971E-02  1.80008613261865E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.45991003986194E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   9.79500747584976E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.79500758238396E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2601,29 +2607,29 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0322888547748E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4933148746564E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609402E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609397E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4660503096510E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1811801941737E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0873295321938E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5211989798538E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5211989798539E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8115640639145E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.9492057488732E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5441106669746E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5441106669745E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3780746870206E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0638264999547E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5696040636167E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531382386141E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0001953506501E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0638264999546E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5696040635912E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531382386139E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0001953506500E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2223149991387E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8154063334264E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6327060397258E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6327060397244E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4425433336523E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2156986767515E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9702754301253E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035192610541E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200939135040E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165995634356E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3078277930083E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3078277930084E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433557089934E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9752497723803E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008669517E+01
@@ -2656,61 +2662,61 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.2661153146501E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7708339313014E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4451756093320E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9676665912652E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4451756093314E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9676665912646E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0668442721539E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.5586600763377E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.5517208429636E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.5586600763376E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.5517208429635E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.8232149956272E-04
 (PID.TID 0000.0001) %MON ke_max                       =   7.3148762425676E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.3878706558570E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   6.3878706558569E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -3.1072519953079E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.0975474710439E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.0975474710438E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807029370E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604258285896E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668353707E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163653866742E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0974547715499E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1887783568877E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0974547715485E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1887783569026E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.35517550753373E-02  1.57543364885418E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.55403301334096E-01
+ cg2d: Sum(rhs),rhsMax =   4.35517550753397E-02  1.57543364885390E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.55403301336019E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   9.75868994722174E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.75868995006715E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0917845119341E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4562388543413E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545968E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4562388543415E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545961E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3582120686418E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0853780497341E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2742174785767E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9053560823687E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9053560823525E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.6028531419524E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2616984171994E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0248450892775E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0476432835185E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1288828659618E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2616984171993E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0248450892780E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0476432835184E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1288828659619E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9243540430830E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0332767076131E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0555909997915E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0555909997916E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3457395799974E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8990202451855E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8183609593037E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8990202451859E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8183609593035E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5235244148221E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2221378572609E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699949761774E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042457536336E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201626507336E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165515574418E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2297678415693E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2297678415694E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7432974286627E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751194441609E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009435849E+01
@@ -2741,33 +2747,33 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9227604812524E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9684041930024E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9684041930018E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9763233007328E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8331052900755E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0586724081232E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8331052900753E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0586724081140E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1932383575192E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0452549528689E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1023311277946E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.6738496353302E-04
 (PID.TID 0000.0001) %MON ke_max                       =   9.2883523099455E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8988960342704E-05
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8988960342702E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0215495476828E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.4638979294144E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0215495476827E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.4638979294162E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807037561E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604299350296E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669417794E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163608746225E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7605489775277E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9843234230561E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7605489775262E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9843234228884E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.80565565447622E-02  1.35885021128368E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.77059921564391E-01
+ cg2d: Sum(rhs),rhsMax =   5.80565565447977E-02  1.35885021128348E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.77059921565014E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.31143674450455E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.31143673468040E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -2775,29 +2781,29 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0696389413342E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4250003337957E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721100E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721103E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2783539194405E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9919445956779E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4424962478009E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1563112500209E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4570732402991E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5880936974405E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4104687424120E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4424962478010E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1563112500262E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4570732402987E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5880936974407E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4104687424088E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4484126810460E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1678246436671E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9441242276416E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0727435716819E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0860904365607E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9441242276415E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0727435716817E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0860904365595E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3935760444528E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9235235864487E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1562692250664E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9235235864486E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1562692250682E-09
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5205589881691E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1081207281433E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1081207281432E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697556873107E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050355926985E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202270793713E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165070798884E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1573434437643E-03
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1573434437644E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7432118086740E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750122052199E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009863289E+01
@@ -2828,58 +2834,58 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0596105705785E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0596105705693E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1232918666922E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2060121428374E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5684064304449E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2688959860901E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5684064304752E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2688959860902E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2907302481127E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3801486788347E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5651575260764E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1211853198764E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   9.3469210630888E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.1211853198763E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   9.3469210630878E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3391079511809E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3391079511633E-07
 (PID.TID 0000.0001) %MON vort_r_max                   =   4.7832431286262E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807082224E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336695383E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665622298E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163561336646E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2797442144704E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4933622524876E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2797442144711E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4933622525854E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.62383743773936E-02  1.17114620781290E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.84765613765906E-01
+ cg2d: Sum(rhs),rhsMax =   7.62383743773920E-02  1.17114620781291E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.84765613765487E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.50859462508934E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.50859462312395E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8854257556392E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3964404488755E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134810E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8854257556393E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3964404488771E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134807E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2446130453753E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9092919086456E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9092919086457E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5868226074399E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4052707831557E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.4969513197219E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4052707831574E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.4969513197222E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0878556092207E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7362960912174E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5953642889254E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7362960912140E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5953642889253E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1856430954683E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1260220072253E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0857889409481E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0885454657314E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0857889409479E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0885454657307E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3545543659662E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9708566397557E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1326119155871E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4474856500271E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9018620201280E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9708566397556E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1326119155874E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4474856500272E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9018620201283E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695585563507E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9132355269702E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202890358025E+00
@@ -2915,57 +2921,57 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5696244402404E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5696244402707E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1965400930724E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4259510374108E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9826168329933E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9826168330028E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3035143802039E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2588619359865E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2588619359864E-02
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3441891565531E-02
 (PID.TID 0000.0001) %MON pe_b_mean                    =   3.5197251865899E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.3006362308662E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0674674206113E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0674674206112E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7098226348329E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.1347689031199E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7098226348240E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.1347689031220E-07
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807149695E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367360970E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658603570E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163527785477E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3456920630921E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5991497208630E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3456920630926E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5991497208974E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   9.04844671184248E-02  1.10296562862766E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.85033306637952E-01
+ cg2d: Sum(rhs),rhsMax =   9.04844671184000E-02  1.10296562862768E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.85033306637990E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.71434903505793E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.71434903854611E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8001942960471E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3720030608762E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787083E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2602190562437E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8001942960472E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3720030608775E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787089E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2602190562436E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8411634091154E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7028921716190E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5782853235867E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1269829507815E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2092050802130E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0292595044734E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1269829507820E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2092050802129E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0292595044714E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7635129721526E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1795668451818E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013576728468E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013576728470E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0765090778227E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0685938097797E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0685938097793E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2474512591898E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9622128569589E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4953168280028E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3241089984675E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4953168280030E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3241089984674E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6412908861112E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694172359614E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9134999683955E+00
@@ -3002,25 +3008,25 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.9840964719868E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.9840964719963E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2300451571834E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3974830822712E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.9654229934513E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2917092004107E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.9654229934512E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2917092004106E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0111694679662E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.0640457845128E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5407043635096E-04
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.0640457845129E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5407043635095E-04
 (PID.TID 0000.0001) %MON ke_max                       =   1.4608149803360E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.1853294553277E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2441590781459E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.3848072432102E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209146E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2441590782420E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.3848072432050E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209145E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389536174E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649773334E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163505237410E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1325577127933E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7730807667185E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1325577127935E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7730807667534E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3040,168 +3046,168 @@ listId=   2 ; file name: oceStDiag
  Computing Diagnostic #     64  RHOAnoma     Counter:      10   Parms: SMR     MR      
  Computing Diagnostic #     78  DRHODR       Counter:      10   Parms: SM      LR      
  Computing Diagnostic #     79  CONVADJ      Counter:      10   Parms: SMR     LR      
- Computing Diagnostic #    208  GM_Kwx       Counter:      10   Parms: UM      LR      
-           Vector  Mate for  GM_Kwx       Diagnostic #    209  GM_Kwy   exists 
- Computing Diagnostic #    209  GM_Kwy       Counter:      10   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    208  GM_Kwx   exists 
- Computing Diagnostic #    210  GM_Kwz       Counter:      10   Parms: WM P    LR      
+ Computing Diagnostic #    209  GM_Kwx       Counter:      10   Parms: UM      LR      
+           Vector  Mate for  GM_Kwx       Diagnostic #    210  GM_Kwy   exists 
+ Computing Diagnostic #    210  GM_Kwy       Counter:      10   Parms: VM      LR      
+           Vector  Mate for  GM_Kwy       Diagnostic #    209  GM_Kwx   exists 
+ Computing Diagnostic #    211  GM_Kwz       Counter:      10   Parms: WM P    LR      
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.625472436193377
-(PID.TID 0000.0001)         System time:  0.23200699500739574
-(PID.TID 0000.0001)     Wall clock time:   16.876699924468994
+(PID.TID 0000.0001)           User time:   15.863589286804199
+(PID.TID 0000.0001)         System time:  0.27817099029198289
+(PID.TID 0000.0001)     Wall clock time:   16.149056911468506
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.19874800508841872
-(PID.TID 0000.0001)         System time:   4.3822000501677394E-002
-(PID.TID 0000.0001)     Wall clock time:  0.24351000785827637
+(PID.TID 0000.0001)           User time:  0.13060399889945984
+(PID.TID 0000.0001)         System time:   4.9622998572885990E-002
+(PID.TID 0000.0001)     Wall clock time:  0.18166899681091309
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.426673710346222
-(PID.TID 0000.0001)         System time:  0.18816499412059784
-(PID.TID 0000.0001)     Wall clock time:   16.633141040802002
+(PID.TID 0000.0001)           User time:   15.732969656586647
+(PID.TID 0000.0001)         System time:  0.22851799055933952
+(PID.TID 0000.0001)     Wall clock time:   15.967355012893677
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.79467599093914032
-(PID.TID 0000.0001)         System time:   5.1677998155355453E-002
-(PID.TID 0000.0001)     Wall clock time:  0.85483002662658691
+(PID.TID 0000.0001)           User time:  0.73705402016639709
+(PID.TID 0000.0001)         System time:   7.2541005909442902E-002
+(PID.TID 0000.0001)     Wall clock time:  0.81026315689086914
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.631974101066589
-(PID.TID 0000.0001)         System time:  0.13648399710655212
-(PID.TID 0000.0001)     Wall clock time:   15.778285980224609
+(PID.TID 0000.0001)           User time:   14.995883524417877
+(PID.TID 0000.0001)         System time:  0.15597300231456757
+(PID.TID 0000.0001)     Wall clock time:   15.157057046890259
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.631896495819092
-(PID.TID 0000.0001)         System time:  0.13648399710655212
-(PID.TID 0000.0001)     Wall clock time:   15.778206825256348
+(PID.TID 0000.0001)           User time:   14.995788395404816
+(PID.TID 0000.0001)         System time:  0.15597200393676758
+(PID.TID 0000.0001)     Wall clock time:   15.156961441040039
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   15.631747484207153
-(PID.TID 0000.0001)         System time:  0.13648299872875214
-(PID.TID 0000.0001)     Wall clock time:   15.778054952621460
+(PID.TID 0000.0001)           User time:   14.995633304119110
+(PID.TID 0000.0001)         System time:  0.15597100555896759
+(PID.TID 0000.0001)     Wall clock time:   15.156803131103516
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32427668571472168
-(PID.TID 0000.0001)         System time:   1.8700212240219116E-004
-(PID.TID 0000.0001)     Wall clock time:  0.32451605796813965
+(PID.TID 0000.0001)           User time:  0.32676905393600464
+(PID.TID 0000.0001)         System time:   1.3992190361022949E-005
+(PID.TID 0000.0001)     Wall clock time:  0.32682681083679199
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30497729778289795
-(PID.TID 0000.0001)         System time:   4.0079876780509949E-003
-(PID.TID 0000.0001)     Wall clock time:  0.30919194221496582
+(PID.TID 0000.0001)           User time:  0.29777890443801880
+(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
+(PID.TID 0000.0001)     Wall clock time:  0.29783368110656738
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8623232841491699E-002
-(PID.TID 0000.0001)         System time:   3.7997961044311523E-005
-(PID.TID 0000.0001)     Wall clock time:   1.8657207489013672E-002
+(PID.TID 0000.0001)           User time:   1.8170893192291260E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.8172264099121094E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.8443107604980469E-002
-(PID.TID 0000.0001)         System time:   3.6001205444335938E-005
-(PID.TID 0000.0001)     Wall clock time:   1.8490791320800781E-002
+(PID.TID 0000.0001)           User time:   1.7986893653869629E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.8008708953857422E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2612037658691406E-005
+(PID.TID 0000.0001)           User time:   8.6903572082519531E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.1777572631835938E-005
+(PID.TID 0000.0001)     Wall clock time:   8.3446502685546875E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.3165640830993652
-(PID.TID 0000.0001)         System time:   5.1988996565341949E-002
-(PID.TID 0000.0001)     Wall clock time:   5.3775517940521240
+(PID.TID 0000.0001)           User time:   4.8164287209510803
+(PID.TID 0000.0001)         System time:   3.5972997546195984E-002
+(PID.TID 0000.0001)     Wall clock time:   4.8544754981994629
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GMREDI_K3D      [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.6601834297180176
-(PID.TID 0000.0001)         System time:   5.1511973142623901E-002
-(PID.TID 0000.0001)     Wall clock time:   3.7205548286437988
+(PID.TID 0000.0001)           User time:   3.2949277162551880
+(PID.TID 0000.0001)         System time:   3.5783991217613220E-002
+(PID.TID 0000.0001)     Wall clock time:   3.3321151733398438
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5511908531188965
-(PID.TID 0000.0001)         System time:   3.9994716644287109E-005
-(PID.TID 0000.0001)     Wall clock time:   2.5514178276062012
+(PID.TID 0000.0001)           User time:   2.5113046169281006
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.5128266811370850
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.9744770526885986
-(PID.TID 0000.0001)         System time:   5.9008598327636719E-005
-(PID.TID 0000.0001)     Wall clock time:   3.9747858047485352
+(PID.TID 0000.0001)           User time:   4.0143959522247314
+(PID.TID 0000.0001)         System time:   3.0100345611572266E-006
+(PID.TID 0000.0001)     Wall clock time:   4.0156540870666504
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.3229570388793945E-002
-(PID.TID 0000.0001)         System time:   8.3997845649719238E-005
-(PID.TID 0000.0001)     Wall clock time:   5.3328990936279297E-002
+(PID.TID 0000.0001)           User time:   5.0795078277587891E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   5.0812482833862305E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6553158760070801
-(PID.TID 0000.0001)         System time:   1.6003847122192383E-005
-(PID.TID 0000.0001)     Wall clock time:   1.6554391384124756
+(PID.TID 0000.0001)           User time:   1.5320127010345459
+(PID.TID 0000.0001)         System time:   8.0019235610961914E-006
+(PID.TID 0000.0001)     Wall clock time:   1.5320441722869873
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.4555139541625977E-002
-(PID.TID 0000.0001)         System time:   6.1020255088806152E-005
-(PID.TID 0000.0001)     Wall clock time:   9.4657421112060547E-002
+(PID.TID 0000.0001)           User time:   9.2309951782226562E-002
+(PID.TID 0000.0001)         System time:   9.9986791610717773E-006
+(PID.TID 0000.0001)     Wall clock time:   9.2325925827026367E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13781404495239258
-(PID.TID 0000.0001)         System time:   3.0994415283203125E-005
-(PID.TID 0000.0001)     Wall clock time:  0.13791108131408691
+(PID.TID 0000.0001)           User time:  0.13371205329895020
+(PID.TID 0000.0001)         System time:   1.0997056961059570E-005
+(PID.TID 0000.0001)     Wall clock time:  0.13374805450439453
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4235239028930664E-002
+(PID.TID 0000.0001)           User time:   3.3499717712402344E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.4244298934936523E-002
+(PID.TID 0000.0001)     Wall clock time:   3.3517599105834961E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2254409790039062E-005
+(PID.TID 0000.0001)           User time:   8.7499618530273438E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.0108642578125000E-005
+(PID.TID 0000.0001)     Wall clock time:   8.7976455688476562E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35938382148742676
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.35940766334533691
+(PID.TID 0000.0001)           User time:  0.35375142097473145
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
+(PID.TID 0000.0001)     Wall clock time:  0.35378384590148926
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60471987724304199
-(PID.TID 0000.0001)         System time:   3.9930045604705811E-003
-(PID.TID 0000.0001)     Wall clock time:  0.60877394676208496
+(PID.TID 0000.0001)           User time:  0.65095376968383789
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.65101933479309082
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.7423572540283203E-002
-(PID.TID 0000.0001)         System time:   4.3948993086814880E-002
-(PID.TID 0000.0001)     Wall clock time:  0.12144327163696289
+(PID.TID 0000.0001)           User time:   6.5558433532714844E-002
+(PID.TID 0000.0001)         System time:   5.9961006045341492E-002
+(PID.TID 0000.0001)     Wall clock time:  0.12568664550781250
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12194728851318359
-(PID.TID 0000.0001)         System time:   3.2005995512008667E-002
-(PID.TID 0000.0001)     Wall clock time:  0.15400767326354980
+(PID.TID 0000.0001)           User time:   9.5203161239624023E-002
+(PID.TID 0000.0001)         System time:   5.9973001480102539E-002
+(PID.TID 0000.0001)     Wall clock time:  0.15536785125732422
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #433: update FWD output of exp.: global_ocean.gm_k3d & .gm_res since
+    both use quasiHydrostatic=T (-> affects results @ machine trunc. level).
+
 checkpoint67w (2021/03/06) synchronised with main MITgcm code.
   - add MOC sensitivity cost in experiment global_oce_cs32/input_ad.sens/ and
     generate new ADM output, now from villon.mit.edu (previously from engaging)


### PR DESCRIPTION
The two global_ocean.gm_k3d and gm_res experiments use "quasiHydrostatic=T";
Since addition ordering terms have changed in S/R MOM_QUASIHYDROSTATIC
with PR #433 (https://github.com/MITgcm/MITgcm/pull/433), this affects results
at machine truncation level and now getting only 11 matching digits for gc2d for
these 2 experiments ; generate new output on reference platform "villon.mit.edu".