### PR TITLE
Update 1 AD output after merging PR 449

### DIFF
--- a/global_oce_llc90/results/output_adm.ecco_v4.txt
+++ b/global_oce_llc90/results/output_adm.ecco_v4.txt
@@ -7,8 +7,8 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // MITgcmUV version:  checkpoint67w
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node035
-(PID.TID 0000.0001) // Build date:        Wed Mar 17 01:03:49 EDT 2021
+(PID.TID 0000.0001) // Build host:        node139
+(PID.TID 0000.0001) // Build date:        Sat Mar 27 04:49:04 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node035
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node139
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -5477,62 +5477,62 @@
 (PID.TID 0000.0001)  global fc =  0.918150705913423D+07
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00842379673058E+00  1.08485292697898E+00
- cg2d: Sum(rhs),rhsMax =   3.00820101364232E+00  1.09147064699317E+00
- cg2d: Sum(rhs),rhsMax =   3.00744813208199E+00  1.09526561772929E+00
- cg2d: Sum(rhs),rhsMax =   3.00655862155437E+00  1.09412541366676E+00
+ cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588518803E+00  1.09558808552461E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954214495678E+00  1.09443701612858E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.00715282468911E+00  1.08957477524619E+00
- cg2d: Sum(rhs),rhsMax =   3.00895609565287E+00  1.08205900615285E+00
- cg2d: Sum(rhs),rhsMax =   3.01167338807128E+00  1.07063433073072E+00
- cg2d: Sum(rhs),rhsMax =   3.01504541917231E+00  1.05603777270388E+00
+ cg2d: Sum(rhs),rhsMax =   3.01016045548307E+00  1.08987441574900E+00
+ cg2d: Sum(rhs),rhsMax =   3.01200063669187E+00  1.08234533946216E+00
+ cg2d: Sum(rhs),rhsMax =   3.01472254612810E+00  1.07091042398987E+00
+ cg2d: Sum(rhs),rhsMax =   3.01809829994306E+00  1.05630803624323E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.00731600880274E+00  1.08957477522675E+00
- cg2d: Sum(rhs),rhsMax =   3.00910013814986E+00  1.08205965970385E+00
- cg2d: Sum(rhs),rhsMax =   3.01174510479852E+00  1.07063556825250E+00
- cg2d: Sum(rhs),rhsMax =   3.01506338999683E+00  1.05603970310870E+00
+ cg2d: Sum(rhs),rhsMax =   3.01016045548307E+00  1.08987441574900E+00
+ cg2d: Sum(rhs),rhsMax =   3.01200063669187E+00  1.08234533946216E+00
+ cg2d: Sum(rhs),rhsMax =   3.01472254612810E+00  1.07091042398987E+00
+ cg2d: Sum(rhs),rhsMax =   3.01809829994306E+00  1.05630803624323E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.01506338748869E+00  1.05603969369022E+00
+ cg2d: Sum(rhs),rhsMax =   3.01809804902057E+00  1.05630806396422E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.01506338748869E+00  1.05603969369022E+00
+ cg2d: Sum(rhs),rhsMax =   3.01809804902057E+00  1.05630806396422E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -3.55076211489003E-18  1.83988217938863E-04
- cg2d: Sum(rhs),rhsMax =   3.01174482585250E+00  1.07063558465413E+00
- cg2d: Sum(rhs),rhsMax =   3.01174482585250E+00  1.07063558465413E+00
+ cg2d: Sum(rhs),rhsMax =   2.71050543121376E-18  1.83998182747982E-04
+ cg2d: Sum(rhs),rhsMax =   3.01472242461314E+00  1.07091042206398E+00
+ cg2d: Sum(rhs),rhsMax =   3.01472242461314E+00  1.07091042206398E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -5.36680075380325E-18  3.43199154995069E-04
- cg2d: Sum(rhs),rhsMax =   3.00910011050830E+00  1.08205963498963E+00
- cg2d: Sum(rhs),rhsMax =   3.00910011050830E+00  1.08205963498963E+00
+ cg2d: Sum(rhs),rhsMax =   2.46655994240452E-18  3.43198702012042E-04
+ cg2d: Sum(rhs),rhsMax =   3.01200061493434E+00  1.08234535716197E+00
+ cg2d: Sum(rhs),rhsMax =   3.01200061493434E+00  1.08234535716197E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.62630325872826E-19  8.65048465559207E-04
- cg2d: Sum(rhs),rhsMax =   3.00731598852462E+00  1.08957475885402E+00
- cg2d: Sum(rhs),rhsMax =   3.00731598852462E+00  1.08957475885402E+00
+ cg2d: Sum(rhs),rhsMax =   6.39679281766448E-18  8.65048493731531E-04
+ cg2d: Sum(rhs),rhsMax =   3.01016033991108E+00  1.08987441826371E+00
+ cg2d: Sum(rhs),rhsMax =   3.01016033991108E+00  1.08987441826371E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.10588621593521E-17  1.48391646735509E-03
+ cg2d: Sum(rhs),rhsMax =  -8.78203759713259E-18  1.48391646097158E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00830335294239E+00  1.08485292699021E+00
- cg2d: Sum(rhs),rhsMax =   3.00808653195366E+00  1.09146863446101E+00
- cg2d: Sum(rhs),rhsMax =   3.00733802349313E+00  1.09526232825629E+00
- cg2d: Sum(rhs),rhsMax =   3.00645397069904E+00  1.09412108444468E+00
- cg2d: Sum(rhs),rhsMax =   3.00645408490495E+00  1.09412108021522E+00
- cg2d: Sum(rhs),rhsMax =   3.00645408490495E+00  1.09412108021522E+00
+ cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588518803E+00  1.09558808552461E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954214495678E+00  1.09443701612858E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954232920302E+00  1.09443700049974E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954232920302E+00  1.09443700049974E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.50521303491303E-19  2.12701399815437E-03
- cg2d: Sum(rhs),rhsMax =   3.00733785773616E+00  1.09526234438945E+00
- cg2d: Sum(rhs),rhsMax =   3.00733785773616E+00  1.09526234438945E+00
+ cg2d: Sum(rhs),rhsMax =   3.90312782094782E-18  2.12700167827571E-03
+ cg2d: Sum(rhs),rhsMax =   3.01041588832618E+00  1.09558808150575E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588832618E+00  1.09558808150575E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.77809156287623E-17  2.73193510782245E-03
- cg2d: Sum(rhs),rhsMax =   3.00808651882477E+00  1.09146863209926E+00
- cg2d: Sum(rhs),rhsMax =   3.00808651882477E+00  1.09146863209926E+00
+ cg2d: Sum(rhs),rhsMax =   1.90819582357449E-17  2.73193000324363E-03
+ cg2d: Sum(rhs),rhsMax =   3.01104383800070E+00  1.09179583702524E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104383800070E+00  1.09179583702524E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -4.11996825544492E-17  3.23778143564412E-03
+ cg2d: Sum(rhs),rhsMax =   8.67361737988404E-18  3.23777153727352E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00830362252477E+00  1.08485294641564E+00
+ cg2d: Sum(rhs),rhsMax =   3.01093922340877E+00  1.08516769462177E+00
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00830362252477E+00  1.08485294641564E+00
+ cg2d: Sum(rhs),rhsMax =   3.01093922340877E+00  1.08516769462177E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.04083408558608E-17  3.72673658791861E-03
+ cg2d: Sum(rhs),rhsMax =  -1.38777878078145E-17  3.72673458855032E-03
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5734,7 +5734,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150642730589D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150642730589E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217162132263E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217221736908E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.65408971533179E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
@@ -6014,7 +6014,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150725407700D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150725407700E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19271993637085E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19272053241730E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.00992285273969E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
@@ -6154,7 +6154,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150698368234D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150698368234E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455873012543E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455932617188E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.47791613824666E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
@@ -6170,7 +6170,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   1  9.1815070591342E+06  9.1815073581238E+06  9.1815064273059E+06
-(PID.TID 0000.0001) grdchk output (g):   1     4.6540897153318E+01  7.3921716213226E-01 -6.1959708645118E+01
+(PID.TID 0000.0001) grdchk output (g):   1     4.6540897153318E+01  7.3921722173691E-01 -6.1959703568543E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   2  9.1815070591342E+06  9.1815068595585E+06  9.1815070073697E+06
@@ -6178,262 +6178,262 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   3  9.1815070591342E+06  9.1815068520924E+06  9.1815072540770E+06
-(PID.TID 0000.0001) grdchk output (g):   3    -2.0099228527397E+01  6.1927199363708E-01  3.3456220746155E+01
+(PID.TID 0000.0001) grdchk output (g):   3    -2.0099228527397E+01  6.1927205324173E-01  3.3456217622259E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   4  9.1815070591342E+06  9.1815072792656E+06  9.1815069836823E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.4779161382467E+01  5.4545587301254E-01 -2.6095063255698E+01
+(PID.TID 0000.0001) grdchk output (g):   4     1.4779161382467E+01  5.4545593261719E-01 -2.6095060294887E+01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8007148950039E+01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8007145685394E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5672.8536835908890
-(PID.TID 0000.0001)         System time:   9.4515638351440430
-(PID.TID 0000.0001)     Wall clock time:   5704.0400259494781
+(PID.TID 0000.0001)           User time:   5662.0091226994991
+(PID.TID 0000.0001)         System time:   14.339819580316544
+(PID.TID 0000.0001)     Wall clock time:   5741.8593268394470
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   13.959878087043762
-(PID.TID 0000.0001)         System time:  0.81387698650360107
-(PID.TID 0000.0001)     Wall clock time:   17.453164100646973
+(PID.TID 0000.0001)           User time:   13.187994807958603
+(PID.TID 0000.0001)         System time:  0.87886705994606018
+(PID.TID 0000.0001)     Wall clock time:   19.967828035354614
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2546.9797430038452
-(PID.TID 0000.0001)         System time:   4.0823789834976196
-(PID.TID 0000.0001)     Wall clock time:   2562.9472749233246
+(PID.TID 0000.0001)           User time:   2537.6651220321655
+(PID.TID 0000.0001)         System time:   6.0950729846954346
+(PID.TID 0000.0001)     Wall clock time:   2580.0323970317841
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   543.95254516601562
-(PID.TID 0000.0001)         System time:  0.67889714241027832
-(PID.TID 0000.0001)     Wall clock time:   546.73877668380737
+(PID.TID 0000.0001)           User time:   541.66915893554688
+(PID.TID 0000.0001)         System time:  0.75388503074645996
+(PID.TID 0000.0001)     Wall clock time:   547.47098922729492
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2156982421875000
+(PID.TID 0000.0001)           User time:   8.1958618164062500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.2162208557128906
+(PID.TID 0000.0001)     Wall clock time:   8.2005610466003418
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5233459472656250
-(PID.TID 0000.0001)         System time:   8.2986593246459961E-002
-(PID.TID 0000.0001)     Wall clock time:   6.7391936779022217
+(PID.TID 0000.0001)           User time:   5.6217346191406250
+(PID.TID 0000.0001)         System time:  0.11498165130615234
+(PID.TID 0000.0001)     Wall clock time:   6.6663975715637207
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.1711730957031250
-(PID.TID 0000.0001)         System time:   6.7990064620971680E-002
-(PID.TID 0000.0001)     Wall clock time:   6.3488848209381104
+(PID.TID 0000.0001)           User time:   5.2392883300781250
+(PID.TID 0000.0001)         System time:  0.10498547554016113
+(PID.TID 0000.0001)     Wall clock time:   6.0534243583679199
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
+(PID.TID 0000.0001)           User time:   9.7656250000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0197162628173828E-003
+(PID.TID 0000.0001)     Wall clock time:   1.0461807250976562E-003
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.69540405273437500
-(PID.TID 0000.0001)         System time:   9.9921226501464844E-004
-(PID.TID 0000.0001)     Wall clock time:  0.69572830200195312
+(PID.TID 0000.0001)           User time:  0.60583496093750000
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.60571885108947754
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25344848632812500
+(PID.TID 0000.0001)           User time:  0.25326538085937500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.25364518165588379
+(PID.TID 0000.0001)     Wall clock time:  0.25680208206176758
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   131.27954101562500
-(PID.TID 0000.0001)         System time:   1.4998197555541992E-002
-(PID.TID 0000.0001)     Wall clock time:   131.43577861785889
+(PID.TID 0000.0001)           User time:   131.95867919921875
+(PID.TID 0000.0001)         System time:   2.0996332168579102E-002
+(PID.TID 0000.0001)     Wall clock time:   132.48725628852844
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   45.023254394531250
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:   45.136704921722412
+(PID.TID 0000.0001)           User time:   44.901550292968750
+(PID.TID 0000.0001)         System time:   4.9982070922851562E-003
+(PID.TID 0000.0001)     Wall clock time:   45.189737081527710
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   42.193237304687500
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   42.300150871276855
+(PID.TID 0000.0001)           User time:   42.008697509765625
+(PID.TID 0000.0001)         System time:   2.9981136322021484E-003
+(PID.TID 0000.0001)     Wall clock time:   42.281084537506104
 (PID.TID 0000.0001)          No. starts:          88
 (PID.TID 0000.0001)           No. stops:          88
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   37.990631103515625
-(PID.TID 0000.0001)         System time:   6.0000419616699219E-003
-(PID.TID 0000.0001)     Wall clock time:   38.013788223266602
+(PID.TID 0000.0001)           User time:   38.254913330078125
+(PID.TID 0000.0001)         System time:   8.9988708496093750E-003
+(PID.TID 0000.0001)     Wall clock time:   38.300113201141357
 (PID.TID 0000.0001)          No. starts:         264
 (PID.TID 0000.0001)           No. stops:         264
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   115.96096801757812
-(PID.TID 0000.0001)         System time:   2.9988288879394531E-003
-(PID.TID 0000.0001)     Wall clock time:   116.02584505081177
+(PID.TID 0000.0001)           User time:   115.77877807617188
+(PID.TID 0000.0001)         System time:   8.9974403381347656E-003
+(PID.TID 0000.0001)     Wall clock time:   115.85011148452759
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.1014099121093750
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.1059401035308838
+(PID.TID 0000.0001)           User time:   2.8038024902343750
+(PID.TID 0000.0001)         System time:   9.9945068359375000E-004
+(PID.TID 0000.0001)     Wall clock time:   2.8062636852264404
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.435302734375000
-(PID.TID 0000.0001)         System time:   9.9945068359375000E-004
-(PID.TID 0000.0001)     Wall clock time:   14.444369316101074
+(PID.TID 0000.0001)           User time:   13.649627685546875
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   13.652677774429321
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5957031250000000
+(PID.TID 0000.0001)           User time:   2.6016235351562500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.5974972248077393
+(PID.TID 0000.0001)     Wall clock time:   2.6003210544586182
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8123474121093750
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   4.8152294158935547
+(PID.TID 0000.0001)           User time:   4.7811889648437500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.7872881889343262
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.49172973632812500
+(PID.TID 0000.0001)           User time:  0.30471801757812500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.48819565773010254
+(PID.TID 0000.0001)     Wall clock time:  0.29995679855346680
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.2396545410156250
+(PID.TID 0000.0001)           User time:   6.9607849121093750
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.2479758262634277
+(PID.TID 0000.0001)     Wall clock time:   6.9666378498077393
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   120.40521240234375
-(PID.TID 0000.0001)         System time:   4.0009021759033203E-003
-(PID.TID 0000.0001)     Wall clock time:   120.60698223114014
+(PID.TID 0000.0001)           User time:   119.54830932617188
+(PID.TID 0000.0001)         System time:   1.7999410629272461E-002
+(PID.TID 0000.0001)     Wall clock time:   119.63800835609436
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.9296875000000000E-003
+(PID.TID 0000.0001)           User time:   9.7656250000000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.1266632080078125E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0146064758300781E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7287292480468750
+(PID.TID 0000.0001)           User time:   1.7207031250000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.7295062541961670
+(PID.TID 0000.0001)     Wall clock time:   1.7222547531127930
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.7656250000000000E-004
+(PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9430809020996094E-004
+(PID.TID 0000.0001)     Wall clock time:   8.7547302246093750E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2244873046875000
-(PID.TID 0000.0001)         System time:  0.12997984886169434
-(PID.TID 0000.0001)     Wall clock time:   3.7370326519012451
+(PID.TID 0000.0001)           User time:   2.6395874023437500
+(PID.TID 0000.0001)         System time:  0.14597821235656738
+(PID.TID 0000.0001)     Wall clock time:   3.0971817970275879
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8764038085937500
-(PID.TID 0000.0001)         System time:  0.43593406677246094
-(PID.TID 0000.0001)     Wall clock time:   5.4401807785034180
+(PID.TID 0000.0001)           User time:   3.1854553222656250
+(PID.TID 0000.0001)         System time:  0.43993282318115234
+(PID.TID 0000.0001)     Wall clock time:   6.7142651081085205
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   32.976684570312500
-(PID.TID 0000.0001)         System time:  0.76088261604309082
-(PID.TID 0000.0001)     Wall clock time:   34.971487998962402
+(PID.TID 0000.0001)           User time:   32.946685791015625
+(PID.TID 0000.0001)         System time:  0.89286565780639648
+(PID.TID 0000.0001)     Wall clock time:   37.365024089813232
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.9741821289062500
-(PID.TID 0000.0001)         System time:  0.11998200416564941
-(PID.TID 0000.0001)     Wall clock time:   8.1225261688232422
+(PID.TID 0000.0001)           User time:   7.9556884765625000
+(PID.TID 0000.0001)         System time:  0.12697935104370117
+(PID.TID 0000.0001)     Wall clock time:   8.3225622177124023
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6535644531250000
-(PID.TID 0000.0001)         System time:   8.7986946105957031E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8515911102294922
+(PID.TID 0000.0001)           User time:   3.7565917968750000
+(PID.TID 0000.0001)         System time:   1.0248436927795410
+(PID.TID 0000.0001)     Wall clock time:   5.6010990142822266
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.8093261718750000
-(PID.TID 0000.0001)         System time:   6.8989276885986328E-002
-(PID.TID 0000.0001)     Wall clock time:   3.9742100238800049
+(PID.TID 0000.0001)           User time:   3.7424316406250000
+(PID.TID 0000.0001)         System time:   8.7986946105957031E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9079000949859619
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3104.4511718750000
-(PID.TID 0000.0001)         System time:   4.3973317146301270
-(PID.TID 0000.0001)     Wall clock time:   3115.8136689662933
+(PID.TID 0000.0001)           User time:   3103.6569824218750
+(PID.TID 0000.0001)         System time:   6.2530488967895508
+(PID.TID 0000.0001)     Wall clock time:   3132.3499779701233
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2623.1225585937500
-(PID.TID 0000.0001)         System time:   2.9625492095947266
-(PID.TID 0000.0001)     Wall clock time:   2629.9570231437683
+(PID.TID 0000.0001)           User time:   2622.1057128906250
+(PID.TID 0000.0001)         System time:   3.7874240875244141
+(PID.TID 0000.0001)     Wall clock time:   2639.2106370925903
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   470.56103515625000
-(PID.TID 0000.0001)         System time:   1.0488400459289551
-(PID.TID 0000.0001)     Wall clock time:   473.83257317543030
+(PID.TID 0000.0001)           User time:   470.62939453125000
+(PID.TID 0000.0001)         System time:   1.3197994232177734
+(PID.TID 0000.0001)     Wall clock time:   477.66264224052429
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4389648437500000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.4425203800201416
+(PID.TID 0000.0001)           User time:   5.1264648437500000
+(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
+(PID.TID 0000.0001)     Wall clock time:   5.1246745586395264
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7578125000000000E-002
+(PID.TID 0000.0001)           User time:   1.8066406250000000E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8502712249755859E-002
+(PID.TID 0000.0001)     Wall clock time:   1.8614768981933594E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   422.20605468750000
-(PID.TID 0000.0001)         System time:   6.8989276885986328E-002
-(PID.TID 0000.0001)     Wall clock time:   422.51704096794128
+(PID.TID 0000.0001)           User time:   422.55126953125000
+(PID.TID 0000.0001)         System time:  0.10898303985595703
+(PID.TID 0000.0001)     Wall clock time:   423.39067339897156
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.9316406250000000
-(PID.TID 0000.0001)         System time:  0.24596261978149414
-(PID.TID 0000.0001)     Wall clock time:   7.0676541328430176
+(PID.TID 0000.0001)           User time:   5.9870605468750000
+(PID.TID 0000.0001)         System time:  0.31895256042480469
+(PID.TID 0000.0001)     Wall clock time:   7.8845989704132080
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   0.0000000000000000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.4340152740478516E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5088787078857422E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   36.341796875000000
-(PID.TID 0000.0001)         System time:  0.73288774490356445
-(PID.TID 0000.0001)     Wall clock time:   38.153427600860596
+(PID.TID 0000.0001)           User time:   36.290039062500000
+(PID.TID 0000.0001)         System time:  0.88786506652832031
+(PID.TID 0000.0001)     Wall clock time:   40.568817853927612
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.3691406250000000E-002
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   3.8621902465820312E-002
+(PID.TID 0000.0001)           User time:   3.0029296875000000E-002
+(PID.TID 0000.0001)         System time:   2.9983520507812500E-003
+(PID.TID 0000.0001)     Wall clock time:   4.1804790496826172E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================

--- a/update_history
+++ b/update_history
@@ -1,6 +1,8 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #449 (fix TICES storage): update ADM output of exp global_oce_llc90,
+    ecco_v4 test only.
   - post PR #438: update 2 ADM output from exp.: global_oce_llc90.
     Fixing missing re-initialisation of recip_hFac change gradient-check of
     ecco_v4 & ecmwf AD tests. Update reference output (from engaging, gfortran).


### PR DESCRIPTION
Fixing pkg/seaice TICES storage affects only 1 test from global_oce_llc90
experiment, namely ecco_v4 ; generate new output (from engaging, using gfortran,
 -devel and run on 32 procs).