### PR TITLE
Post pr438 output update

### DIFF
--- a/global_oce_llc90/results/output_adm.ecco_v4.txt
+++ b/global_oce_llc90/results/output_adm.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67u
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node027
-(PID.TID 0000.0001) // Build date:        Tue Jan 26 12:41:34 EST 2021
+(PID.TID 0000.0001) // Build host:        node035
+(PID.TID 0000.0001) // Build date:        Wed Mar 17 01:03:49 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node027
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node035
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -837,6 +837,9 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
@@ -1995,7 +1998,7 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
-(PID.TID 0000.0001)                    1500
+(PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2730,8 +2733,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            6
-(PID.TID 0000.0001) ctrl_init: control vector length:         7645498
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            6
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:         7645498
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2754,18 +2757,26 @@
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
 (PID.TID 0000.0001)       weight     = wt_theta.data
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  preprocess = WC01
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_salt
 (PID.TID 0000.0001)       weight     = wt_salt.data
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  preprocess = WC01
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_kapgm.data
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001)  preprocess = WC01
 (PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_atemp
 (PID.TID 0000.0001)       weight     = wt_atemp.data
+(PID.TID 0000.0001)       index      =  0301
+(PID.TID 0000.0001)       ncvarindex =  0401
 (PID.TID 0000.0001)       period     =  00000000 040000
 (PID.TID 0000.0001)       preprocess = docycle
 (PID.TID 0000.0001)         param. (int.)=      1
@@ -2773,6 +2784,8 @@
 (PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_precip
 (PID.TID 0000.0001)       weight     = wt_precip.data
+(PID.TID 0000.0001)       index      =  0302
+(PID.TID 0000.0001)       ncvarindex =  0402
 (PID.TID 0000.0001)       period     =  00000000 040000
 (PID.TID 0000.0001)       preprocess = docycle
 (PID.TID 0000.0001)         param. (int.)=      2
@@ -2780,6 +2793,8 @@
 (PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_swdown
 (PID.TID 0000.0001)       weight     = wt_swdown.data
+(PID.TID 0000.0001)       index      =  0303
+(PID.TID 0000.0001)       ncvarindex =  0403
 (PID.TID 0000.0001)       period     =  00000000 040000
 (PID.TID 0000.0001)       preprocess = WC01
 (PID.TID 0000.0001) 
@@ -5693,34 +5708,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
  cg2d: Sum(rhs),rhsMax =   3.01104374390890E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588529235E+00  1.09558808552463E+00
- cg2d: Sum(rhs),rhsMax =   3.00955227985337E+00  1.09443701612858E+00
- cg2d: Sum(rhs),rhsMax =   3.01018153568135E+00  1.08987441581993E+00
- cg2d: Sum(rhs),rhsMax =   3.01200562010724E+00  1.08234533911810E+00
- cg2d: Sum(rhs),rhsMax =   3.01470694713823E+00  1.07091042415522E+00
- cg2d: Sum(rhs),rhsMax =   3.01809293592541E+00  1.05630803647089E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588529224E+00  1.09558808552459E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953984851885E+00  1.09443701612842E+00
+ cg2d: Sum(rhs),rhsMax =   3.01015464507458E+00  1.08987441584703E+00
+ cg2d: Sum(rhs),rhsMax =   3.01196467522837E+00  1.08234533899706E+00
+ cg2d: Sum(rhs),rhsMax =   3.01466735055031E+00  1.07091042415027E+00
+ cg2d: Sum(rhs),rhsMax =   3.01804723400621E+00  1.05630803582882E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535095377904D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615588962437D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195208034034D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535102899776D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615539820814D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195193090464D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150684350340D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150642730589D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010315008496D+06
-(PID.TID 0000.0001)  global fc =  0.918150684350340D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150684350340E+06
+(PID.TID 0000.0001)   local fc =  0.631010349544775D+06
+(PID.TID 0000.0001)  global fc =  0.918150642730589D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150642730589E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217162132263E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.57310216315091E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.65408971533179E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5766,31 +5781,31 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
  cg2d: Sum(rhs),rhsMax =   3.01104374390898E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588508908E+00  1.09558808552457E+00
- cg2d: Sum(rhs),rhsMax =   3.00953815018695E+00  1.09443701612848E+00
- cg2d: Sum(rhs),rhsMax =   3.01013734718519E+00  1.08987441567869E+00
- cg2d: Sum(rhs),rhsMax =   3.01194721173536E+00  1.08234533852244E+00
- cg2d: Sum(rhs),rhsMax =   3.01466044830028E+00  1.07091042396447E+00
- cg2d: Sum(rhs),rhsMax =   3.01803945594454E+00  1.05630803622257E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588508899E+00  1.09558808552457E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953625861827E+00  1.09443701612831E+00
+ cg2d: Sum(rhs),rhsMax =   3.01013375110529E+00  1.08987441567121E+00
+ cg2d: Sum(rhs),rhsMax =   3.01193109946800E+00  1.08234533916168E+00
+ cg2d: Sum(rhs),rhsMax =   3.01462510362864E+00  1.07091042392201E+00
+ cg2d: Sum(rhs),rhsMax =   3.01800852785854E+00  1.05630803638774E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535120399954D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615580394161D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195200981051D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535132313980D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615553631866D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195183530857D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150700804115D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150685955846D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010310371619D+06
-(PID.TID 0000.0001)  global fc =  0.918150700804115D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150700804115E+06
+(PID.TID 0000.0001)   local fc =  0.631010355285330D+06
+(PID.TID 0000.0001)  global fc =  0.918150685955846D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150685955846E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5832,35 +5847,35 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390897E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588528707E+00  1.09558808552463E+00
- cg2d: Sum(rhs),rhsMax =   3.00953694801277E+00  1.09443701612860E+00
- cg2d: Sum(rhs),rhsMax =   3.01014443994568E+00  1.08987441594618E+00
- cg2d: Sum(rhs),rhsMax =   3.01196541768283E+00  1.08234533905814E+00
- cg2d: Sum(rhs),rhsMax =   3.01467726560582E+00  1.07091042417652E+00
- cg2d: Sum(rhs),rhsMax =   3.01807063851034E+00  1.05630803663641E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390896E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588528689E+00  1.09558808552463E+00
+ cg2d: Sum(rhs),rhsMax =   3.00956370849629E+00  1.09443701612863E+00
+ cg2d: Sum(rhs),rhsMax =   3.01017948441832E+00  1.08987441575063E+00
+ cg2d: Sum(rhs),rhsMax =   3.01201590965418E+00  1.08234533896412E+00
+ cg2d: Sum(rhs),rhsMax =   3.01472948869790E+00  1.07091042416189E+00
+ cg2d: Sum(rhs),rhsMax =   3.01812094548721E+00  1.05630803667633E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535108958894D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615598634329D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195199182960D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535076998973D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615623727998D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195250851929D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150707603223D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150700736972D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010355915152D+06
-(PID.TID 0000.0001)  global fc =  0.918150707603223D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150707603223E+06
+(PID.TID 0000.0001)   local fc =  0.631010352448524D+06
+(PID.TID 0000.0001)  global fc =  0.918150700736972D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150700736972E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.85234189033508E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -3.39955370873213E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -7.39056272432208E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5906,31 +5921,31 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
  cg2d: Sum(rhs),rhsMax =   3.01104374390877E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588509673E+00  1.09558808552459E+00
- cg2d: Sum(rhs),rhsMax =   3.00954089064260E+00  1.09443701612863E+00
- cg2d: Sum(rhs),rhsMax =   3.01016456715668E+00  1.08987441571391E+00
- cg2d: Sum(rhs),rhsMax =   3.01199733916378E+00  1.08234533863839E+00
- cg2d: Sum(rhs),rhsMax =   3.01470987093895E+00  1.07091042343376E+00
- cg2d: Sum(rhs),rhsMax =   3.01809220097883E+00  1.05630803580798E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588509677E+00  1.09558808552458E+00
+ cg2d: Sum(rhs),rhsMax =   3.00952812760866E+00  1.09443701612852E+00
+ cg2d: Sum(rhs),rhsMax =   3.01013083125854E+00  1.08987441607465E+00
+ cg2d: Sum(rhs),rhsMax =   3.01193511019707E+00  1.08234533838854E+00
+ cg2d: Sum(rhs),rhsMax =   3.01464690104225E+00  1.07091042397858E+00
+ cg2d: Sum(rhs),rhsMax =   3.01800403007922E+00  1.05630803645326E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535103039714D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615591085200D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195228384862D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535135769318D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615549429926D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195169535500D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150694134914D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150685209243D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010347878187D+06
-(PID.TID 0000.0001)  global fc =  0.918150694134914D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150694134914E+06
+(PID.TID 0000.0001)   local fc =  0.631010342568546D+06
+(PID.TID 0000.0001)  global fc =  0.918150685209243D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150685209243E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5972,35 +5987,35 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390910E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588527877E+00  1.09558808552462E+00
- cg2d: Sum(rhs),rhsMax =   3.00954702106640E+00  1.09443701612858E+00
- cg2d: Sum(rhs),rhsMax =   3.01017271783277E+00  1.08987441587452E+00
- cg2d: Sum(rhs),rhsMax =   3.01197629594046E+00  1.08234533915669E+00
- cg2d: Sum(rhs),rhsMax =   3.01467853054415E+00  1.07091042410217E+00
- cg2d: Sum(rhs),rhsMax =   3.01804100098336E+00  1.05630803618250E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390917E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588527888E+00  1.09558808552458E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953911188996E+00  1.09443701612862E+00
+ cg2d: Sum(rhs),rhsMax =   3.01015260995154E+00  1.08987441580691E+00
+ cg2d: Sum(rhs),rhsMax =   3.01199616884082E+00  1.08234533845973E+00
+ cg2d: Sum(rhs),rhsMax =   3.01470389433347E+00  1.07091042421148E+00
+ cg2d: Sum(rhs),rhsMax =   3.01809920452894E+00  1.05630803617294E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535114444336D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615590424984D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195175093762D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535116758025D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615608639676D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195217082258D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150704879321D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150725407700D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010338789611D+06
-(PID.TID 0000.0001)  global fc =  0.918150704879321D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150704879321E+06
+(PID.TID 0000.0001)   local fc =  0.631010343276011D+06
+(PID.TID 0000.0001)  global fc =  0.918150725407700D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150725407700E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19271993637085E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -5.37220342084765E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.00992285273969E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -6045,32 +6060,32 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390929E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588510715E+00  1.09558808552457E+00
- cg2d: Sum(rhs),rhsMax =   3.00956221835105E+00  1.09443701612855E+00
- cg2d: Sum(rhs),rhsMax =   3.01022265409663E+00  1.08987441584234E+00
- cg2d: Sum(rhs),rhsMax =   3.01204097530820E+00  1.08234533893525E+00
- cg2d: Sum(rhs),rhsMax =   3.01477158182298E+00  1.07091042430506E+00
- cg2d: Sum(rhs),rhsMax =   3.01815973675490E+00  1.05630803643874E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390930E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588510694E+00  1.09558808552458E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954987233595E+00  1.09443701612861E+00
+ cg2d: Sum(rhs),rhsMax =   3.01016990071168E+00  1.08987441589887E+00
+ cg2d: Sum(rhs),rhsMax =   3.01199279721120E+00  1.08234533900488E+00
+ cg2d: Sum(rhs),rhsMax =   3.01472784455805E+00  1.07091042415224E+00
+ cg2d: Sum(rhs),rhsMax =   3.01811513863563E+00  1.05630803650977E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535086616795D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615650492121D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195216574354D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535094648053D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615633268504D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195251974674D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150737118915D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150727926557D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010328896107D+06
-(PID.TID 0000.0001)  global fc =  0.918150737118915D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150737118915E+06
+(PID.TID 0000.0001)   local fc =  0.631010342896798D+06
+(PID.TID 0000.0001)  global fc =  0.918150727926557D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150727926557E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -6112,35 +6127,35 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390902E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588526930E+00  1.09558808552459E+00
- cg2d: Sum(rhs),rhsMax =   3.00955579374946E+00  1.09443701612846E+00
- cg2d: Sum(rhs),rhsMax =   3.01017548304332E+00  1.08987441591527E+00
- cg2d: Sum(rhs),rhsMax =   3.01199260662536E+00  1.08234533911914E+00
- cg2d: Sum(rhs),rhsMax =   3.01468477919034E+00  1.07091042382195E+00
- cg2d: Sum(rhs),rhsMax =   3.01803867755702E+00  1.05630803671289E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390904E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588526909E+00  1.09558808552460E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953609478396E+00  1.09443701612853E+00
+ cg2d: Sum(rhs),rhsMax =   3.01013479879541E+00  1.08987441597024E+00
+ cg2d: Sum(rhs),rhsMax =   3.01195168098912E+00  1.08234533909442E+00
+ cg2d: Sum(rhs),rhsMax =   3.01466061125088E+00  1.07091042418912E+00
+ cg2d: Sum(rhs),rhsMax =   3.01802596354605E+00  1.05630803660810E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535101673283D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615609034348D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195207574494D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535134973469D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615563384765D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195191659270D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150710717632D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150698368234D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010325928074D+06
-(PID.TID 0000.0001)  global fc =  0.918150710717632D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150710717632E+06
+(PID.TID 0000.0001)   local fc =  0.631010337230496D+06
+(PID.TID 0000.0001)  global fc =  0.918150698368234D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150698368234E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455873012543E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.32006416097283E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.47791613824666E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6154,277 +6169,271 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1815070591342E+06  9.1815073581238E+06  9.1815068435034E+06
-(PID.TID 0000.0001) grdchk output (g):   1     2.5731021631509E+01  7.3921716213226E-01 -3.3808474355882E+01
+(PID.TID 0000.0001) grdchk output (c):   1  9.1815070591342E+06  9.1815073581238E+06  9.1815064273059E+06
+(PID.TID 0000.0001) grdchk output (g):   1     4.6540897153318E+01  7.3921716213226E-01 -6.1959708645118E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   2  9.1815070591342E+06  9.1815070080412E+06  9.1815070760322E+06
-(PID.TID 0000.0001) grdchk output (g):   2    -3.3995537087321E+00  6.8523418903351E-01  5.9611560005887E+00
+(PID.TID 0000.0001) grdchk output (c):   2  9.1815070591342E+06  9.1815068595585E+06  9.1815070073697E+06
+(PID.TID 0000.0001) grdchk output (g):   2    -7.3905627243221E+00  6.8523418903351E-01  1.1785455312360E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1815070591342E+06  9.1815069413491E+06  9.1815070487932E+06
-(PID.TID 0000.0001) grdchk output (g):   3    -5.3722034208477E+00  6.1927199363708E-01  9.6750304810263E+00
+(PID.TID 0000.0001) grdchk output (c):   3  9.1815070591342E+06  9.1815068520924E+06  9.1815072540770E+06
+(PID.TID 0000.0001) grdchk output (g):   3    -2.0099228527397E+01  6.1927199363708E-01  3.3456220746155E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   4  9.1815070591342E+06  9.1815073711892E+06  9.1815071071763E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.3200641609728E+01  5.4545587301254E-01 -2.3201117382459E+01
+(PID.TID 0000.0001) grdchk output (c):   4  9.1815070591342E+06  9.1815072792656E+06  9.1815069836823E+06
+(PID.TID 0000.0001) grdchk output (g):   4     1.4779161382467E+01  5.4545587301254E-01 -2.6095063255698E+01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.1274670277934E+01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8007148950039E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5689.4529182314873
-(PID.TID 0000.0001)         System time:   10.198449045419693
-(PID.TID 0000.0001)     Wall clock time:   5741.9942128658295
+(PID.TID 0000.0001)           User time:   5672.8536835908890
+(PID.TID 0000.0001)         System time:   9.4515638351440430
+(PID.TID 0000.0001)     Wall clock time:   5704.0400259494781
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   13.956877887248993
-(PID.TID 0000.0001)         System time:  0.79287901520729065
-(PID.TID 0000.0001)     Wall clock time:   18.522256135940552
+(PID.TID 0000.0001)           User time:   13.959878087043762
+(PID.TID 0000.0001)         System time:  0.81387698650360107
+(PID.TID 0000.0001)     Wall clock time:   17.453164100646973
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2549.4064407348633
-(PID.TID 0000.0001)         System time:   4.3743348121643066
-(PID.TID 0000.0001)     Wall clock time:   2574.5281441211700
+(PID.TID 0000.0001)           User time:   2546.9797430038452
+(PID.TID 0000.0001)         System time:   4.0823789834976196
+(PID.TID 0000.0001)     Wall clock time:   2562.9472749233246
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   551.75207519531250
-(PID.TID 0000.0001)         System time:  0.72988796234130859
-(PID.TID 0000.0001)     Wall clock time:   556.14778017997742
+(PID.TID 0000.0001)           User time:   543.95254516601562
+(PID.TID 0000.0001)         System time:  0.67889714241027832
+(PID.TID 0000.0001)     Wall clock time:   546.73877668380737
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2131347656250000
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   8.2271475791931152
+(PID.TID 0000.0001)           User time:   8.2156982421875000
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.2162208557128906
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5476989746093750
-(PID.TID 0000.0001)         System time:   8.7988615036010742E-002
-(PID.TID 0000.0001)     Wall clock time:   7.0944862365722656
+(PID.TID 0000.0001)           User time:   6.5233459472656250
+(PID.TID 0000.0001)         System time:   8.2986593246459961E-002
+(PID.TID 0000.0001)     Wall clock time:   6.7391936779022217
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.2207946777343750
-(PID.TID 0000.0001)         System time:   7.6991081237792969E-002
-(PID.TID 0000.0001)     Wall clock time:   6.6287546157836914
+(PID.TID 0000.0001)           User time:   6.1711730957031250
+(PID.TID 0000.0001)         System time:   6.7990064620971680E-002
+(PID.TID 0000.0001)     Wall clock time:   6.3488848209381104
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   1.9531250000000000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.9921226501464844E-004
+(PID.TID 0000.0001)     Wall clock time:   1.0197162628173828E-003
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.62219238281250000
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:  0.62443327903747559
+(PID.TID 0000.0001)           User time:  0.69540405273437500
+(PID.TID 0000.0001)         System time:   9.9921226501464844E-004
+(PID.TID 0000.0001)     Wall clock time:  0.69572830200195312
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25729370117187500
+(PID.TID 0000.0001)           User time:  0.25344848632812500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.25889134407043457
+(PID.TID 0000.0001)     Wall clock time:  0.25364518165588379
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   132.17959594726562
-(PID.TID 0000.0001)         System time:   2.6993513107299805E-002
-(PID.TID 0000.0001)     Wall clock time:   132.46271944046021
+(PID.TID 0000.0001)           User time:   131.27954101562500
+(PID.TID 0000.0001)         System time:   1.4998197555541992E-002
+(PID.TID 0000.0001)     Wall clock time:   131.43577861785889
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   45.077392578125000
-(PID.TID 0000.0001)         System time:   8.9974403381347656E-003
-(PID.TID 0000.0001)     Wall clock time:   45.215234994888306
+(PID.TID 0000.0001)           User time:   45.023254394531250
+(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
+(PID.TID 0000.0001)     Wall clock time:   45.136704921722412
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   42.233642578125000
-(PID.TID 0000.0001)         System time:   8.9974403381347656E-003
-(PID.TID 0000.0001)     Wall clock time:   42.369337320327759
+(PID.TID 0000.0001)           User time:   42.193237304687500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   42.300150871276855
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   38.184417724609375
-(PID.TID 0000.0001)         System time:   5.9998035430908203E-003
-(PID.TID 0000.0001)     Wall clock time:   38.245594024658203
+(PID.TID 0000.0001)           User time:   37.990631103515625
+(PID.TID 0000.0001)         System time:   6.0000419616699219E-003
+(PID.TID 0000.0001)     Wall clock time:   38.013788223266602
 (PID.TID 0000.0001)          No. starts:         264
 (PID.TID 0000.0001)           No. stops:         264
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   120.27008056640625
-(PID.TID 0000.0001)         System time:   7.9996585845947266E-003
-(PID.TID 0000.0001)     Wall clock time:   120.42461466789246
+(PID.TID 0000.0001)           User time:   115.96096801757812
+(PID.TID 0000.0001)         System time:   2.9988288879394531E-003
+(PID.TID 0000.0001)     Wall clock time:   116.02584505081177
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.5553894042968750
+(PID.TID 0000.0001)           User time:   2.1014099121093750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.5575993061065674
+(PID.TID 0000.0001)     Wall clock time:   2.1059401035308838
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.271606445312500
-(PID.TID 0000.0001)         System time:   1.9998550415039062E-003
-(PID.TID 0000.0001)     Wall clock time:   14.293150663375854
+(PID.TID 0000.0001)           User time:   14.435302734375000
+(PID.TID 0000.0001)         System time:   9.9945068359375000E-004
+(PID.TID 0000.0001)     Wall clock time:   14.444369316101074
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6144714355468750
+(PID.TID 0000.0001)           User time:   2.5957031250000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.6184124946594238
+(PID.TID 0000.0001)     Wall clock time:   2.5974972248077393
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8941345214843750
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:   4.9023399353027344
+(PID.TID 0000.0001)           User time:   4.8123474121093750
+(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
+(PID.TID 0000.0001)     Wall clock time:   4.8152294158935547
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32693481445312500
-(PID.TID 0000.0001)         System time:   9.9849700927734375E-004
-(PID.TID 0000.0001)     Wall clock time:  0.33132886886596680
+(PID.TID 0000.0001)           User time:  0.49172973632812500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.48819565773010254
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.2316589355468750
-(PID.TID 0000.0001)         System time:   1.9993782043457031E-003
-(PID.TID 0000.0001)     Wall clock time:   7.2500083446502686
+(PID.TID 0000.0001)           User time:   7.2396545410156250
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.2479758262634277
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   120.30859375000000
-(PID.TID 0000.0001)         System time:   4.9993991851806641E-003
-(PID.TID 0000.0001)     Wall clock time:   120.46460437774658
+(PID.TID 0000.0001)           User time:   120.40521240234375
+(PID.TID 0000.0001)         System time:   4.0009021759033203E-003
+(PID.TID 0000.0001)     Wall clock time:   120.60698223114014
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   2.9296875000000000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.1361999511718750E-004
+(PID.TID 0000.0001)     Wall clock time:   9.1266632080078125E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7236938476562500
+(PID.TID 0000.0001)           User time:   1.7287292480468750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8354320526123047
+(PID.TID 0000.0001)     Wall clock time:   1.7295062541961670
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9133300781250000E-003
+(PID.TID 0000.0001)           User time:   9.7656250000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.0122222900390625E-004
+(PID.TID 0000.0001)     Wall clock time:   8.9430809020996094E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5485839843750000
-(PID.TID 0000.0001)         System time:  0.12398099899291992
-(PID.TID 0000.0001)     Wall clock time:   2.9604611396789551
+(PID.TID 0000.0001)           User time:   3.2244873046875000
+(PID.TID 0000.0001)         System time:  0.12997984886169434
+(PID.TID 0000.0001)     Wall clock time:   3.7370326519012451
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7504272460937500
-(PID.TID 0000.0001)         System time:  0.46692895889282227
-(PID.TID 0000.0001)     Wall clock time:   5.2545838356018066
+(PID.TID 0000.0001)           User time:   3.8764038085937500
+(PID.TID 0000.0001)         System time:  0.43593406677246094
+(PID.TID 0000.0001)     Wall clock time:   5.4401807785034180
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   33.534423828125000
-(PID.TID 0000.0001)         System time:  0.82587504386901855
-(PID.TID 0000.0001)     Wall clock time:   36.180649518966675
+(PID.TID 0000.0001)           User time:   32.976684570312500
+(PID.TID 0000.0001)         System time:  0.76088261604309082
+(PID.TID 0000.0001)     Wall clock time:   34.971487998962402
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.9876708984375000
-(PID.TID 0000.0001)         System time:   9.9986791610717773E-002
-(PID.TID 0000.0001)     Wall clock time:   8.1410598754882812
+(PID.TID 0000.0001)           User time:   7.9741821289062500
+(PID.TID 0000.0001)         System time:  0.11998200416564941
+(PID.TID 0000.0001)     Wall clock time:   8.1225261688232422
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
-(PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:   2.0141601562500000E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.9563903808593750E-004
-(PID.TID 0000.0001)          No. starts:          24
-(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.8974609375000000
-(PID.TID 0000.0001)         System time:   9.1986179351806641E-002
-(PID.TID 0000.0001)     Wall clock time:   4.1667160987854004
+(PID.TID 0000.0001)           User time:   3.6535644531250000
+(PID.TID 0000.0001)         System time:   8.7986946105957031E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8515911102294922
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.9453125000000000
-(PID.TID 0000.0001)         System time:   8.2986831665039062E-002
-(PID.TID 0000.0001)     Wall clock time:   4.1212389469146729
+(PID.TID 0000.0001)           User time:   3.8093261718750000
+(PID.TID 0000.0001)         System time:   6.8989276885986328E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9742100238800049
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3118.2468261718750
-(PID.TID 0000.0001)         System time:   4.8562622070312500
-(PID.TID 0000.0001)     Wall clock time:   3140.6557428836823
+(PID.TID 0000.0001)           User time:   3104.4511718750000
+(PID.TID 0000.0001)         System time:   4.3973317146301270
+(PID.TID 0000.0001)     Wall clock time:   3115.8136689662933
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2630.7214355468750
-(PID.TID 0000.0001)         System time:   3.3344907760620117
-(PID.TID 0000.0001)     Wall clock time:   2647.1732411384583
+(PID.TID 0000.0001)           User time:   2623.1225585937500
+(PID.TID 0000.0001)         System time:   2.9625492095947266
+(PID.TID 0000.0001)     Wall clock time:   2629.9570231437683
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   476.62963867187500
-(PID.TID 0000.0001)         System time:   1.1528277397155762
-(PID.TID 0000.0001)     Wall clock time:   481.22056078910828
+(PID.TID 0000.0001)           User time:   470.56103515625000
+(PID.TID 0000.0001)         System time:   1.0488400459289551
+(PID.TID 0000.0001)     Wall clock time:   473.83257317543030
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4902343750000000
+(PID.TID 0000.0001)           User time:   5.4389648437500000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.4962882995605469
+(PID.TID 0000.0001)     Wall clock time:   5.4425203800201416
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.3925781250000000E-002
+(PID.TID 0000.0001)           User time:   1.7578125000000000E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8729209899902344E-002
+(PID.TID 0000.0001)     Wall clock time:   1.8502712249755859E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   427.57788085937500
-(PID.TID 0000.0001)         System time:   7.9987049102783203E-002
-(PID.TID 0000.0001)     Wall clock time:   428.31525897979736
+(PID.TID 0000.0001)           User time:   422.20605468750000
+(PID.TID 0000.0001)         System time:   6.8989276885986328E-002
+(PID.TID 0000.0001)     Wall clock time:   422.51704096794128
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.0942382812500000
-(PID.TID 0000.0001)         System time:  0.28095722198486328
-(PID.TID 0000.0001)     Wall clock time:   7.5673658847808838
+(PID.TID 0000.0001)           User time:   5.9316406250000000
+(PID.TID 0000.0001)         System time:  0.24596261978149414
+(PID.TID 0000.0001)     Wall clock time:   7.0676541328430176
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.3899078369140625E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4340152740478516E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   36.809814453125000
-(PID.TID 0000.0001)         System time:  0.78688383102416992
-(PID.TID 0000.0001)     Wall clock time:   39.171441316604614
+(PID.TID 0000.0001)           User time:   36.341796875000000
+(PID.TID 0000.0001)         System time:  0.73288774490356445
+(PID.TID 0000.0001)     Wall clock time:   38.153427600860596
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   4.3457031250000000E-002
-(PID.TID 0000.0001)         System time:   3.0002593994140625E-003
-(PID.TID 0000.0001)     Wall clock time:   4.9397945404052734E-002
+(PID.TID 0000.0001)           User time:   3.3691406250000000E-002
+(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
+(PID.TID 0000.0001)     Wall clock time:   3.8621902465820312E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6464,9 +6473,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =        1028438
+(PID.TID 0000.0001) //            No. barriers =        1028446
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =        1028438
+(PID.TID 0000.0001) //     Total barrier spins =        1028446
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecmwf.txt
+++ b/global_oce_llc90/results/output_adm.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67u
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node027
-(PID.TID 0000.0001) // Build date:        Tue Jan 26 12:41:34 EST 2021
+(PID.TID 0000.0001) // Build host:        node035
+(PID.TID 0000.0001) // Build date:        Wed Mar 17 01:03:49 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node027
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node035
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -762,6 +762,9 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) inAdExact = /* get an exact adjoint (no approximation) */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
@@ -1999,8 +2002,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            6
-(PID.TID 0000.0001) ctrl_init: control vector length:         7645498
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            6
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:         7645498
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2023,18 +2026,26 @@
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
 (PID.TID 0000.0001)       weight     = wt_theta.data
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  preprocess = WC01
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_salt
 (PID.TID 0000.0001)       weight     = wt_salt.data
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  preprocess = WC01
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_kapgm.data
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001)  preprocess = WC01
 (PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_atemp
 (PID.TID 0000.0001)       weight     = wt_atemp.data
+(PID.TID 0000.0001)       index      =  0301
+(PID.TID 0000.0001)       ncvarindex =  0401
 (PID.TID 0000.0001)       period     =  00000000 040000
 (PID.TID 0000.0001)       preprocess = docycle
 (PID.TID 0000.0001)         param. (int.)=      1
@@ -2042,6 +2053,8 @@
 (PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_precip
 (PID.TID 0000.0001)       weight     = wt_precip.data
+(PID.TID 0000.0001)       index      =  0302
+(PID.TID 0000.0001)       ncvarindex =  0402
 (PID.TID 0000.0001)       period     =  00000000 040000
 (PID.TID 0000.0001)       preprocess = docycle
 (PID.TID 0000.0001)         param. (int.)=      2
@@ -2049,6 +2062,8 @@
 (PID.TID 0000.0001)  -> time variable 2D control, gentim2d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_swdown
 (PID.TID 0000.0001)       weight     = wt_swdown.data
+(PID.TID 0000.0001)       index      =  0303
+(PID.TID 0000.0001)       ncvarindex =  0403
 (PID.TID 0000.0001)       period     =  00000000 040000
 (PID.TID 0000.0001)       preprocess = WC01
 (PID.TID 0000.0001) 
@@ -4785,20 +4800,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.73784634266963E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.78451867102101E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.75680295093657E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.72004253668279E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.71227088546651E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.70388041845407E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.69565508445409E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411949E+00  1.69262228492724E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.73784634266963E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.78451867102115E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.75680295093601E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.72004253668318E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.71227088546763E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.70388041845432E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.69565508445369E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.69262228492649E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501472191576D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501472189601D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417647979D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4806,14 +4821,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388889849555D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388889847581D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677265576D+06
-(PID.TID 0000.0001)  global fc =  0.918388889849555D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889849555E+06
+(PID.TID 0000.0001)  global fc =  0.918388889847581D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889847581E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.26981954574585E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.41676160506904E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.41686034388840E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -4842,20 +4857,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.73784634267100E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.78451867102444E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.75680295094298E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.72004253670213E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.71227088550988E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411955E+00  1.70388041852305E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.69565508452370E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.69262228492266E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.73784634267100E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.78451867102413E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.75680295094325E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.72004253670316E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.71227088551012E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.70388041852286E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.69565508452390E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411949E+00  1.69262228492264E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501500873154D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501500874861D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417778489D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4863,11 +4878,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388918661643D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388918663349D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677266851D+06
-(PID.TID 0000.0001)  global fc =  0.918388918661643D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388918661643E+06
+(PID.TID 0000.0001)  global fc =  0.918388918663349D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388918663349E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -4893,20 +4908,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.73784634266966E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78451867102133E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.75680295093732E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.72004253668341E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.71227088546778E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.70388041845567E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.69565508445517E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411949E+00  1.69262228492872E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.73784634266966E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.78451867102070E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.75680295093688E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.72004253668297E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.71227088546819E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.70388041845664E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.69565508445505E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69262228492915E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501471716507D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501471715117D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417668789D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4914,14 +4929,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388889395297D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388889393906D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677265576D+06
-(PID.TID 0000.0001)  global fc =  0.918388889395297D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889395297E+06
+(PID.TID 0000.0001)  global fc =  0.918388889393906D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889393906E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.31621408462524E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.46331731230021E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.46347214467824E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -4950,20 +4965,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.73784634267096E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.78451867102435E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.75680295094273E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.72004253670184E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.71227088550883E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.70388041852197E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.69565508452034E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69262228492229E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.73784634267096E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102424E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.75680295094184E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.72004253670083E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.71227088550914E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.70388041852110E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69565508452014E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.69262228492060E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501501996199D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501501996853D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417823651D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4971,11 +4986,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388919829850D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388919830504D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677266193D+06
-(PID.TID 0000.0001)  global fc =  0.918388919829850D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388919829850E+06
+(PID.TID 0000.0001)  global fc =  0.918388919830504D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388919830504E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5001,20 +5016,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.73784634266969E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.78451867102054E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.75680295093655E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.72004253668380E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411908E+00  1.71227088546905E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.70388041845903E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411910E+00  1.69565508445770E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.69262228492998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.73784634266969E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.78451867102085E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.75680295093716E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.72004253668390E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411952E+00  1.71227088546908E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.70388041845795E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69565508445820E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69262228492968E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501470599935D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501470598155D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417707705D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5022,14 +5037,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388888317640D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388888315861D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677265848D+06
-(PID.TID 0000.0001)  global fc =  0.918388888317640D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388888317640E+06
+(PID.TID 0000.0001)  global fc =  0.918388888315861D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388888315861E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.43534650802612E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.57561052590609E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.57573219388723E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5058,20 +5073,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.73784634267093E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.78451867102422E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.75680295094293E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411906E+00  1.72004253670249E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.71227088550811E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.70388041851945E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.69565508451820E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.69262228492031E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.73784634267093E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78451867102423E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.75680295094426E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.72004253670117E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.71227088550773E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.70388041851824E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.69565508451906E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.69262228492060E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501504513250D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501504513324D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417949201D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5079,11 +5094,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388922472451D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388922472525D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677266193D+06
-(PID.TID 0000.0001)  global fc =  0.918388922472451D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388922472451E+06
+(PID.TID 0000.0001)  global fc =  0.918388922472525D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388922472525E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5109,20 +5124,20 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.73784634266973E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.78451867102142E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.75680295093622E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.72004253668421E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.71227088546984E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411949E+00  1.70388041846032E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411902E+00  1.69565508446080E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69262228493153E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.73784634266973E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.78451867102144E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411905E+00  1.75680295093611E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.72004253668371E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.71227088546942E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.70388041846043E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.69565508446190E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.69262228493063E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501468077071D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501468075194D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417751557D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5130,14 +5145,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388885838629D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388885836751D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265888D+06
-(PID.TID 0000.0001)  global fc =  0.918388885838629D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388885838629E+06
+(PID.TID 0000.0001)   local fc =  0.630760677265848D+06
+(PID.TID 0000.0001)  global fc =  0.918388885836751D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388885836751E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.70237884521484E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.83169107884169E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.83178866282105E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -5151,265 +5166,259 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1838890402863E+06  9.1838891818479E+06  9.1838888984956E+06
-(PID.TID 0000.0001) grdchk output (g):   1     1.4167616050690E+01  1.2698195457458E+01 -1.1571885140332E-01
+(PID.TID 0000.0001) grdchk output (c):   1  9.1838890402863E+06  9.1838891818479E+06  9.1838888984758E+06
+(PID.TID 0000.0001) grdchk output (g):   1     1.4168603438884E+01  1.2698195457458E+01 -1.1579660955383E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   2  9.1838890402863E+06  9.1838891866164E+06  9.1838888939530E+06
-(PID.TID 0000.0001) grdchk output (g):   2     1.4633173123002E+01  1.3162140846252E+01 -1.1176238682847E-01
+(PID.TID 0000.0001) grdchk output (c):   2  9.1838890402863E+06  9.1838891866335E+06  9.1838888939391E+06
+(PID.TID 0000.0001) grdchk output (g):   2     1.4634721446782E+01  1.3162140846252E+01 -1.1188002147456E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1838890402863E+06  9.1838891982985E+06  9.1838888831764E+06
-(PID.TID 0000.0001) grdchk output (g):   3     1.5756105259061E+01  1.4353465080261E+01 -9.7721363514412E-02
+(PID.TID 0000.0001) grdchk output (c):   3  9.1838890402863E+06  9.1838891983050E+06  9.1838888831586E+06
+(PID.TID 0000.0001) grdchk output (g):   3     1.5757321938872E+01  1.4353465080261E+01 -9.7806129095732E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   4  9.1838890402863E+06  9.1838892247245E+06  9.1838888583863E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.8316910788417E+01  1.7023788452148E+01 -7.5959727759965E-02
+(PID.TID 0000.0001) grdchk output (c):   4  9.1838890402863E+06  9.1838892247252E+06  9.1838888583675E+06
+(PID.TID 0000.0001) grdchk output (g):   4     1.8317886628211E+01  1.7023788452148E+01 -7.6017049888727E-02
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.0149018278654E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.0157586419985E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5630.7377780377865
-(PID.TID 0000.0001)         System time:   9.3545784354209900
-(PID.TID 0000.0001)     Wall clock time:   5670.5727870464325
+(PID.TID 0000.0001)           User time:   5779.4355058670044
+(PID.TID 0000.0001)         System time:   9.1886032223701477
+(PID.TID 0000.0001)     Wall clock time:   5810.3810679912567
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   13.866892188787460
-(PID.TID 0000.0001)         System time:  0.78987997770309448
-(PID.TID 0000.0001)     Wall clock time:   18.023680925369263
+(PID.TID 0000.0001)           User time:   13.666922569274902
+(PID.TID 0000.0001)         System time:  0.81787604093551636
+(PID.TID 0000.0001)     Wall clock time:   16.922663927078247
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2531.0813350677490
-(PID.TID 0000.0001)         System time:   3.8564140796661377
-(PID.TID 0000.0001)     Wall clock time:   2550.5135269165039
+(PID.TID 0000.0001)           User time:   2525.2761516571045
+(PID.TID 0000.0001)         System time:   3.6444460153579712
+(PID.TID 0000.0001)     Wall clock time:   2540.9064788818359
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   511.69296264648438
-(PID.TID 0000.0001)         System time:  0.68389630317687988
-(PID.TID 0000.0001)     Wall clock time:   515.31596994400024
+(PID.TID 0000.0001)           User time:   503.77294921875000
+(PID.TID 0000.0001)         System time:  0.61590576171875000
+(PID.TID 0000.0001)     Wall clock time:   507.02375245094299
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2219238281250000
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   8.2336275577545166
+(PID.TID 0000.0001)           User time:   8.2141723632812500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.2186906337738037
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.8489379882812500
-(PID.TID 0000.0001)         System time:   9.7983598709106445E-002
-(PID.TID 0000.0001)     Wall clock time:   9.3237473964691162
+(PID.TID 0000.0001)           User time:   8.4838867187500000
+(PID.TID 0000.0001)         System time:   9.3985557556152344E-002
+(PID.TID 0000.0001)     Wall clock time:   8.7846446037292480
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   8.5527954101562500
-(PID.TID 0000.0001)         System time:   8.8984847068786621E-002
-(PID.TID 0000.0001)     Wall clock time:   8.9874796867370605
+(PID.TID 0000.0001)           User time:   8.1060485839843750
+(PID.TID 0000.0001)         System time:   7.4988842010498047E-002
+(PID.TID 0000.0001)     Wall clock time:   8.3700885772705078
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:   9.8586082458496094E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.0070800781250000E-003
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.66940307617187500
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:  0.66984677314758301
+(PID.TID 0000.0001)           User time:  0.74258422851562500
+(PID.TID 0000.0001)         System time:   9.9897384643554688E-004
+(PID.TID 0000.0001)     Wall clock time:  0.74217152595520020
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25640869140625000
+(PID.TID 0000.0001)           User time:  0.26229858398437500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.25682139396667480
+(PID.TID 0000.0001)     Wall clock time:  0.25720024108886719
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   89.631530761718750
-(PID.TID 0000.0001)         System time:   2.4997472763061523E-002
-(PID.TID 0000.0001)     Wall clock time:   89.787221908569336
+(PID.TID 0000.0001)           User time:   86.978790283203125
+(PID.TID 0000.0001)         System time:   1.1999011039733887E-002
+(PID.TID 0000.0001)     Wall clock time:   87.556930065155029
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   38.210357666015625
-(PID.TID 0000.0001)         System time:   7.0004463195800781E-003
-(PID.TID 0000.0001)     Wall clock time:   38.274462699890137
+(PID.TID 0000.0001)           User time:   38.128845214843750
+(PID.TID 0000.0001)         System time:   5.9989690780639648E-003
+(PID.TID 0000.0001)     Wall clock time:   38.336974859237671
 (PID.TID 0000.0001)          No. starts:         264
 (PID.TID 0000.0001)           No. stops:         264
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   120.24252319335938
-(PID.TID 0000.0001)         System time:   8.9961290359497070E-003
-(PID.TID 0000.0001)     Wall clock time:   120.34626102447510
+(PID.TID 0000.0001)           User time:   115.96044921875000
+(PID.TID 0000.0001)         System time:   1.9990205764770508E-003
+(PID.TID 0000.0001)     Wall clock time:   116.02158355712891
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0361938476562500
+(PID.TID 0000.0001)           User time:   2.3433227539062500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.0295770168304443
+(PID.TID 0000.0001)     Wall clock time:   2.3460922241210938
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.048522949218750
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   16.067752838134766
+(PID.TID 0000.0001)           User time:   18.832244873046875
+(PID.TID 0000.0001)         System time:   9.9945068359375000E-004
+(PID.TID 0000.0001)     Wall clock time:   18.847306489944458
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6210632324218750
+(PID.TID 0000.0001)           User time:   2.5991821289062500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.6173150539398193
+(PID.TID 0000.0001)     Wall clock time:   2.5981554985046387
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8109436035156250
+(PID.TID 0000.0001)           User time:   4.8046569824218750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.8130936622619629
+(PID.TID 0000.0001)     Wall clock time:   4.8072078227996826
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.26129150390625000
+(PID.TID 0000.0001)           User time:  0.48919677734375000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.26678466796875000
+(PID.TID 0000.0001)     Wall clock time:  0.48540234565734863
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.6300659179687500
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:   6.6394519805908203
+(PID.TID 0000.0001)           User time:   8.7794494628906250
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.7841868400573730
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   118.07803344726562
-(PID.TID 0000.0001)         System time:   3.9992332458496094E-003
-(PID.TID 0000.0001)     Wall clock time:   118.16772150993347
+(PID.TID 0000.0001)           User time:   118.02944946289062
+(PID.TID 0000.0001)         System time:   5.9998035430908203E-003
+(PID.TID 0000.0001)     Wall clock time:   118.25853109359741
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
 (PID.TID 0000.0001)           User time:   9.7656250000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.1147422790527344E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0265274047851562E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4367980957031250
-(PID.TID 0000.0001)         System time:   1.0000467300415039E-003
-(PID.TID 0000.0001)     Wall clock time:   1.4396636486053467
+(PID.TID 0000.0001)           User time:   1.4347839355468750
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.4386930465698242
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9836425781250000E-003
+(PID.TID 0000.0001)           User time:   9.7656250000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.8977813720703125E-004
+(PID.TID 0000.0001)     Wall clock time:   8.8453292846679688E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2696533203125000
-(PID.TID 0000.0001)         System time:  0.12798106670379639
-(PID.TID 0000.0001)     Wall clock time:   2.7664585113525391
+(PID.TID 0000.0001)           User time:   2.1356811523437500
+(PID.TID 0000.0001)         System time:   9.2985868453979492E-002
+(PID.TID 0000.0001)     Wall clock time:   2.6505498886108398
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8183898925781250
-(PID.TID 0000.0001)         System time:  0.40793800354003906
-(PID.TID 0000.0001)     Wall clock time:   5.9658300876617432
+(PID.TID 0000.0001)           User time:   3.2827148437500000
+(PID.TID 0000.0001)         System time:  0.40693807601928711
+(PID.TID 0000.0001)     Wall clock time:   4.7481293678283691
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   24.456542968750000
-(PID.TID 0000.0001)         System time:  0.62190508842468262
-(PID.TID 0000.0001)     Wall clock time:   26.592047691345215
+(PID.TID 0000.0001)           User time:   24.245208740234375
+(PID.TID 0000.0001)         System time:  0.62690663337707520
+(PID.TID 0000.0001)     Wall clock time:   26.107238292694092
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   8.0475769042968750
-(PID.TID 0000.0001)         System time:  0.10798430442810059
-(PID.TID 0000.0001)     Wall clock time:   8.1846468448638916
+(PID.TID 0000.0001)           User time:   8.2110290527343750
+(PID.TID 0000.0001)         System time:  0.14197826385498047
+(PID.TID 0000.0001)     Wall clock time:   8.3772389888763428
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
-(PID.TID 0000.0001)   Seconds in section "I/O (WRITE)        [ADJOINT LOOP]":
-(PID.TID 0000.0001)           User time:   1.0986328125000000E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8705596923828125E-004
-(PID.TID 0000.0001)          No. starts:          24
-(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.7812500000000000
-(PID.TID 0000.0001)         System time:   8.0986976623535156E-002
-(PID.TID 0000.0001)     Wall clock time:   4.0157880783081055
+(PID.TID 0000.0001)           User time:   3.6423339843750000
+(PID.TID 0000.0001)         System time:  0.11298274993896484
+(PID.TID 0000.0001)     Wall clock time:   3.8153359889984131
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.8493652343750000
-(PID.TID 0000.0001)         System time:   9.3986034393310547E-002
-(PID.TID 0000.0001)     Wall clock time:   4.0175318717956543
+(PID.TID 0000.0001)           User time:   3.6525878906250000
+(PID.TID 0000.0001)         System time:   7.1989059448242188E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8308110237121582
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3078.1589355468750
-(PID.TID 0000.0001)         System time:   4.5333113670349121
-(PID.TID 0000.0001)     Wall clock time:   3094.0021471977234
+(PID.TID 0000.0001)           User time:   3233.1965332031250
+(PID.TID 0000.0001)         System time:   4.5413093566894531
+(PID.TID 0000.0001)     Wall clock time:   3244.9056580066681
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2630.4912109375000
-(PID.TID 0000.0001)         System time:   3.1575217247009277
-(PID.TID 0000.0001)     Wall clock time:   2639.8177230358124
+(PID.TID 0000.0001)           User time:   2790.3645019531250
+(PID.TID 0000.0001)         System time:   3.1405229568481445
+(PID.TID 0000.0001)     Wall clock time:   2797.9484555721283
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   436.46459960937500
-(PID.TID 0000.0001)         System time:   1.0148434638977051
-(PID.TID 0000.0001)     Wall clock time:   441.26080775260925
+(PID.TID 0000.0001)           User time:   431.92700195312500
+(PID.TID 0000.0001)         System time:   1.0248456001281738
+(PID.TID 0000.0001)     Wall clock time:   434.83320546150208
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5300292968750000
+(PID.TID 0000.0001)           User time:   5.4240722656250000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.5389161109924316
+(PID.TID 0000.0001)     Wall clock time:   5.4232594966888428
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.0996093750000000E-002
+(PID.TID 0000.0001)           User time:   2.3681640625000000E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8732309341430664E-002
+(PID.TID 0000.0001)     Wall clock time:   1.8537759780883789E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   395.32885742187500
-(PID.TID 0000.0001)         System time:   9.7985267639160156E-002
-(PID.TID 0000.0001)     Wall clock time:   395.77678346633911
+(PID.TID 0000.0001)           User time:   391.63916015625000
+(PID.TID 0000.0001)         System time:   7.4988842010498047E-002
+(PID.TID 0000.0001)     Wall clock time:   392.03835821151733
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.0705566406250000
-(PID.TID 0000.0001)         System time:  0.28895473480224609
-(PID.TID 0000.0001)     Wall clock time:   7.3525209426879883
+(PID.TID 0000.0001)           User time:   5.9538574218750000
+(PID.TID 0000.0001)         System time:  0.29895401000976562
+(PID.TID 0000.0001)     Wall clock time:   6.9063036441802979
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2207031250000000E-003
+(PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.3334026336669922E-003
+(PID.TID 0000.0001)     Wall clock time:   2.3100376129150391E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   28.858642578125000
-(PID.TID 0000.0001)         System time:  0.62590551376342773
-(PID.TID 0000.0001)     Wall clock time:   30.805893421173096
+(PID.TID 0000.0001)           User time:   28.264892578125000
+(PID.TID 0000.0001)         System time:  0.65090274810791016
+(PID.TID 0000.0001)     Wall clock time:   29.815967082977295
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   4.0283203125000000E-002
-(PID.TID 0000.0001)         System time:   9.9897384643554688E-004
-(PID.TID 0000.0001)     Wall clock time:   1.1464850902557373
+(PID.TID 0000.0001)           User time:   3.1494140625000000E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6692857742309570E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -5449,9 +5458,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         904642
+(PID.TID 0000.0001) //            No. barriers =         904650
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         904642
+(PID.TID 0000.0001) //     Total barrier spins =         904650
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #438: update 2 ADM output from exp.: global_oce_llc90.
+    Fixing missing re-initialisation of recip_hFac change gradient-check of
+    ecco_v4 & ecmwf AD tests. Update reference output (from engaging, gfortran).
   - post PR #433: update FWD output of exp.: global_ocean.gm_k3d & .gm_res since
     both use quasiHydrostatic=T (-> affects results @ machine trunc. level).
 


### PR DESCRIPTION
Update 2 ADM output from exp.: global_oce_llc90 (ecco_v4 & ecmwf):
 
Fixing missing re-initialisation of recip_hFac in PR #438 change gradient-check of ecco_v4 and ecmwf AD tests.
Update reference output (from engaging, using gfortran with -devel, run on 32.procs)