### PR TITLE
Update all 6 AD-output after merging PR #446

### DIFF
--- a/global_oce_cs32/results/output_adm.sens.txt
+++ b/global_oce_cs32/results/output_adm.sens.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Sat Apr 17 23:19:56 EDT 2021
+(PID.TID 0000.0001) // Build date:        Fri May  7 10:13:10 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -5428,40 +5428,36 @@
  cg2d: Sum(rhs),rhsMax =   5.15911604137395E+00  3.10708255938939E+00
  cg2d: Sum(rhs),rhsMax =   5.85339734146226E+00  2.96284271209768E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   5.85339715001570E+00  2.96284277328386E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   5.85339715001570E+00  2.96284277328386E+00
  Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   2.09610107049230E-13  3.55600724767241E+02
- cg2d: Sum(rhs),rhsMax =   5.15911495910990E+00  3.10708254024853E+00
- cg2d: Sum(rhs),rhsMax =   5.15911495910990E+00  3.10708254024853E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.13082892944294E-13  4.69523232046752E+01
+ cg2d: Sum(rhs),rhsMax =  -7.61002372229314E-13  4.69523172580516E+01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.5145494232227E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3452513797908E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.6109088139367E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   9.2404149943914E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3457244547876E+02
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.9679167085262E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -9.6224531369808E+04
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6446440432944E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.7650698929244E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6017271338727E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.4962107866124E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.2749265987649E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.6268247756800E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7869480199658E-02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.2961681365608E-03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.3138439225346E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.7619087322267E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.8935917933999E+04
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8136678001562E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.4413928047329E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.5145494433157E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3452513542556E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.6109088003514E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   9.2404149409377E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3457244456146E+02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.9679167113987E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -9.6224527739913E+04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6446440206801E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.7650699328340E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6017271459245E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.4962098470329E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.2749272084468E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.6268247740818E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7869483124789E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.2961682819523E-03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.3138440257720E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.7619086767024E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.8935906348104E+04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8136678033917E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.4413928054436E+04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5470,16 +5466,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.0199712148033E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -7.5025273457170E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.9612463866050E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.0512795730114E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0121927119735E+02
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.0847521439366E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.1381617270286E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.4241656960967E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   6.9853572428932E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1270624387558E+02
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.0199711769474E+04
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -7.5025272702551E+04
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.9612463675083E+03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.0512795207290E+03
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0121927098566E+02
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.0847521493574E+05
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.1381616743861E+04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.4241656857560E+03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   6.9853572768922E+03
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1270624433590E+02
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5490,11 +5486,11 @@
 (PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   7.2647834716709E-03
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -3.4653933380799E-03
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   3.9120233244333E-06
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.7212856412949E-04
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   7.1324011194883E-06
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   7.2647830513296E-03
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -3.4653933453044E-03
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   3.9120205697561E-06
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.7212853954630E-04
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   7.1324001385493E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
 (PID.TID 0000.0001) // =======================================================
@@ -5503,60 +5499,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3428259145593E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3062307146203E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -4.3598467807446E+01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3321420114901E+02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.6532466580515E+00
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.5083847976252E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0693524179744E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   2.4881984276607E+01
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2047844493729E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2986637944353E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.3966676425198E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2448599509360E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.3724972481482E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.3918811610016E+01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.4316948905862E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.2911043815127E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0922955130045E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.6743116205129E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.1184100634196E+04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.4556630400609E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3428259211578E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3062306777374E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -4.3598467655418E+01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3321420055538E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.6532466520543E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.5083847476873E+03
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0693523240321E+02
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   2.4881983945991E+01
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2047844507404E+02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2986637984010E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.3966676639220E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2448599502913E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.3724970746980E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.3918811456935E+01
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.4316948721896E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.2911043896075E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0922956467174E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.6743109969198E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.1184100677542E+04
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.4556630142240E+02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   7.7621747392028E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.3135437524193E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.9187554323311E+07
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.8136741785052E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.4414102014347E+07
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   7.7621746959061E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.3135438418588E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.9187554305766E+07
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.8136741820338E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.4414102029447E+07
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.9364221898183E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.1840527725743E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.3777365911298E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   8.1527958800204E-02
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1293096396343E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.2749265987649E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -4.4962107866124E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.6238780291077E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   8.7869594252919E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.2961689180265E-03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2801867423644E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.3468846274351E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   6.8096395181420E+07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.9128003166552E+09
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.3454248585226E+07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.9364227498831E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.1840518921754E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.3777365817340E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   8.1527961517105E-02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1293097740634E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.2749272084468E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -4.4962098470329E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.6238780167236E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   8.7869597178718E-02
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.2961690634373E-03
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2801867346511E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.3468846177718E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   6.8096394806865E+07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.9128003198036E+09
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.3454248455049E+07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.45761744290652E+00  3.33597886225108E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5567,31 +5562,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.1929066231622E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.7365822688828E+07
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -3.2508476140406E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2749869874178E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2683889340143E+03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6907138947938E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.3587927687164E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   7.5199673961961E+04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   8.3113082279378E+05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2165129020972E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.7733142207355E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.8946676360411E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   4.4226350914499E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.1215860389372E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.5291050178525E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.6095565757136E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.6231868678392E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.7340077508166E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.6676426842610E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1959004059521E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.7050550720836E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.6553537651727E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.1967824850495E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.1663022281635E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0432642810255E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.1929066249773E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.7365822744469E+07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -3.2508475892784E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2749869863230E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2683889379808E+03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6907139015706E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.3587927699422E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   7.5199673082262E+04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   8.3113082640954E+05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2165129047059E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.7733142925937E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.8946677464941E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   4.4226345163447E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.1215859051434E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.5291050385489E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.6095565791134E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.6231868480848E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.7340077627649E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.6676428511760E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1959004572187E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.7050550026517E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.6553537771185E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.1967825374301E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.1663023073865E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0432643070873E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5600,75 +5595,70 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     6
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.5961294540183E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -1.7354228711518E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -2.5730460556214E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   4.9021659557515E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   5.8228414250039E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   2.5104704065973E+01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -1.0811053799230E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -6.2729649728040E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.2319278651724E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   5.1385989651249E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.7381646222365E+03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -4.8468870091802E+03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -7.0019240839225E+01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   3.3935908058863E+02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   6.7701889381506E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.0085088808586E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.1469737207293E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   1.2787635799318E+04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.6844483276634E+05
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   8.9546830740454E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.2710118328681E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -7.7719723813316E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   4.6322907018451E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6958571856322E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.2396135394475E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.5961311760355E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -1.7354228063548E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -2.5730459688184E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   4.9021658065453E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   5.8228412641908E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   2.5104705946450E+01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -1.0811053290351E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -6.2729650151873E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.2319278202536E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   5.1385986822320E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.7381647314273E+03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -4.8468870350048E+03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -7.0019239931977E+01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   3.3935907949890E+02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   6.7701889384166E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.0085088665526E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.1469737492258E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   1.2787632870433E+04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.6844483382587E+05
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   8.9546830941435E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.2710117810993E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -7.7719724839396E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   4.6322896398028E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6958571893997E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.2396135461900E+03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.45761744290652E+00  3.33597886225108E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   5.12923037376822E-13  1.66201906723980E+01
- cg2d: Sum(rhs),rhsMax =   3.74608577771221E+00  3.61303112154743E+00
- cg2d: Sum(rhs),rhsMax =   3.74608577771221E+00  3.61303112154743E+00
+ cg2d: Sum(rhs),rhsMax =   6.15951734062037E-13  1.66201895161950E+01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -9.66338120633736E-13  1.27807749728084E+01
+ cg2d: Sum(rhs),rhsMax =   2.82440737464640E-13  1.27807736760603E+01
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
  cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
  cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
  cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
- cg2d: Sum(rhs),rhsMax =   3.02165677723545E+00  3.85995008150527E+00
- cg2d: Sum(rhs),rhsMax =   3.02165677723545E+00  3.85995008150527E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.82121026329696E-13  7.60802676427408E+00
+ cg2d: Sum(rhs),rhsMax =  -1.88293824976427E-12  7.60802552502461E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9116145499776E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.5874694372220E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.3387786250680E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.7332661500844E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.7319668322526E+02
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9860598203131E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.1525901684215E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.1530867902668E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8803800453376E+04
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6652834139780E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   7.3211222165427E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.3023772128880E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6847010889375E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1114657649849E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0050726346989E-03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1683704700670E+07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.2420025476697E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2263878910341E+05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8836938414104E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.6934288199842E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9116145509372E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.5874693441658E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.3387785957164E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.7332661378668E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.7319667836126E+02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9860598224318E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.1525901730451E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.1530867721364E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8803800418902E+04
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6652834046497E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   7.3211221455949E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.3023761774421E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6847009156259E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1114657853209E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0050728398053E-03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1683704663874E+07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.2420025805017E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2263878270316E+05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8836938356584E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.6934288126837E+04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5677,16 +5667,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2818296471449E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5956587957362E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.6258175950068E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2357185635909E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.1388088376388E+02
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.9492364203634E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.6089581809821E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6017209135629E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2998195658508E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.3260188438932E+02
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2818296403334E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5956587426296E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.6258175628593E+03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2357185536737E+04
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.1388088164005E+02
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.9492364281447E+05
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.6089581249606E+04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6017209063621E+03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2998195640060E+04
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.3260188244340E+02
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5697,11 +5687,11 @@
 (PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   5.5775079924927E-02
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -2.1306439534149E-02
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   2.7742169494348E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.2171405591634E-03
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   4.1611982227987E-05
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   5.5775071934294E-02
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -2.1306446216713E-02
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   2.7742166294854E-05
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.2171405163518E-03
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   4.1611985313928E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
 (PID.TID 0000.0001) // =======================================================
@@ -5710,60 +5700,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.5083794155201E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.0225308248207E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.8865315183969E+01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.6281964009852E+02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.4957062233971E+00
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.3827678579175E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.2078553317057E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   7.3219720254648E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.1100989635313E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.8280868392153E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.8928331843783E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6462506748633E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.2902269425918E-01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.9974845307063E+01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.3181673911002E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.8081635545726E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9804641704287E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -1.2015664604854E+03
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   3.4033598276700E+04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.2846796033197E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.5083793876542E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.0225306536383E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.8865314942858E+01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.6281963856840E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.4957061748790E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.3827678932443E+03
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.2078553124315E+03
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   7.3219620200896E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.1100989766193E+02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.8280868642959E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.8928349415756E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6462502230805E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.2902256413079E-01
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.9974846585144E+01
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.3181677429128E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.8081640684991E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9804642119037E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -1.2015664725014E+03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   3.4033598349999E+04
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.2846795387421E+02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   8.2428272816371E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1682798344878E+10
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2342400818560E+08
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8837241227205E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.6935125299479E+07
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   8.2428273206095E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1682798301334E+10
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2342400764050E+08
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8837241171898E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.6935125232715E+07
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.6769701753585E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -6.7554650208542E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.0255761473475E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.9569865400174E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.7904127147260E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.3023772128880E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -7.3211222165427E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.9337193283280E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1120456074109E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.0078914080425E-03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.3680366224155E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.0626461502936E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   3.8008947525308E+08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0414598188092E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.6972339580368E+08
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.6769692095921E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -6.7554649308757E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.0255761449620E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.9569865600979E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.7904129115607E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.3023761774421E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -7.3211221455949E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.9337193771500E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1120456297623E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.0078916246142E-03
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.3680366114867E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.0626461205639E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   3.8008947316238E+08
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0414598175779E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.6972339540132E+08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27601731093161E+00  4.04197216976108E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5774,31 +5763,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.9555201603865E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.6852719842943E+07
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.3947372846886E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2555467912925E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2621389015880E+03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6273590200789E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5297290497708E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   4.2490451433045E+04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   9.2251280063367E+05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2190589879294E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.3099598271157E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5522776929811E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.5573846853248E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4023225098663E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.8397719471233E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   9.7023942733908E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -8.5530978635654E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6078062999943E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.3076536874340E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.6394666800119E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0061878994193E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.4090254627094E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.4341364589240E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.0368765108829E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.9219068759660E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.9555201724775E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.6852719823444E+07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.3947372662345E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2555467887631E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2621388993019E+03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6273590138907E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5297290529054E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   4.2490450296010E+04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   9.2251280441407E+05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2190589880193E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.3099597778358E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5522776760174E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.5573836712185E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4023224999451E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.8397719210227E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   9.7023942974312E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -8.5530978548047E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6078063886169E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.3076536979993E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.6394667024924E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0061878963398E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.4090254711565E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.4341365047198E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.0368765158974E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.9219068893970E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5807,72 +5796,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     3
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   2.5726488968492E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.7523754160135E+03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -3.3314764317371E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   6.9059204435645E+01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.0368516992213E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.3586608028698E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.9179062717995E+03
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.4493861249159E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   6.1525963668852E+01
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   1.5642037435077E+00
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.4119768784675E+03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.0573898204220E+04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   7.0398673767065E+00
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   7.0436157444799E+02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.4120517290197E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1645938503851E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.0532049452559E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1398556192549E+04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.5320935301691E+05
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.6773211548036E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8290808234914E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.1043243699411E+06
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1358545311375E+04
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.7242954836806E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.4993798781545E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   2.5726490519020E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.7523751582069E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -3.3314762217941E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   6.9059200014528E+01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.0368511585557E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.3586603875516E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.9179060253515E+03
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.4493860874175E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   6.1525960145447E+01
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   1.5642035820894E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.4119768819130E+03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.0573898122894E+04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   7.0398666220427E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   7.0436157143963E+02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.4120517202867E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1645938599057E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.0532049234524E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1398554576486E+04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.5320935178677E+05
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.6773211629436E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8290808580566E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.1043243624068E+06
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1358544729886E+04
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.7242954791113E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.4993798802280E+03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27601731093161E+00  4.04197216976108E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.55271367880050E-14  7.08138195632595E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356396389E+00  4.17022492069095E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356396389E+00  4.17022492069095E+00
+ cg2d: Sum(rhs),rhsMax =   3.33955085807247E-13  7.08138196317667E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.98427949019242E-13  8.06165908741359E+00
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   7.73551085820188E-01  3.29048620660793E+00
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   7.73551085820188E-01  3.29048620660793E+00
+ cg2d: Sum(rhs),rhsMax =  -1.27897692436818E-13  8.06165949210180E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -5.96855898038484E-13  6.51439399553468E+00
+ cg2d: Sum(rhs),rhsMax =  -1.05160324892495E-12  6.51439354482620E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3277685655870E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.9100829993777E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.7187423269101E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0470746496235E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.5411767627105E+02
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.0595210784073E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.4380777099632E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9874027669290E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3363770011335E+04
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388689712928E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.0328575412234E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -9.9174903921242E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.1794199034207E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.5583928455136E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0807313765880E-03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.3410719088710E+07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.1075826348210E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2043463125168E+05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.4619884816810E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7776402080631E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3277685362078E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.9100830018624E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.7187422858628E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0470746422046E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.5411767546154E+02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.0595210895523E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.4380776955633E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9874027818979E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3363770019095E+04
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388689651496E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.0328575985349E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -9.9174900178528E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.1794203847667E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.5583928606055E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0807315644178E-03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.3410719083372E+07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.1075826654060E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2043464008160E+05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.4619884847998E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7776402028973E+04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5881,16 +5863,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5800651830245E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.9022622599908E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7853828940457E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.4570575231643E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5901123414948E+02
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.1748643972025E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.2763662280525E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.3281930411167E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.6791124541892E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.6964262839722E+02
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5800651698072E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.9022622387545E+05
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7853828635183E+03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.4570575150899E+04
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5901123330823E+02
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.1748644068618E+05
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.2763662120428E+05
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.3281930526807E+03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.6791124548332E+04
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.6964262857248E+02
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5914,56 +5896,56 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.9827583081104E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.4000804157786E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.6579312317291E+01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.4675132968242E+02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   7.1358836865444E+00
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2677694522510E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.2132880097148E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -2.0873346619645E+01
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.0399810824732E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.0321411810161E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1668143710001E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5894369595179E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.9799975501742E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.6246784975102E+01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.9396559807345E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.6299229102368E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.7025276507915E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -3.1913685455413E+03
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.3224037194995E+04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   6.0925473998762E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.9827582740944E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.4000803160522E+03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.6579312242783E+01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.4675132737780E+02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   7.1358836087243E+00
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2677694226355E+03
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.2132879679653E+03
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -2.0873346770295E+01
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.0399810767558E+02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.0321411573837E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1668140569326E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5894372382557E+02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.9799973354503E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.6246784780121E+01
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.9396560201698E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.6299228119002E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.7025276801591E+05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -3.1913685477707E+03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.3224037351225E+04
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   6.0925473856002E+02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.1088969708411E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.3409272867034E+10
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2167339124446E+08
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.4620275386461E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7777517959656E+07
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.1088969933317E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.3409272870603E+10
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2167339244547E+08
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.4620275415247E+09
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7777517901133E+07
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   9.7411690964679E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -6.8968926892201E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0329541438735E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.3732718348753E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.9126784727733E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.0966528717787E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -8.0328575412234E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.4372696560687E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.5773394204194E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.1756965885095E-03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.6883447524121E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.3250411059126E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.5820126701685E+08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.9679734008511E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.7792203118789E+08
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   9.7411697745047E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -6.8968925807195E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0329542240221E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.3732718530167E-01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.9126786419497E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.0966533713883E+00
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -8.0328575985349E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.4372696240152E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.5773394422505E-01
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.1756967657705E-03
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.6883447741070E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.3250410151930E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.5820126583633E+08
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.9679733992781E+10
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.7792203053380E+08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5980,31 +5962,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.6756924630120E+07
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -5.7668277262099E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.8005847452886E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   4.7800816727653E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.5335211908879E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.4315209528525E+06
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.7564265093403E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0938015588960E+04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9190651223094E+05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.8773041513366E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.6756924643375E+07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -5.7668277228159E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.8005847287813E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   4.7800816628186E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.5335211713560E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.4315209509915E+06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.7564265104221E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0938014263543E+04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9190651320566E+05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.8773041611887E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.4720424457309E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.9965580376318E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.7397671755403E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.3169386362884E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3804414873322E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174175692807E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.6856861341422E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.6298374007921E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8587589770718E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.8911181809237E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.4720424482754E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.9965580373459E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.7397673270763E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.3169386441564E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3804414894416E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174175682755E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.6856861430831E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.6298374800870E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8587589807232E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.8911181915524E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6013,31 +5995,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     0
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.4285527361079E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7598735327407E+03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -8.0542181592513E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.7650264020297E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   1.4664537302996E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.4409367814069E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.6140878444887E+03
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3785170494506E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5928434863348E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   4.2615705769640E+00
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   1.1657183205097E+04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.6655108101563E+04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   8.4571455076354E+01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   9.4467119990895E+02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.7166932445894E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.3976191464431E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.4883571927882E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1645111416063E+04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   9.0404255284725E+05
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.8952717571888E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   8.6732803660368E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.2622131154145E+06
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1443640871415E+04
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2693931413575E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.5782116256828E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.4285527364125E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7598732784887E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -8.0542178166050E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.7650263294679E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   1.4664536420846E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.4409360996524E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.6140875659262E+03
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3785169154619E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5928434159719E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   4.2615703299700E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   1.1657183153831E+04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.6655107980829E+04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   8.4571454626853E+01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   9.4467119349184E+02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.7166932314326E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.3976191547745E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.4883571918284E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1645113706304E+04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   9.0404255377532E+05
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.8952717651856E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   8.6732803963657E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.2622131150510E+06
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1443641700796E+04
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2693931446716E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.5782116279118E+03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6759,249 +6741,249 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   219.89334940165281
-(PID.TID 0000.0001)         System time:   3.7853420674800873
-(PID.TID 0000.0001)     Wall clock time:   228.79478979110718
+(PID.TID 0000.0001)           User time:   228.19628123193979
+(PID.TID 0000.0001)         System time:   3.5964660830795765
+(PID.TID 0000.0001)     Wall clock time:   235.94089007377625
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   1.1737819463014603
-(PID.TID 0000.0001)         System time:  0.32777198404073715
-(PID.TID 0000.0001)     Wall clock time:   1.5936300754547119
+(PID.TID 0000.0001)           User time:   1.3586829416453838
+(PID.TID 0000.0001)         System time:  0.42246999219059944
+(PID.TID 0000.0001)     Wall clock time:   1.8293609619140625
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   129.95804429054260
-(PID.TID 0000.0001)         System time:   2.2692529261112213
-(PID.TID 0000.0001)     Wall clock time:   136.13925909996033
+(PID.TID 0000.0001)           User time:   101.35235714912415
+(PID.TID 0000.0001)         System time:   2.1101629734039307
+(PID.TID 0000.0001)     Wall clock time:   105.84134006500244
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   99.361492156982422
-(PID.TID 0000.0001)         System time:  0.39878576993942261
-(PID.TID 0000.0001)     Wall clock time:   100.83447670936584
+(PID.TID 0000.0001)           User time:   135.30474925041199
+(PID.TID 0000.0001)         System time:  0.51635193824768066
+(PID.TID 0000.0001)     Wall clock time:   137.71519136428833
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0009436607360840
-(PID.TID 0000.0001)         System time:   6.3180923461914062E-004
-(PID.TID 0000.0001)     Wall clock time:   2.0080549716949463
+(PID.TID 0000.0001)           User time:   2.5268390178680420
+(PID.TID 0000.0001)         System time:   5.1395893096923828E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5483751296997070
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0042119026184082
-(PID.TID 0000.0001)         System time:   8.9350998401641846E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1155514717102051
+(PID.TID 0000.0001)           User time:   2.0989239215850830
+(PID.TID 0000.0001)         System time:   5.5115222930908203E-002
+(PID.TID 0000.0001)     Wall clock time:   2.2264001369476318
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.0039737224578857
-(PID.TID 0000.0001)         System time:   7.2956204414367676E-002
-(PID.TID 0000.0001)     Wall clock time:   1.0984308719635010
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   1.9681203365325928
+(PID.TID 0000.0001)         System time:   3.5613477230072021E-002
+(PID.TID 0000.0001)     Wall clock time:   2.0751488208770752
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.2959403991699219E-004
-(PID.TID 0000.0001)         System time:   1.6808509826660156E-005
-(PID.TID 0000.0001)     Wall clock time:   9.3531608581542969E-004
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   7.8248977661132812E-004
+(PID.TID 0000.0001)         System time:   1.4662742614746094E-005
+(PID.TID 0000.0001)     Wall clock time:   7.9989433288574219E-004
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17233848571777344
-(PID.TID 0000.0001)         System time:   1.4677047729492188E-003
-(PID.TID 0000.0001)     Wall clock time:  0.17428588867187500
+(PID.TID 0000.0001)           User time:  0.24381017684936523
+(PID.TID 0000.0001)         System time:   6.0701370239257812E-004
+(PID.TID 0000.0001)     Wall clock time:  0.25334858894348145
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7576646804809570E-002
-(PID.TID 0000.0001)         System time:   3.1995773315429688E-004
-(PID.TID 0000.0001)     Wall clock time:   6.7970275878906250E-002
+(PID.TID 0000.0001)           User time:   8.0383300781250000E-002
+(PID.TID 0000.0001)         System time:   2.0849704742431641E-004
+(PID.TID 0000.0001)     Wall clock time:   8.0661296844482422E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   21.857963562011719
-(PID.TID 0000.0001)         System time:   8.6210548877716064E-002
-(PID.TID 0000.0001)     Wall clock time:   22.188276529312134
+(PID.TID 0000.0001)           User time:   29.761304140090942
+(PID.TID 0000.0001)         System time:  0.13488996028900146
+(PID.TID 0000.0001)     Wall clock time:   30.256855249404907
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.0508928298950195
-(PID.TID 0000.0001)         System time:   4.7391653060913086E-004
-(PID.TID 0000.0001)     Wall clock time:   2.0750942230224609
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   2.8205854892730713
+(PID.TID 0000.0001)         System time:   4.1437149047851562E-003
+(PID.TID 0000.0001)     Wall clock time:   2.8647637367248535
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.5316808223724365
-(PID.TID 0000.0001)         System time:   2.2488832473754883E-004
-(PID.TID 0000.0001)     Wall clock time:   1.5551297664642334
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   2.1075403690338135
+(PID.TID 0000.0001)         System time:   3.7422180175781250E-003
+(PID.TID 0000.0001)     Wall clock time:   2.1440460681915283
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   6.9538159370422363
-(PID.TID 0000.0001)         System time:   1.9110560417175293E-002
-(PID.TID 0000.0001)     Wall clock time:   7.0448853969573975
-(PID.TID 0000.0001)          No. starts:         264
-(PID.TID 0000.0001)           No. stops:         264
+(PID.TID 0000.0001)           User time:   8.0095713138580322
+(PID.TID 0000.0001)         System time:   5.7150721549987793E-003
+(PID.TID 0000.0001)     Wall clock time:   8.0943641662597656
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   21.577233791351318
-(PID.TID 0000.0001)         System time:   4.4324398040771484E-003
-(PID.TID 0000.0001)     Wall clock time:   21.780092477798462
+(PID.TID 0000.0001)           User time:   26.810731887817383
+(PID.TID 0000.0001)         System time:   2.5723397731781006E-002
+(PID.TID 0000.0001)     Wall clock time:   27.329919576644897
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8370308876037598
-(PID.TID 0000.0001)         System time:   4.9000978469848633E-004
-(PID.TID 0000.0001)     Wall clock time:   3.8649919033050537
+(PID.TID 0000.0001)           User time:   6.5812497138977051
+(PID.TID 0000.0001)         System time:   7.4007511138916016E-003
+(PID.TID 0000.0001)     Wall clock time:   6.6568093299865723
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4453995227813721
-(PID.TID 0000.0001)         System time:   1.7136335372924805E-004
-(PID.TID 0000.0001)     Wall clock time:   1.4468624591827393
+(PID.TID 0000.0001)           User time:   1.9831995964050293
+(PID.TID 0000.0001)         System time:   5.1239132881164551E-003
+(PID.TID 0000.0001)     Wall clock time:   2.0390982627868652
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.52304267883300781
-(PID.TID 0000.0001)         System time:   2.1559000015258789E-004
-(PID.TID 0000.0001)     Wall clock time:  0.52416038513183594
+(PID.TID 0000.0001)           User time:  0.69218206405639648
+(PID.TID 0000.0001)         System time:   3.5852193832397461E-004
+(PID.TID 0000.0001)     Wall clock time:  0.69824337959289551
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0959131717681885
-(PID.TID 0000.0001)         System time:   6.3419342041015625E-005
-(PID.TID 0000.0001)     Wall clock time:   1.1070303916931152
+(PID.TID 0000.0001)           User time:   1.6173372268676758
+(PID.TID 0000.0001)         System time:   2.2882223129272461E-004
+(PID.TID 0000.0001)     Wall clock time:   1.6411135196685791
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2424640655517578E-002
-(PID.TID 0000.0001)         System time:   8.8989734649658203E-005
-(PID.TID 0000.0001)     Wall clock time:   8.2632780075073242E-002
+(PID.TID 0000.0001)           User time:  0.10819911956787109
+(PID.TID 0000.0001)         System time:   2.4926662445068359E-004
+(PID.TID 0000.0001)     Wall clock time:  0.10915565490722656
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.6246864795684814
-(PID.TID 0000.0001)         System time:   6.2732636928558350E-002
-(PID.TID 0000.0001)     Wall clock time:   4.7293412685394287
+(PID.TID 0000.0001)           User time:   8.4175655841827393
+(PID.TID 0000.0001)         System time:  0.10619288682937622
+(PID.TID 0000.0001)     Wall clock time:   8.6039631366729736
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   23.054911375045776
-(PID.TID 0000.0001)         System time:   1.2523531913757324E-002
-(PID.TID 0000.0001)     Wall clock time:   23.329113006591797
+(PID.TID 0000.0001)           User time:   29.118278741836548
+(PID.TID 0000.0001)         System time:   1.8272936344146729E-002
+(PID.TID 0000.0001)     Wall clock time:   29.532597780227661
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.2002410888671875E-004
-(PID.TID 0000.0001)         System time:   5.7816505432128906E-006
-(PID.TID 0000.0001)     Wall clock time:   7.8892707824707031E-004
+(PID.TID 0000.0001)           User time:   8.8453292846679688E-004
+(PID.TID 0000.0001)         System time:   1.3589859008789062E-005
+(PID.TID 0000.0001)     Wall clock time:   7.9607963562011719E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25580310821533203
-(PID.TID 0000.0001)         System time:   8.8214874267578125E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25697302818298340
+(PID.TID 0000.0001)           User time:  0.39191961288452148
+(PID.TID 0000.0001)         System time:   7.1704387664794922E-005
+(PID.TID 0000.0001)     Wall clock time:  0.41156005859375000
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.3753128051757812E-004
-(PID.TID 0000.0001)         System time:   4.8875808715820312E-006
-(PID.TID 0000.0001)     Wall clock time:   6.9999694824218750E-004
+(PID.TID 0000.0001)           User time:   7.3385238647460938E-004
+(PID.TID 0000.0001)         System time:   1.1801719665527344E-005
+(PID.TID 0000.0001)     Wall clock time:   7.9131126403808594E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15386557579040527
-(PID.TID 0000.0001)         System time:   1.9904851913452148E-002
-(PID.TID 0000.0001)     Wall clock time:  0.17905902862548828
+(PID.TID 0000.0001)           User time:  0.31568765640258789
+(PID.TID 0000.0001)         System time:   4.7413110733032227E-002
+(PID.TID 0000.0001)     Wall clock time:  0.36538052558898926
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10476660728454590
-(PID.TID 0000.0001)         System time:  0.10794395208358765
-(PID.TID 0000.0001)     Wall clock time:  0.21274828910827637
+(PID.TID 0000.0001)           User time:  0.12798309326171875
+(PID.TID 0000.0001)         System time:   9.7720861434936523E-002
+(PID.TID 0000.0001)     Wall clock time:  0.22750043869018555
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.0448646545410156
-(PID.TID 0000.0001)         System time:  0.15928924083709717
-(PID.TID 0000.0001)     Wall clock time:   3.5537023544311523
+(PID.TID 0000.0001)           User time:   1.3773002624511719
+(PID.TID 0000.0001)         System time:  0.14633631706237793
+(PID.TID 0000.0001)     Wall clock time:   1.5533316135406494
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.42619132995605469
-(PID.TID 0000.0001)         System time:   9.1668367385864258E-002
-(PID.TID 0000.0001)     Wall clock time:  0.53401541709899902
+(PID.TID 0000.0001)           User time:  0.45797538757324219
+(PID.TID 0000.0001)         System time:   9.9092125892639160E-002
+(PID.TID 0000.0001)     Wall clock time:  0.56317710876464844
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20501708984375000
-(PID.TID 0000.0001)         System time:   3.9995908737182617E-002
-(PID.TID 0000.0001)     Wall clock time:  0.25517988204956055
+(PID.TID 0000.0001)           User time:  0.20928192138671875
+(PID.TID 0000.0001)         System time:   5.1732063293457031E-002
+(PID.TID 0000.0001)     Wall clock time:  0.26587486267089844
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.18698120117187500
-(PID.TID 0000.0001)         System time:   2.7906894683837891E-002
-(PID.TID 0000.0001)     Wall clock time:  0.21596217155456543
+(PID.TID 0000.0001)           User time:  0.22371673583984375
+(PID.TID 0000.0001)         System time:   2.3772954940795898E-002
+(PID.TID 0000.0001)     Wall clock time:  0.25164389610290527
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   88.369338989257812
-(PID.TID 0000.0001)         System time:   1.1203341484069824
-(PID.TID 0000.0001)     Wall clock time:   90.584393978118896
+(PID.TID 0000.0001)           User time:   125.05207824707031
+(PID.TID 0000.0001)         System time:  0.98829317092895508
+(PID.TID 0000.0001)     Wall clock time:   127.75250601768494
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.3290405273437500
-(PID.TID 0000.0001)         System time:  0.54141283035278320
-(PID.TID 0000.0001)     Wall clock time:   6.9549672603607178
+(PID.TID 0000.0001)           User time:   9.0157775878906250
+(PID.TID 0000.0001)         System time:  0.32218289375305176
+(PID.TID 0000.0001)     Wall clock time:   9.4925725460052490
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   82.029464721679688
-(PID.TID 0000.0001)         System time:  0.55529522895812988
-(PID.TID 0000.0001)     Wall clock time:   83.590855121612549
+(PID.TID 0000.0001)           User time:   115.97778320312500
+(PID.TID 0000.0001)         System time:  0.65823912620544434
+(PID.TID 0000.0001)     Wall clock time:   118.18579530715942
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.8013153076171875
-(PID.TID 0000.0001)         System time:  0.17775774002075195
-(PID.TID 0000.0001)     Wall clock time:   3.0191185474395752
+(PID.TID 0000.0001)           User time:   5.4202194213867188
+(PID.TID 0000.0001)         System time:  0.21080636978149414
+(PID.TID 0000.0001)     Wall clock time:   6.1479525566101074
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0070800781250000E-002
-(PID.TID 0000.0001)         System time:   1.2183189392089844E-004
-(PID.TID 0000.0001)     Wall clock time:   1.0234355926513672E-002
+(PID.TID 0000.0001)           User time:   1.2145996093750000E-002
+(PID.TID 0000.0001)         System time:   1.8334388732910156E-004
+(PID.TID 0000.0001)     Wall clock time:   1.2368917465209961E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   77.434997558593750
-(PID.TID 0000.0001)         System time:  0.14117813110351562
-(PID.TID 0000.0001)     Wall clock time:   78.523792028427124
+(PID.TID 0000.0001)           User time:   107.64271545410156
+(PID.TID 0000.0001)         System time:  0.23007917404174805
+(PID.TID 0000.0001)     Wall clock time:   108.88632392883301
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.37345886230468750
-(PID.TID 0000.0001)         System time:   2.3770093917846680E-002
-(PID.TID 0000.0001)     Wall clock time:  0.40356397628784180
+(PID.TID 0000.0001)           User time:   1.0776138305664062
+(PID.TID 0000.0001)         System time:   1.7944097518920898E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1068415641784668
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1138916015625000E-003
-(PID.TID 0000.0001)         System time:   1.1920928955078125E-005
-(PID.TID 0000.0001)     Wall clock time:   1.2040138244628906E-003
+(PID.TID 0000.0001)           User time:   1.4724731445312500E-003
+(PID.TID 0000.0001)         System time:   1.5974044799804688E-005
+(PID.TID 0000.0001)     Wall clock time:   1.4917850494384766E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2323608398437500
-(PID.TID 0000.0001)         System time:  0.21104741096496582
-(PID.TID 0000.0001)     Wall clock time:   1.4554107189178467
+(PID.TID 0000.0001)           User time:   1.6078491210937500
+(PID.TID 0000.0001)         System time:  0.19501471519470215
+(PID.TID 0000.0001)     Wall clock time:   1.8106923103332520
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.2664794921875000E-002
-(PID.TID 0000.0001)         System time:   1.3248920440673828E-003
-(PID.TID 0000.0001)     Wall clock time:   1.4062404632568359E-002
+(PID.TID 0000.0001)           User time:   1.8409729003906250E-002
+(PID.TID 0000.0001)         System time:   9.0599060058593750E-005
+(PID.TID 0000.0001)     Wall clock time:   1.8500566482543945E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -7041,9 +7023,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         238166
+(PID.TID 0000.0001) //            No. barriers =         229046
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         238166
+(PID.TID 0000.0001) //     Total barrier spins =         229046
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_cs32/results/output_adm.txt
+++ b/global_oce_cs32/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Sat Apr 17 23:19:56 EDT 2021
+(PID.TID 0000.0001) // Build date:        Fri May  7 10:13:10 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -5386,40 +5386,36 @@
  cg2d: Sum(rhs),rhsMax =   5.15911604137395E+00  3.10708255938939E+00
  cg2d: Sum(rhs),rhsMax =   5.85339734146226E+00  2.96284271209768E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   5.85339715001570E+00  2.96284277328386E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   5.85339715001570E+00  2.96284277328386E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.68882138776405E-17  2.59260668204037E-03
- cg2d: Sum(rhs),rhsMax =   5.15911495910990E+00  3.10708254024853E+00
- cg2d: Sum(rhs),rhsMax =   5.15911495910990E+00  3.10708254024853E+00
+ cg2d: Sum(rhs),rhsMax =   1.47451495458029E-17  2.59260668204037E-03
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.21430643318376E-17  2.28694952676615E-03
+ cg2d: Sum(rhs),rhsMax =  -9.97465998686664E-18  2.28694924569916E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7042374763520E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2119132770151E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.7286864049131E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8171248681010E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3150816029319E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1205834752724E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2256645505628E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4682787123235E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0732521727266E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5364054668282E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196776264074E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875271848986E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1257572886581E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.3544565301341E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7881957077608E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.1626509139725E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.1174737484794E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   7.8713259872812E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1858703206458E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.0678106734256E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7042374251496E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2119133090194E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.7286876219092E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8171248129705E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3150815866912E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1205832073029E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2256645661127E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4682785931570E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0732521631237E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5364054535095E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196776262627E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875271853879E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1257572885020E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.3544565302023E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7881957079704E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.1626509520787E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.1174737345498E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   7.8713266269185E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1858703282223E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.0678106725603E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5428,16 +5424,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.3007712050928E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2577479260569E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.5719813757328E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.0118645834115E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.2538226687505E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.3294376677959E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.4087103512285E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -7.9828163024311E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   7.0222493408528E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4147278768981E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.3007712585751E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2577479290909E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.5719792740106E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.0118645471067E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.2538226555869E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.3294376795794E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.4087104042163E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -7.9828160558829E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   7.0222493457938E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4147278736920E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5448,11 +5444,11 @@
 (PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   1.0080709361509E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -1.3089987095344E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -4.5723439798687E-08
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   6.3659547236046E-07
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.1986568828139E-08
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   1.0080710802461E-05
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -1.3089987139600E-05
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -4.5723444685724E-08
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   6.3659549392397E-07
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.1986569511769E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
 (PID.TID 0000.0001) // =======================================================
@@ -5461,60 +5457,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.1568909146555E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.0248088229324E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   2.1581343163966E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.0521090875946E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.2996419734046E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7670905114174E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -4.1093334095633E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.8962847085493E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.4852919583416E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.6562892738745E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.7799429860379E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.5000936705274E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.1049082325133E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.4943470596603E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2300202810487E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2679328336239E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.4669683912994E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.2839554574212E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.2062982402293E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8361538620008E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.1568909174648E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.0248092394377E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   2.1581343336572E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.0521090493646E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.2996419541864E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7670905156800E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -4.1093334109322E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.8962846277833E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.4852919461777E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.6562892559234E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.7799418840966E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.5000922342957E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.1049084377862E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.4943470239489E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2300203343579E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2679328266223E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.4669683701748E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.2839554608538E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.2062982394987E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8361538642794E-01
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   7.2053910335412E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -7.0675440180016E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7663260220761E+01
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1862115978919E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.0686525597214E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   7.2053910263764E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -7.0675440490525E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7663256213583E+01
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1862116054439E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.0686525590860E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5113893715363E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3881304035344E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.3096428610424E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0778326451148E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.1377200632388E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.0875271848986E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9196776264074E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   5.9732302641683E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.1831140837091E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.7127065822716E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2813634541319E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.2570622524405E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -2.1072399800683E+01
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.8729225795851E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.5867686217361E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5113893718719E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3881304034442E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.3096428622743E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0778326451654E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.1377200633831E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.0875271853879E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9196776262627E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   5.9732302659424E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.1831140837535E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.7127065825105E-06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2813634541980E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.2570622360756E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -2.1072423796342E+01
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.8729225921749E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.5867686206527E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.45761744290652E+00  3.33597886225108E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5525,31 +5520,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -4.7801920623822E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.7437245341451E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8722714164592E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1341182151507E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1396756331544E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.8926728088671E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0506075460053E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0665350497816E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3080552862272E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5158246614179E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.1483681262003E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.9874504997863E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0034035834106E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6089852902097E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5276082659325E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4568357787459E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3553425985004E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0422408617445E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2008716683028E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4402512671928E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.6031993385555E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6763518926011E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1692144212656E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1328085200315E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.2476140399561E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.7168156200725E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9610172527419E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3808035804816E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1341182084311E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1396756700831E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.8927018523545E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0506075878555E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0665350981938E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3080552897237E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5158246322462E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.1483680462085E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.9874505241360E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0034036357934E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6089850801307E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5276081571095E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4568354463012E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3553425464535E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0422408136273E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2008716674611E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4402512672479E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.6031993542578E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6763518924716E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1692144215633E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1328085200407E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.2476140352144E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.7168157003000E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9610172479383E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3808036445417E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5558,75 +5553,70 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     6
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2253856334265E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7308377688722E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7878196726830E-05
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5342942388126E-03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5301076055712E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0581237590860E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0332794004273E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3278588901224E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1517616022268E-03
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0871191175297E-05
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378295435831E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1436254341971E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.0219695907881E-06
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0906271425289E-03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3910383169873E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1558758272510E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3506530313174E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -6.4577551420250E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.4146163983722E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.0175106275642E-01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8181489227015E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5244221597205E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3493824370441E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015427361215E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879385415246E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2253857849773E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7308378174473E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7878196880268E-05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5342942413284E-03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5301076188974E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0581237511235E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0332794890516E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3278588991294E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1517616020703E-03
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0871191023561E-05
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378295586651E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1436254455606E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.0219619995027E-06
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0906271388125E-03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3910383164964E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1558758253181E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3506530315151E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -6.4577551597618E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.4146163991417E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.0175106259832E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8181489156679E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5244221604671E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3493824434459E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015427363980E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879385409458E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.45761744290652E+00  3.33597886225108E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.43114686768087E-17  3.49934992197269E-03
- cg2d: Sum(rhs),rhsMax =   3.74608577771221E+00  3.61303112154743E+00
- cg2d: Sum(rhs),rhsMax =   3.74608577771221E+00  3.61303112154743E+00
+ cg2d: Sum(rhs),rhsMax =   6.17995238316738E-18  3.49934970105552E-03
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -8.67361737988404E-19  2.04009079277674E-03
+ cg2d: Sum(rhs),rhsMax =   2.25514051876985E-17  2.04009046652893E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
  cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
  cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
  cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
- cg2d: Sum(rhs),rhsMax =   3.02165677723545E+00  3.85995008150527E+00
- cg2d: Sum(rhs),rhsMax =   3.02165677723545E+00  3.85995008150527E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -5.20417042793042E-18  2.83603672734962E-03
+ cg2d: Sum(rhs),rhsMax =   6.93889390390723E-18  2.83603652392051E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3101801013388E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8263620934877E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0212151814051E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9722009896571E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2827338301164E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7298927373607E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9068311699402E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6382637505725E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0019827367317E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7395804595122E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0394345731860E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2932775772404E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6108819660737E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459180696612E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8614874136286E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5723374537563E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5761509791543E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.9911012328743E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5424976902943E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.4433780436899E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3101801259183E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8263621263518E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0212151755591E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9722009943326E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2827338188074E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7298927920136E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9068311090507E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6382637644528E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0019827358433E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7395804557796E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0394345719167E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2932775759382E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6108819652866E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459180698244E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8614874145103E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5723374577767E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5761510053863E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.9911011083166E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5424976681291E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.4433780471732E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5635,16 +5625,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.7326004384743E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5323297714459E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.1785283174055E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.5860531939873E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.1994468299708E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3649463686804E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4855932027774E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.3376170432116E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5528616343266E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.1329486931449E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.7326004554033E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5323297899198E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.1785282917849E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.5860531982840E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.1994468338146E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3649463960068E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4855931729822E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.3376170629186E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5528616350171E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.1329486764011E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5655,11 +5645,11 @@
 (PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   2.1290842093108E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -5.7245160769056E-06
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   4.9525260827790E-08
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   6.6586301183567E-07
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.6341030589188E-08
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   2.1290842081962E-05
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -5.7245169067443E-06
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   4.9525263379392E-08
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   6.6586303616265E-07
+(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.6341031931099E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
 (PID.TID 0000.0001) // =======================================================
@@ -5668,60 +5658,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   8.5127903614654E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.1985425825330E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   6.0032882512814E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   8.8477319649954E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.9470281052261E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.9558318898072E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0323614050962E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.0428608650291E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   8.0888521883215E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.9309085237010E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.0081819730743E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -6.3382742578460E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.4670867482381E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.6421392519878E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.2799121593281E-04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0115042677825E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3886256149689E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   7.4174628865136E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.9062800170882E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8882191829470E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   8.5127904282191E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.1985429469905E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   6.0032881659038E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   8.8477319726328E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.9470281106601E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.9558318895732E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0323613587113E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.0428609421341E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   8.0888521884122E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.9309085440237E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.0081822320763E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -6.3382740306536E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.4670865469439E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.6421391425346E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.2799121476821E-04
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0115042687650E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3886256102212E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   7.4174628436492E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.9062800152346E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8882191784564E-01
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.9314236145034E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.5403425575118E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1141425093303E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.5433223309827E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.4313581430145E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.9314236150111E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.5403425637727E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1141415891887E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.5433223076222E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.4313581470611E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3732123755813E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2180612549978E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.2025294089641E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9083171997170E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.3797648181185E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.2932775772404E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.0394345731860E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.5385497808186E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.6189842949413E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.7873883873858E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.6202531125453E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.9692088083136E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -1.0030767203649E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.9066512490327E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.1734122002686E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3732123746512E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2180612538734E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.2025294076235E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9083171998782E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.3797648185690E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.2932775759382E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.0394345719167E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.5385497790899E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.6189842951266E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.7873883878089E-06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.6202531167736E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.9692088130213E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -1.0030786159124E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.9066512274657E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.1734121828239E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27601731093161E+00  4.04197216976108E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5732,31 +5721,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   1.9246047352709E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.6093149342319E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.6374460834453E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.4112080298405E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.3838092061006E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4967200470682E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.8726116053634E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.9845591068385E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4604072761885E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4797065301275E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.9876797081603E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6357394195707E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.9330079365001E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.8201112793369E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8116331350830E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.0115873946998E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.2720952884160E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.3928765063308E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.3380525569237E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.2399285740419E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.3945591182648E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.1160766149767E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.0367655858146E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.6647887761050E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.9254582349747E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.0388330102371E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.5880894635139E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0265709117742E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.4112080465147E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.3838091739858E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4967195457508E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.8726116406241E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.9845591594114E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4604074014395E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4797065995985E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.9876801251131E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6357394013078E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.9330079648082E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.8201115190336E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8116331215956E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.0115873595623E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.2720952924657E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.3928764808781E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.3380525567395E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.2399285741789E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.3945591995389E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.1160766199097E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.0367655865500E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.6647887733214E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.9254623638710E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.0388334329248E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.5880895268354E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0265709267515E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5765,72 +5754,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     3
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1740570789975E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2161412152078E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4515862046046E-04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5199416328803E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9193969614546E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299887556964E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7473232180148E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1535815638471E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5798586455726E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2193436477466E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4297516900930E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3620086814255E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.4730089569924E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4491017933552E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5500929688691E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4086999495277E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7138933528228E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -5.7118628992054E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.0005838206788E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.2012719519834E-01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.2362863097541E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3468628732172E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.0777679613349E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.5386075242141E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.3366635559377E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1740571535125E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2161412010073E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4515862504626E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5199416405814E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9193969869688E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299887390782E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7473232141681E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1535815233256E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5798586412304E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2193436150449E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4297517729715E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3620086118978E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.4730089547544E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4491018070847E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5500929401755E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4086999459622E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7138933509604E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -5.7118628660053E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.0005838173599E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.2012719500522E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.2362863084963E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3468628725405E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.0777679493126E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.5386075230068E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.3366635552046E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27601731093161E+00  4.04197216976108E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   5.74627151417317E-18  1.94342370168409E-03
- cg2d: Sum(rhs),rhsMax =   1.52697356396389E+00  4.17022492069095E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356396389E+00  4.17022492069095E+00
+ cg2d: Sum(rhs),rhsMax =  -1.75640751942652E-17  1.94342368675061E-03
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.11672823766007E-17  1.58412650951596E-03
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   7.73551085820188E-01  3.29048620660793E+00
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   7.73551085820188E-01  3.29048620660793E+00
+ cg2d: Sum(rhs),rhsMax =   7.48099499014998E-18  1.58412648734265E-03
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.30104260698261E-18  2.31197682134806E-03
+ cg2d: Sum(rhs),rhsMax =  -1.30104260698261E-18  2.31197703703447E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7854907035946E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3593797926574E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9946259658151E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7801460806345E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1545359184938E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5235986053804E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0450547710477E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8893202706610E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6411923492292E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5371341776976E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956895808118E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4091308957400E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.6081886656656E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7477999384520E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419808809650E-05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5374192818442E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5386443041705E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.9597312188293E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8362029788087E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5438155357476E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7854907650343E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3593798356716E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9946259290888E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7801460856860E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1545359388769E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5235986070066E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0450547779028E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8893203615448E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6411923442741E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5371341591614E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956895803745E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4091308948291E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.6081886646773E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7477999386743E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419808810625E-05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5374192852953E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5386443041251E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.9597311761153E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8362029510534E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5438155316060E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5839,16 +5821,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.7437493332585E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5917439816729E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.0334921699502E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.3230816530720E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.4571099397669E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8536307922746E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.7803670691572E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.5126411575117E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0863856131650E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.4470654047962E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.7437493743617E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5917439895689E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.0334921270305E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.3230816572385E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.4571099497600E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8536308029025E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.7803669262983E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.5126412371241E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0863856107057E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.4470653941238E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5872,56 +5854,56 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2418305485880E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.8761239108940E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   5.6973780504993E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.2058591799972E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.6152238796388E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   8.1282796950066E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -4.2181549778942E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -6.7348719361147E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2667665472804E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.8534386212353E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.9794371462481E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -7.8403071628040E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.3820400169634E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.1173179042706E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6913856393849E-04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.2303164214307E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9344367724212E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4127176266296E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.4104584762685E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7048370937346E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2418305570607E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.8761239112234E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   5.6973778517272E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.2058591887654E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.6152238703263E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   8.1282773927222E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -4.2181549763028E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -6.7348730573240E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2667665460814E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.8534386052205E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.9794362675887E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -7.8403060618549E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.3820397878295E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.1173179004010E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6913855890912E-04
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.2303164046281E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9344367516751E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4127176199600E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.4104584754864E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7048370860393E-01
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5844471638647E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.5078972822532E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =  -2.0062538818745E+01
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.8351921146065E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.5335240039852E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5844471635580E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.5078972858726E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =  -2.0062518573437E+01
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.8351920871613E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.5335239993460E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4076784523722E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -3.3104314672783E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.2973075505153E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1823111376511E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.1110830028144E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3244027538852E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -4.5956895808118E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.0068386845135E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   8.3424966299430E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.1242862532620E-05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.8498693025856E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8315974689899E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -1.3526067815068E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   8.4404590423756E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.4907407766668E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4076784519630E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -3.3104314669592E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.2973075435537E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1823111378958E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.1110830027001E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3244027533740E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -4.5956895803745E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.0068386753406E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   8.3424966302278E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.1242862532324E-05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.8498693297198E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8315974787183E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -1.3526085386808E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   8.4404589373559E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.4907407108766E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5938,31 +5920,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9804679844584E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.1266024162948E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3033452026391E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2821267757018E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.4659141959571E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3452712435062E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.4013573427687E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.3654360756461E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3890261256742E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.6337378248056E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9804680348074E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.1266023981405E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3033448927737E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2821267694218E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.4659142166707E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3452713430160E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.4013571898089E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.3654369000928E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3890260664704E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.6337378326569E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0955080468336E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.4242604574666E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5284797929908E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4371375471154E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700842226111E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174214524050E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4711297462673E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6221911288091E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3393233517056E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6754515984717E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0955080420031E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.4242604569479E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5284799098629E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4371375577351E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700842237147E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174214509438E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4711305561207E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6221911902664E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3393233631783E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6754516385784E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5971,31 +5953,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     0
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8132190158664E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1834666789276E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0929056752997E-04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2608529064188E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1070350753065E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890935529597E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5622148562645E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9716226252357E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1005505028846E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9936605659477E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1711785892570E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3353849894936E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6468626400488E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3711473510365E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2630055531376E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9823477434906E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7087608644044E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -7.4160671406192E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   8.9981377706913E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.1722230789632E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8072393771696E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3460042687431E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.6948834350333E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2631377894835E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.2507621761732E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8132191297611E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1834666623637E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0929057897657E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2608529202088E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1070351106290E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890935349381E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5622148527256E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9716220093132E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1005504968013E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9936605066522E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1711786189105E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3353849744159E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6468625453491E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3711473517757E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2630055483285E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9823477397125E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7087608714628E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -7.4160671285878E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   8.9981377688008E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.1722230786254E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8072393758011E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3460042713133E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.6948834307503E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2631377887967E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.2507621749226E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6094,9 +6076,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31895291454067E+04
 grad-res -------------------------------
  grad-res     0    1    1    1    1    1    1    1   3.31895297944E+04  3.31895305189E+04  3.31895291454E+04
- grad-res     0    1    1    1    0    1    1    1   5.09790591896E-02  6.86745897838E-02 -3.47113714445E-01
+ grad-res     0    1    1    1    0    1    1    1   5.09790554643E-02  6.86745897838E-02 -3.47113812885E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31895297944020E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09790591895580E-02
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09790554642677E-02
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.86745897837682E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
@@ -6358,9 +6340,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31895297370160E+04
 grad-res -------------------------------
  grad-res     0    4    4    1    1    1    1    1   3.31895297944E+04  3.31895297875E+04  3.31895297370E+04
- grad-res     0    4    4    4    0    1    1    1   4.67482395470E-03  2.52482968790E-03  4.59909140458E-01
+ grad-res     0    4    4    4    0    1    1    1   4.67482302338E-03  2.52482968790E-03  4.59909032861E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31895297944020E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.67482395470142E-03
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.67482302337885E-03
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.52482968789991E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
@@ -6376,7 +6358,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   1  3.3189529794402E+04  3.3189530518898E+04  3.3189529145407E+04
-(PID.TID 0000.0001) grdchk output (g):   1     6.8674589783768E-02  5.0979059189558E-02 -3.4711371444522E-01
+(PID.TID 0000.0001) grdchk output (g):   1     6.8674589783768E-02  5.0979055464268E-02 -3.4711381288544E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   2  3.3189529794402E+04  3.3189530420841E+04  3.3189529122173E+04
@@ -6388,258 +6370,258 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   4  3.3189529794402E+04  3.3189529787513E+04  3.3189529737016E+04
-(PID.TID 0000.0001) grdchk output (g):   4     2.5248296878999E-03  4.6748239547014E-03  4.5990914045849E-01
+(PID.TID 0000.0001) grdchk output (g):   4     2.5248296878999E-03  4.6748230233788E-03  4.5990903286109E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.3257474786292E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.3257473635042E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   224.87598030641675
-(PID.TID 0000.0001)         System time:   4.2411730587482452
-(PID.TID 0000.0001)     Wall clock time:   233.86054086685181
+(PID.TID 0000.0001)           User time:   261.57172036916018
+(PID.TID 0000.0001)         System time:   3.7431039810180664
+(PID.TID 0000.0001)     Wall clock time:   283.41399979591370
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   1.0883580073714256
-(PID.TID 0000.0001)         System time:  0.30474801361560822
-(PID.TID 0000.0001)     Wall clock time:   1.7668879032135010
+(PID.TID 0000.0001)           User time:   1.6839419826865196
+(PID.TID 0000.0001)         System time:  0.37137998640537262
+(PID.TID 0000.0001)     Wall clock time:   2.3726098537445068
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   133.03464567661285
-(PID.TID 0000.0001)         System time:   2.9669170379638672
-(PID.TID 0000.0001)     Wall clock time:   139.15104079246521
+(PID.TID 0000.0001)           User time:   122.01326441764832
+(PID.TID 0000.0001)         System time:   2.3394979238510132
+(PID.TID 0000.0001)     Wall clock time:   133.24424099922180
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   100.18816804885864
-(PID.TID 0000.0001)         System time:  0.37805730104446411
-(PID.TID 0000.0001)     Wall clock time:   101.97866892814636
+(PID.TID 0000.0001)           User time:   144.92237949371338
+(PID.TID 0000.0001)         System time:  0.48906904458999634
+(PID.TID 0000.0001)     Wall clock time:   153.55122780799866
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0196883678436279
-(PID.TID 0000.0001)         System time:   1.0606050491333008E-003
-(PID.TID 0000.0001)     Wall clock time:   2.0326793193817139
+(PID.TID 0000.0001)           User time:   2.4456906318664551
+(PID.TID 0000.0001)         System time:   4.3926835060119629E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5616633892059326
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2778239250183105
-(PID.TID 0000.0001)         System time:   8.4087431430816650E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4928967952728271
+(PID.TID 0000.0001)           User time:   3.2396762371063232
+(PID.TID 0000.0001)         System time:   6.7929148674011230E-002
+(PID.TID 0000.0001)     Wall clock time:   3.5185043811798096
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.3405480384826660
-(PID.TID 0000.0001)         System time:   9.0241074562072754E-002
-(PID.TID 0000.0001)     Wall clock time:   1.5617623329162598
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   3.1263146400451660
+(PID.TID 0000.0001)         System time:   6.7339181900024414E-002
+(PID.TID 0000.0001)     Wall clock time:   3.4046058654785156
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.1743469238281250E-004
-(PID.TID 0000.0001)         System time:   3.3915042877197266E-005
-(PID.TID 0000.0001)     Wall clock time:   9.2601776123046875E-004
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   7.2574615478515625E-004
+(PID.TID 0000.0001)         System time:   1.1146068572998047E-005
+(PID.TID 0000.0001)     Wall clock time:   8.5186958312988281E-004
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18015956878662109
-(PID.TID 0000.0001)         System time:   5.9211254119873047E-004
-(PID.TID 0000.0001)     Wall clock time:  0.18137168884277344
+(PID.TID 0000.0001)           User time:  0.35948109626770020
+(PID.TID 0000.0001)         System time:   4.3118000030517578E-003
+(PID.TID 0000.0001)     Wall clock time:  0.41223597526550293
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7647218704223633E-002
-(PID.TID 0000.0001)         System time:   6.2942504882812500E-005
-(PID.TID 0000.0001)     Wall clock time:   6.7764043807983398E-002
+(PID.TID 0000.0001)           User time:   8.5258245468139648E-002
+(PID.TID 0000.0001)         System time:   1.8292665481567383E-004
+(PID.TID 0000.0001)     Wall clock time:   8.5813999176025391E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   22.707337617874146
-(PID.TID 0000.0001)         System time:   9.3906462192535400E-002
-(PID.TID 0000.0001)     Wall clock time:   23.090027809143066
+(PID.TID 0000.0001)           User time:   32.634188175201416
+(PID.TID 0000.0001)         System time:  0.12008345127105713
+(PID.TID 0000.0001)     Wall clock time:   35.026981592178345
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.1907031536102295
-(PID.TID 0000.0001)         System time:   4.4456124305725098E-003
-(PID.TID 0000.0001)     Wall clock time:   2.2093946933746338
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   4.3645236492156982
+(PID.TID 0000.0001)         System time:   1.8995285034179688E-002
+(PID.TID 0000.0001)     Wall clock time:   4.6577699184417725
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.6401689052581787
-(PID.TID 0000.0001)         System time:   3.7301778793334961E-003
-(PID.TID 0000.0001)     Wall clock time:   1.6577754020690918
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   3.1158931255340576
+(PID.TID 0000.0001)         System time:   1.4984250068664551E-002
+(PID.TID 0000.0001)     Wall clock time:   3.3508486747741699
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   7.2074534893035889
-(PID.TID 0000.0001)         System time:   1.5881299972534180E-002
-(PID.TID 0000.0001)     Wall clock time:   7.3428823947906494
-(PID.TID 0000.0001)          No. starts:         264
-(PID.TID 0000.0001)           No. stops:         264
+(PID.TID 0000.0001)           User time:   8.2642426490783691
+(PID.TID 0000.0001)         System time:   8.2607865333557129E-003
+(PID.TID 0000.0001)     Wall clock time:   8.8893122673034668
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   21.813256025314331
-(PID.TID 0000.0001)         System time:   4.3410062789916992E-004
-(PID.TID 0000.0001)     Wall clock time:   22.084770917892456
+(PID.TID 0000.0001)           User time:   26.455229282379150
+(PID.TID 0000.0001)         System time:   3.6488771438598633E-003
+(PID.TID 0000.0001)     Wall clock time:   28.181684017181396
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4598860740661621
-(PID.TID 0000.0001)         System time:   1.8107891082763672E-004
-(PID.TID 0000.0001)     Wall clock time:   3.4710092544555664
+(PID.TID 0000.0001)           User time:   8.2971901893615723
+(PID.TID 0000.0001)         System time:   4.2312741279602051E-003
+(PID.TID 0000.0001)     Wall clock time:   8.5519115924835205
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5569577217102051
-(PID.TID 0000.0001)         System time:   4.2027235031127930E-004
-(PID.TID 0000.0001)     Wall clock time:   1.6149578094482422
+(PID.TID 0000.0001)           User time:   3.3075618743896484
+(PID.TID 0000.0001)         System time:   4.0781497955322266E-003
+(PID.TID 0000.0001)     Wall clock time:   3.3761281967163086
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.53041958808898926
-(PID.TID 0000.0001)         System time:   8.4757804870605469E-005
-(PID.TID 0000.0001)     Wall clock time:  0.54130363464355469
+(PID.TID 0000.0001)           User time:  0.69877338409423828
+(PID.TID 0000.0001)         System time:   7.3194503784179688E-005
+(PID.TID 0000.0001)     Wall clock time:  0.76126813888549805
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1085562705993652
-(PID.TID 0000.0001)         System time:   4.0680766105651855E-003
-(PID.TID 0000.0001)     Wall clock time:   1.1143002510070801
+(PID.TID 0000.0001)           User time:   2.4231801033020020
+(PID.TID 0000.0001)         System time:   4.0915012359619141E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5585913658142090
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2129001617431641E-002
-(PID.TID 0000.0001)         System time:   6.5803527832031250E-005
-(PID.TID 0000.0001)     Wall clock time:   8.7147951126098633E-002
+(PID.TID 0000.0001)           User time:  0.22207927703857422
+(PID.TID 0000.0001)         System time:   8.2314014434814453E-005
+(PID.TID 0000.0001)     Wall clock time:  0.22696924209594727
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9631042480468750
-(PID.TID 0000.0001)         System time:  0.10412800312042236
-(PID.TID 0000.0001)     Wall clock time:   5.1525089740753174
+(PID.TID 0000.0001)           User time:   12.597478866577148
+(PID.TID 0000.0001)         System time:  0.11859393119812012
+(PID.TID 0000.0001)     Wall clock time:   13.167008161544800
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   23.270267248153687
-(PID.TID 0000.0001)         System time:   2.4202227592468262E-002
-(PID.TID 0000.0001)     Wall clock time:   23.609496355056763
+(PID.TID 0000.0001)           User time:   28.757848739624023
+(PID.TID 0000.0001)         System time:   3.1269133090972900E-002
+(PID.TID 0000.0001)     Wall clock time:   30.248376846313477
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7329406738281250E-004
-(PID.TID 0000.0001)         System time:   8.8810920715332031E-006
-(PID.TID 0000.0001)     Wall clock time:   7.8368186950683594E-004
+(PID.TID 0000.0001)           User time:   9.4556808471679688E-004
+(PID.TID 0000.0001)         System time:   7.7486038208007812E-006
+(PID.TID 0000.0001)     Wall clock time:   8.8834762573242188E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.33965349197387695
-(PID.TID 0000.0001)         System time:   2.0885467529296875E-004
-(PID.TID 0000.0001)     Wall clock time:  0.34820628166198730
+(PID.TID 0000.0001)           User time:  0.52240753173828125
+(PID.TID 0000.0001)         System time:   7.0333480834960938E-006
+(PID.TID 0000.0001)     Wall clock time:  0.54837679862976074
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.8116188049316406E-004
-(PID.TID 0000.0001)         System time:   7.2121620178222656E-006
-(PID.TID 0000.0001)     Wall clock time:   6.6494941711425781E-004
+(PID.TID 0000.0001)           User time:   6.7281723022460938E-004
+(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
+(PID.TID 0000.0001)     Wall clock time:   7.6031684875488281E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25185513496398926
-(PID.TID 0000.0001)         System time:   7.8878998756408691E-003
-(PID.TID 0000.0001)     Wall clock time:  0.27096557617187500
+(PID.TID 0000.0001)           User time:  0.59683084487915039
+(PID.TID 0000.0001)         System time:   1.5109717845916748E-002
+(PID.TID 0000.0001)     Wall clock time:  0.65968489646911621
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13311719894409180
-(PID.TID 0000.0001)         System time:   5.5831849575042725E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18915200233459473
+(PID.TID 0000.0001)           User time:  0.32646799087524414
+(PID.TID 0000.0001)         System time:   8.7515890598297119E-002
+(PID.TID 0000.0001)     Wall clock time:  0.45331954956054688
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.8403062820434570
-(PID.TID 0000.0001)         System time:   7.5063943862915039E-002
-(PID.TID 0000.0001)     Wall clock time:   2.1163029670715332
+(PID.TID 0000.0001)           User time:   3.6433887481689453
+(PID.TID 0000.0001)         System time:   7.2693943977355957E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9871866703033447
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.43009090423583984
-(PID.TID 0000.0001)         System time:   5.6385397911071777E-002
-(PID.TID 0000.0001)     Wall clock time:  0.48774003982543945
+(PID.TID 0000.0001)           User time:  0.47706794738769531
+(PID.TID 0000.0001)         System time:  0.14012753963470459
+(PID.TID 0000.0001)     Wall clock time:  0.83186435699462891
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.19029235839843750
-(PID.TID 0000.0001)         System time:   4.3824911117553711E-002
-(PID.TID 0000.0001)     Wall clock time:  0.30479693412780762
+(PID.TID 0000.0001)           User time:  0.37516021728515625
+(PID.TID 0000.0001)         System time:   2.8243780136108398E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42074584960937500
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20387268066406250
-(PID.TID 0000.0001)         System time:   2.3931026458740234E-002
-(PID.TID 0000.0001)     Wall clock time:  0.22815203666687012
+(PID.TID 0000.0001)           User time:  0.22261047363281250
+(PID.TID 0000.0001)         System time:   1.5960216522216797E-002
+(PID.TID 0000.0001)     Wall clock time:  0.23881411552429199
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   90.358703613281250
-(PID.TID 0000.0001)         System time:  0.90171694755554199
-(PID.TID 0000.0001)     Wall clock time:   92.409539937973022
+(PID.TID 0000.0001)           User time:   137.27663421630859
+(PID.TID 0000.0001)         System time:  0.98799085617065430
+(PID.TID 0000.0001)     Wall clock time:   147.13747715950012
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   7.1891632080078125
-(PID.TID 0000.0001)         System time:  0.39872527122497559
-(PID.TID 0000.0001)     Wall clock time:   7.6807050704956055
+(PID.TID 0000.0001)           User time:   12.169746398925781
+(PID.TID 0000.0001)         System time:  0.40932917594909668
+(PID.TID 0000.0001)     Wall clock time:   13.741947174072266
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   83.145828247070312
-(PID.TID 0000.0001)         System time:  0.48700141906738281
-(PID.TID 0000.0001)     Wall clock time:   84.683926820755005
+(PID.TID 0000.0001)           User time:   125.09156799316406
+(PID.TID 0000.0001)         System time:  0.56356287002563477
+(PID.TID 0000.0001)     Wall clock time:   133.34758186340332
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8035888671875000
-(PID.TID 0000.0001)         System time:   2.7511835098266602E-002
-(PID.TID 0000.0001)     Wall clock time:   1.8623507022857666
+(PID.TID 0000.0001)           User time:   6.7923431396484375
+(PID.TID 0000.0001)         System time:   2.7940034866333008E-002
+(PID.TID 0000.0001)     Wall clock time:   7.2899816036224365
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.55413818359375000
-(PID.TID 0000.0001)         System time:   4.3658971786499023E-002
-(PID.TID 0000.0001)     Wall clock time:  0.60235524177551270
+(PID.TID 0000.0001)           User time:  0.69148254394531250
+(PID.TID 0000.0001)         System time:   1.1882305145263672E-002
+(PID.TID 0000.0001)     Wall clock time:  0.78047895431518555
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   77.743713378906250
-(PID.TID 0000.0001)         System time:  0.19660305976867676
-(PID.TID 0000.0001)     Wall clock time:   78.922663927078247
+(PID.TID 0000.0001)           User time:   112.29781341552734
+(PID.TID 0000.0001)         System time:  0.26619291305541992
+(PID.TID 0000.0001)     Wall clock time:   119.29996013641357
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.20257568359375000
-(PID.TID 0000.0001)         System time:   2.1934509277343750E-005
-(PID.TID 0000.0001)     Wall clock time:  0.20983934402465820
+(PID.TID 0000.0001)           User time:  0.50663757324218750
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:  0.51583218574523926
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7852783203125000E-003
-(PID.TID 0000.0001)         System time:   5.2452087402343750E-006
-(PID.TID 0000.0001)     Wall clock time:   1.7981529235839844E-003
+(PID.TID 0000.0001)           User time:   2.4871826171875000E-003
+(PID.TID 0000.0001)         System time:   7.1525573730468750E-006
+(PID.TID 0000.0001)     Wall clock time:   2.5203227996826172E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.9703369140625000
-(PID.TID 0000.0001)         System time:   8.7756156921386719E-002
-(PID.TID 0000.0001)     Wall clock time:   2.0822017192840576
+(PID.TID 0000.0001)           User time:   3.5582885742187500
+(PID.TID 0000.0001)         System time:  0.16389250755310059
+(PID.TID 0000.0001)     Wall clock time:   4.0615916252136230
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.6632080078125000E-002
-(PID.TID 0000.0001)         System time:   6.1035156250000000E-005
-(PID.TID 0000.0001)     Wall clock time:   1.6686916351318359E-002
+(PID.TID 0000.0001)           User time:   5.1055908203125000E-002
+(PID.TID 0000.0001)         System time:   1.9690990447998047E-003
+(PID.TID 0000.0001)     Wall clock time:   5.3037166595458984E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6679,9 +6661,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         243868
+(PID.TID 0000.0001) //            No. barriers =         234788
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         243868
+(PID.TID 0000.0001) //     Total barrier spins =         234788
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.core2.txt
+++ b/global_oce_llc90/results/output_adm.core2.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node113.cm.cluster
-(PID.TID 0000.0001) // Build date:        Tue Apr 20 00:47:29 EDT 2021
+(PID.TID 0000.0001) // Build host:        node016
+(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node113.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -4120,40 +4120,36 @@
  cg2d: Sum(rhs),rhsMax =   3.10862446895044E-14  4.62868955957220E-02
  cg2d: Sum(rhs),rhsMax =  -1.18571819029967E-13  4.51184359657494E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   1.80031638485900E-08  4.51184379790066E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   1.80031638485900E-08  4.51184379790066E-02
  Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   2.04346698525100E-20  1.81186037021313E-06
- cg2d: Sum(rhs),rhsMax =  -9.54404422159882E-09  4.62868919053793E-02
- cg2d: Sum(rhs),rhsMax =  -9.54404422159882E-09  4.62868919053793E-02
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.44742409532500E-19  1.23068566108754E-05
+ cg2d: Sum(rhs),rhsMax =   9.12254484192881E-19  1.23068566104377E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   4.4571683556715E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -4.0186052866610E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.1540487613611E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9078633892610E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7694594029896E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.2085842766383E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.3752631551846E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.3857908326947E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   6.1608297174416E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7916543228336E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.2687831846671E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.7809532005566E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.2726244088994E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4691455247987E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.4461703127102E-08
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1740797016349E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.3164062465322E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1061352527014E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9655041103708E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.2643527757212E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   4.4571683586574E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -4.0186052717060E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.1540487620546E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9078633884519E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7694594030478E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.2085842632029E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.3752631121034E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.3857908368587E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   6.1608297157288E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7916543227447E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.2687831845393E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.7809532006091E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.2726244088977E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4691455247990E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.4461703126962E-08
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1740797016350E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.3164062465618E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1061352560617E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9655041103660E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.2643527757197E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4162,16 +4158,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5634269684047E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5753676537514E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.0532180575864E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.9805567732469E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   6.0464969963513E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8943492146525E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3003412938907E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.3726217507421E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.1361468950009E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   6.2368938272165E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5634269679666E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5753676363565E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.0532180582874E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.9805567730133E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   6.0464969961820E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8943492126884E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3003412912397E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.3726217552723E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.1361468931790E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   6.2368938257675E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4195,60 +4191,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.6579409012181E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -3.8494691835226E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.8125592857661E-07
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.4897267235109E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   8.4699933540305E-07
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   5.0938286433869E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.7400160146405E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.3620094415373E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1989209603215E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   8.7761197474287E-07
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1635519798222E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2062814449960E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.3226276231944E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.6011301136500E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.0977909553701E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.1454848420421E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3637531526540E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.4810049277829E-03
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6085257236209E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.9707313159963E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.6579409017662E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -3.8494692280799E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.8125589991265E-07
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.4897267232904E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   8.4699933476077E-07
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   5.0938287535020E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.7400160153450E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.3620094424913E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1989209600181E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   8.7761197429853E-07
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1635525616149E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2062814299230E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.3226276717849E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.6011301269939E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.0977909704077E-07
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.1454848447969E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3637531487921E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.4810049415889E-03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6085257236130E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.9707313108573E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.3164062465322E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1740797016349E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1061352527014E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9655041103708E+03
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.2643527757212E+01
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.3164062465618E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1740797016350E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1061352560617E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9655041103660E+03
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.2643527757197E+01
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.0874502104833E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.5094487106871E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   9.9422401425805E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.0634822656286E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0553311691494E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.7809532005566E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.2687831846671E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.2726244088994E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.4691455247987E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.4461703127102E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.3164062465322E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1740797016349E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1061352527014E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9655041103708E+03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.2643527757212E+01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.0874502105207E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.5094487105955E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   9.9422401425679E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.0634822656282E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0553311691362E-08
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.7809532006091E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.2687831845393E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.2726244088977E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.4691455247990E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.4461703126962E-08
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.3164062465618E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1740797016350E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1061352560617E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9655041103660E+03
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.2643527757197E+01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   1.05192248245345E-07  4.78829716118617E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4259,75 +4254,70 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.8249138387426E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.5665824092617E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.5813600863499E-04
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2001156853347E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.7429094832038E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.1352585637846E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5693330201009E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.9690477650675E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.1983359662048E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.3635197195174E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.4406350542953E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6147328449407E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.0774921918563E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.0384297716925E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.2135314245476E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.1986378239250E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.4908277499969E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5104279261534E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8446396354732E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.3428222959864E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.8995007291425E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.2725005955518E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.3847122539070E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4221299017216E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0819365065736E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.8249138386130E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.5665824775745E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.5813599490544E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2001156865418E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.7429094803342E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.1352585605422E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5693330193281E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.9690478564684E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.1983359684082E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.3635197224581E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.4406350647829E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6147328447246E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.0774920080750E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.0384297738190E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.2135314246563E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.1986378239452E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.4908277499962E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5104279261470E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8446396354585E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.3428222959638E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.8995007291426E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.2725005955509E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.3847122538803E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4221299017207E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0819365065793E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   1.05192248245345E-07  4.78829716118617E-02
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.71050543121376E-19  3.35616035509018E-05
- cg2d: Sum(rhs),rhsMax =   3.10724281860075E-08  4.91676446125386E-02
- cg2d: Sum(rhs),rhsMax =   3.10724281860075E-08  4.91676446125386E-02
+ cg2d: Sum(rhs),rhsMax =   4.23516473627150E-19  3.35616017148429E-05
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   9.09713385351119E-19  6.11359017110232E-05
+ cg2d: Sum(rhs),rhsMax =   8.40256683676266E-19  6.11359000645173E-05
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.49800180540660E-15  4.10108399308005E-02
  cg2d: Sum(rhs),rhsMax =   8.13932254928318E-15  4.56571171210609E-02
  cg2d: Sum(rhs),rhsMax =   6.13398221105399E-14  4.87116106299301E-02
  cg2d: Sum(rhs),rhsMax =   7.01660951563099E-14  4.97483791440217E-02
- cg2d: Sum(rhs),rhsMax =  -9.08268349419927E-08  4.97483765460063E-02
- cg2d: Sum(rhs),rhsMax =  -9.08268349419927E-08  4.97483765460063E-02
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.35136346157794E-18  9.30047674266384E-05
+ cg2d: Sum(rhs),rhsMax =   1.25360876193636E-19  9.30047782264482E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2968520531799E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3026968111225E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.3529122957573E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.1809944389721E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.7545877368539E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.3648772595314E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2506065686525E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.9215034558351E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.2014084900670E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.6382169316981E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.5670848722488E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -7.2377541713980E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.9532722711354E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.3717306867697E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.4549437964446E-08
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.9353426736063E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.5428003609347E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7235698420231E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   9.9088366076747E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.1579604658320E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2968520425816E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3026968300815E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.3529122708443E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.1809944414171E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.7545877499121E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.3648772662891E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2506065199872E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.9215034472189E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.2014084911927E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.6382169408844E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.5670848722458E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -7.2377541696784E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.9532722711877E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.3717306867731E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.4549437963973E-08
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.9353426736058E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.5428003612819E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7235698831913E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   9.9088366079390E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.1579604660209E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4336,16 +4326,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.4162955392932E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.5376180509200E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.9177748576368E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2641880877774E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2194745160608E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.1478404599196E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -8.9299614589923E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -6.8483237962127E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2792498236476E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.1846962671369E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.4162955458749E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.5376181486670E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.9177748311692E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2641880883245E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2194745174510E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.1478404641807E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -8.9299614628041E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -6.8483237892249E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2792498236829E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.1846962694663E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4369,60 +4359,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   6.4288096987934E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.8321999536584E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -6.1369484092139E-06
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   4.1984103008477E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.7293878958565E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2354118166161E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0880555091860E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -3.7545685579579E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.4161814388185E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.3993963439235E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.3982762411605E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.0727939355537E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.6131605474847E-08
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.6776488138862E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.1961072618565E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.0054896813056E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.4828998249755E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3692142404729E-02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.0331777931081E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.4295596789698E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   6.4288096993120E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.8321997857039E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -6.1369484376287E-06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   4.1984103000164E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.7293879002082E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2354117946729E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0880555277910E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -3.7545685524903E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.4161814413118E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.3993963436684E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.3982762471406E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.0727939397142E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.6132091641362E-08
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.6776488198521E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.1961073215847E-07
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.0054896816329E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.4828998332013E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3692142454920E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.0331777931957E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.4295596801843E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.5428003609347E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.9353426736063E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7235698420231E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   9.9088366076747E+03
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.1579604658320E+01
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.5428003612819E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.9353426736058E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7235698831913E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   9.9088366079390E+03
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.1579604660209E+01
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   5.5511119071684E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1286778747981E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3262777643693E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.0197161385423E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.5418099171930E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   7.2377541713980E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.5670848722488E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.9532722711354E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3717306867697E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.4549437964446E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.5428003609347E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.9353426736063E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7235698420231E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   9.9088366076747E+03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.1579604658320E+01
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   5.5511119068674E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1286778747961E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3262777644121E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.0197161385449E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.5418099172009E-08
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   7.2377541696784E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.5670848722458E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.9532722711877E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3717306867731E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.4549437963973E-08
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.5428003612819E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.9353426736058E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7235698831913E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   9.9088366079390E+03
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.1579604660209E+01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.26542384851314E-09  4.87116116481421E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4433,72 +4422,65 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   9.8684725009112E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.5719136805920E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2894632618018E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3046265136190E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.6586792851420E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.2020065156449E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4525244436665E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.7810195019610E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.3611651199705E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5473179691179E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.4481346948006E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2115989670543E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.5123090168532E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2418504840763E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.3722101760170E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.3386038461766E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.0459457937191E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.5316367238326E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.7187172191489E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3557626918232E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.8893419449301E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.8543531255292E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.7813099611371E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.7865830175035E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2996390539905E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   9.8684724638322E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.5719136759881E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2894635856059E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3046265209382E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.6586792889005E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.2020065022478E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4525244942799E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.7810194304817E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.3611651244607E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5473179714160E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.4481346902183E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2115989654777E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.5123088779715E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2418504823442E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.3722101782101E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.3386038462999E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.0459457937453E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.5316367236351E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.7187172191311E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3557626917883E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.8893419449307E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.8543531257133E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.7813099602464E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.7865830173724E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2996390520220E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.26542384851314E-09  4.87116116481421E-02
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.42301535138722E-18  1.27414992973540E-04
- cg2d: Sum(rhs),rhsMax =  -1.21821960262503E-08  4.56571154424117E-02
- cg2d: Sum(rhs),rhsMax =  -1.21821960262503E-08  4.56571154424117E-02
+ cg2d: Sum(rhs),rhsMax =   2.30054148474268E-18  1.27414982274337E-04
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.43606675630337E-18  1.62830201916412E-04
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -1.94138871645322E-11  4.10108398147269E-02
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -1.94138871645322E-11  4.10108398147269E-02
+ cg2d: Sum(rhs),rhsMax =  -1.74149973955484E-18  1.62830216162880E-04
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -4.74338450462408E-20  1.98180038415838E-04
+ cg2d: Sum(rhs),rhsMax =  -2.96800344717907E-18  1.98180025122208E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.8714600859417E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.0201516272101E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.6134243437576E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.8778462929028E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9058030795194E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.0965922172331E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.2977258689531E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.2934112144672E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.8524462521194E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.6196847990389E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.5044462861347E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.1058019208725E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3123833957893E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.2174822425990E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.5481850713414E-08
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.1320835171911E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -4.3670395943501E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.1284942137787E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.4257550460718E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1602879394198E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.8714602162422E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.0201515592667E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.6134242542401E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.8778462981716E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9058031098013E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.0965922523405E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.2977258844039E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.2934112161189E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.8524462604125E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.6196848227125E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.5044462861154E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.1058019209738E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3123833957083E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.2174822425960E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.5481850714715E-08
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.1320835171870E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -4.3670395950260E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.1284943137609E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.4257550460704E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1602879394227E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4507,16 +4489,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.2705668169359E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -8.3048615536839E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   6.7318757602731E-05
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4817992157606E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.8207457867086E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   8.1272542479269E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4447340383631E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.2799386653473E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.4768021454878E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.7377752592382E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.2705668199550E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -8.3048617357172E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   6.7318748963161E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4817992159423E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.8207457849589E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   8.1272545249236E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4447340385797E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.2799386680675E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.4768021491332E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.7377752705846E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4540,56 +4522,56 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2023120747477E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.5863285756450E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.4505358401220E-05
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.1594457108423E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.3255083265174E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7603951418709E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.3683490643302E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.9603382797642E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.8025319693269E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0807262466463E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.6105881286602E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8945207205626E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -3.0780435900256E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6514856304462E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2748325019874E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.5711949742380E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.1155258204631E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4577827428317E-02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.1911132154247E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.9845270929025E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2023120787073E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.5863286231947E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.4505358607863E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.1594457186374E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.3255083268334E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7603951700615E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.3683490377210E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.9603382789596E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.8025319702761E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0807262513813E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.6105869013262E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8945207670506E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -3.0780436520385E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6514856286127E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2748322056517E-07
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.5711949919574E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.1155258321159E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4577827539795E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.1911132153955E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.9845270909134E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   4.3670395943501E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.1320835171911E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.1284942137787E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.4257550460718E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1602879394198E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   4.3670395950260E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.1320835171870E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.1284943137609E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.4257550460704E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1602879394227E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.0334500490859E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.8057832730138E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.4447804863465E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.6484197401204E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.0939230307336E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.1058019208725E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5044462861347E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.3123833957893E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.2174822425990E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.5481850713414E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.3670395943501E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.1320835171911E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   4.1284942137787E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.4257550460718E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1602879394198E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.0334500491522E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.8057832729991E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.4447804862923E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.6484197401207E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.0939230309710E-08
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.1058019209738E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5044462861154E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.3123833957083E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.2174822425960E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.5481850714715E-08
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.3670395950260E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.1320835171870E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   4.1284943137609E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.4257550460704E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1602879394227E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4606,31 +4588,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.0229491631009E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.2682717066103E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.7491449897145E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.5173884261030E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.7648169625925E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.5190521257195E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8465168276792E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.7598929083633E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6731943363772E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6505755623510E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.0229491497922E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.2682717204361E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.7491459258770E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.5173884276572E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.7648169578874E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.5190521237512E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8465168149023E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.7598925100070E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6731943371241E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6505755592513E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.4038083237437E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.4537263516000E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -8.5203014470622E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.6694218416640E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1642437992859E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   8.6251812063034E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5631803010560E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2214259277175E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   5.6572600993036E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9896294666873E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.4038083237266E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.4537263516015E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -8.5203014471578E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.6694218416760E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1642437992635E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   8.6251812063491E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5631803010437E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2214259277537E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   5.6572600988621E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9896294613993E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4976,231 +4958,231 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4985.8652470409870
-(PID.TID 0000.0001)         System time:   8.4209833443164825
-(PID.TID 0000.0001)     Wall clock time:   5014.6719031333923
+(PID.TID 0000.0001)           User time:   4916.3673114776611
+(PID.TID 0000.0001)         System time:   9.6577443778514862
+(PID.TID 0000.0001)     Wall clock time:   4961.3287570476532
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.652215570211411
-(PID.TID 0000.0001)         System time:  0.76423203945159912
-(PID.TID 0000.0001)     Wall clock time:   16.799004077911377
+(PID.TID 0000.0001)           User time:   10.807338714599609
+(PID.TID 0000.0001)         System time:  0.79642099142074585
+(PID.TID 0000.0001)     Wall clock time:   20.550608873367310
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1994.9107427597046
-(PID.TID 0000.0001)         System time:   3.2711271047592163
-(PID.TID 0000.0001)     Wall clock time:   2008.3458759784698
+(PID.TID 0000.0001)           User time:   1953.0573348999023
+(PID.TID 0000.0001)         System time:   4.5264140367507935
+(PID.TID 0000.0001)     Wall clock time:   1974.9236829280853
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   394.49496459960938
-(PID.TID 0000.0001)         System time:  0.52513837814331055
-(PID.TID 0000.0001)     Wall clock time:   397.56387805938721
+(PID.TID 0000.0001)           User time:   388.95480346679688
+(PID.TID 0000.0001)         System time:  0.60153794288635254
+(PID.TID 0000.0001)     Wall clock time:   392.52657961845398
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2768249511718750
-(PID.TID 0000.0001)         System time:   1.6331672668457031E-005
-(PID.TID 0000.0001)     Wall clock time:   8.2833154201507568
+(PID.TID 0000.0001)           User time:   8.1662597656250000
+(PID.TID 0000.0001)         System time:   8.9406967163085938E-006
+(PID.TID 0000.0001)     Wall clock time:   8.1766622066497803
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3164062500000000
-(PID.TID 0000.0001)         System time:   5.6995034217834473E-002
-(PID.TID 0000.0001)     Wall clock time:   4.9532520771026611
+(PID.TID 0000.0001)           User time:   3.7137451171875000
+(PID.TID 0000.0001)         System time:   6.7908644676208496E-002
+(PID.TID 0000.0001)     Wall clock time:   4.6315917968750000
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.0061035156250000
-(PID.TID 0000.0001)         System time:   3.6008238792419434E-002
-(PID.TID 0000.0001)     Wall clock time:   4.3698387145996094
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   3.0557556152343750
+(PID.TID 0000.0001)         System time:   3.8937091827392578E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9136316776275635
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   7.3242187500000000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.8156929016113281E-004
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   1.7089843750000000E-003
+(PID.TID 0000.0001)         System time:   1.0728836059570312E-006
+(PID.TID 0000.0001)     Wall clock time:   9.1743469238281250E-004
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.61737060546875000
-(PID.TID 0000.0001)         System time:   1.9999742507934570E-003
-(PID.TID 0000.0001)     Wall clock time:  0.61995601654052734
+(PID.TID 0000.0001)           User time:  0.63842773437500000
+(PID.TID 0000.0001)         System time:   2.0129680633544922E-003
+(PID.TID 0000.0001)     Wall clock time:  0.64180660247802734
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.26025390625000000
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25875806808471680
+(PID.TID 0000.0001)           User time:  0.25485229492187500
+(PID.TID 0000.0001)         System time:   3.0994415283203125E-006
+(PID.TID 0000.0001)     Wall clock time:  0.25481200218200684
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.690277099609375
-(PID.TID 0000.0001)         System time:   8.0097913742065430E-003
-(PID.TID 0000.0001)     Wall clock time:   13.710698604583740
+(PID.TID 0000.0001)           User time:   13.696655273437500
+(PID.TID 0000.0001)         System time:   1.0994911193847656E-002
+(PID.TID 0000.0001)     Wall clock time:   13.732310771942139
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   116.42584228515625
-(PID.TID 0000.0001)         System time:   4.9915313720703125E-003
-(PID.TID 0000.0001)     Wall clock time:   116.86531710624695
+(PID.TID 0000.0001)           User time:   116.59762573242188
+(PID.TID 0000.0001)         System time:   1.9818544387817383E-003
+(PID.TID 0000.0001)     Wall clock time:   117.55935811996460
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4599609375000000
-(PID.TID 0000.0001)         System time:   1.1444091796875000E-005
-(PID.TID 0000.0001)     Wall clock time:   3.4611737728118896
+(PID.TID 0000.0001)           User time:   1.7053527832031250
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.7102818489074707
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   19.928100585937500
-(PID.TID 0000.0001)         System time:   1.1993169784545898E-002
-(PID.TID 0000.0001)     Wall clock time:   19.955070972442627
+(PID.TID 0000.0001)           User time:   18.985900878906250
+(PID.TID 0000.0001)         System time:   1.0937333106994629E-002
+(PID.TID 0000.0001)     Wall clock time:   19.025936365127563
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6202392578125000
-(PID.TID 0000.0001)         System time:   1.0037422180175781E-003
-(PID.TID 0000.0001)     Wall clock time:   2.6209893226623535
+(PID.TID 0000.0001)           User time:   2.6135559082031250
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   2.6193728446960449
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8622131347656250
-(PID.TID 0000.0001)         System time:   1.0051727294921875E-003
-(PID.TID 0000.0001)     Wall clock time:   4.8652424812316895
+(PID.TID 0000.0001)           User time:   4.8597106933593750
+(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
+(PID.TID 0000.0001)     Wall clock time:   4.8675458431243896
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.39382934570312500
-(PID.TID 0000.0001)         System time:   2.3841857910156250E-006
-(PID.TID 0000.0001)     Wall clock time:  0.39372634887695312
+(PID.TID 0000.0001)           User time:  0.46298217773437500
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:  0.46077632904052734
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.1452026367187500
-(PID.TID 0000.0001)         System time:   4.9741268157958984E-003
-(PID.TID 0000.0001)     Wall clock time:   7.1538310050964355
+(PID.TID 0000.0001)           User time:   6.5264282226562500
+(PID.TID 0000.0001)         System time:   5.9270858764648438E-003
+(PID.TID 0000.0001)     Wall clock time:   6.5459289550781250
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   83.909667968750000
-(PID.TID 0000.0001)         System time:   2.0186901092529297E-003
-(PID.TID 0000.0001)     Wall clock time:   83.944688796997070
+(PID.TID 0000.0001)           User time:   84.085510253906250
+(PID.TID 0000.0001)         System time:   1.0008811950683594E-003
+(PID.TID 0000.0001)     Wall clock time:   84.212562799453735
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.1879882812500000E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.0360641479492188E-004
+(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.3770027160644531E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.70800781250000000
+(PID.TID 0000.0001)           User time:  0.70907592773437500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.71164727210998535
+(PID.TID 0000.0001)     Wall clock time:  0.70825767517089844
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0517578125000000E-004
+(PID.TID 0000.0001)           User time:   1.5869140625000000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9454650878906250E-004
+(PID.TID 0000.0001)     Wall clock time:   9.3722343444824219E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0391540527343750
-(PID.TID 0000.0001)         System time:  0.10597705841064453
-(PID.TID 0000.0001)     Wall clock time:   2.3721368312835693
+(PID.TID 0000.0001)           User time:   1.9491577148437500
+(PID.TID 0000.0001)         System time:  0.12294709682464600
+(PID.TID 0000.0001)     Wall clock time:   2.2904894351959229
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5992736816406250
-(PID.TID 0000.0001)         System time:  0.32409095764160156
-(PID.TID 0000.0001)     Wall clock time:   3.5638835430145264
+(PID.TID 0000.0001)           User time:   2.7984313964843750
+(PID.TID 0000.0001)         System time:  0.36789083480834961
+(PID.TID 0000.0001)     Wall clock time:   3.5039451122283936
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.309143066406250
-(PID.TID 0000.0001)         System time:  0.66710901260375977
-(PID.TID 0000.0001)     Wall clock time:   23.612319469451904
+(PID.TID 0000.0001)           User time:   22.414459228515625
+(PID.TID 0000.0001)         System time:  0.68059468269348145
+(PID.TID 0000.0001)     Wall clock time:   23.673845529556274
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7227478027343750
-(PID.TID 0000.0001)         System time:  0.14801430702209473
-(PID.TID 0000.0001)     Wall clock time:   7.8823313713073730
+(PID.TID 0000.0001)           User time:   7.7311096191406250
+(PID.TID 0000.0001)         System time:  0.14391803741455078
+(PID.TID 0000.0001)     Wall clock time:   7.9017894268035889
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5627441406250000
-(PID.TID 0000.0001)         System time:  0.10899877548217773
-(PID.TID 0000.0001)     Wall clock time:   3.7809531688690186
+(PID.TID 0000.0001)           User time:   3.7773437500000000
+(PID.TID 0000.0001)         System time:   8.3970069885253906E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9107668399810791
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5794677734375000
-(PID.TID 0000.0001)         System time:   8.2993030548095703E-002
-(PID.TID 0000.0001)     Wall clock time:   3.6933879852294922
+(PID.TID 0000.0001)           User time:   3.7657470703125000
+(PID.TID 0000.0001)         System time:   7.7972888946533203E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8754119873046875
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2973.1599121093750
-(PID.TID 0000.0001)         System time:   4.1936144828796387
-(PID.TID 0000.0001)     Wall clock time:   2982.0525770187378
+(PID.TID 0000.0001)           User time:   2944.9594726562500
+(PID.TID 0000.0001)         System time:   4.1729574203491211
+(PID.TID 0000.0001)     Wall clock time:   2958.0681581497192
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2626.7037353515625
-(PID.TID 0000.0001)         System time:   3.0784010887145996
-(PID.TID 0000.0001)     Wall clock time:   2633.1791234016418
+(PID.TID 0000.0001)           User time:   2600.9876708984375
+(PID.TID 0000.0001)         System time:   3.0358805656433105
+(PID.TID 0000.0001)     Wall clock time:   2611.2404878139496
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   346.18066406250000
-(PID.TID 0000.0001)         System time:   1.1012072563171387
-(PID.TID 0000.0001)     Wall clock time:   348.37222003936768
+(PID.TID 0000.0001)           User time:   343.68530273437500
+(PID.TID 0000.0001)         System time:   1.0980844497680664
+(PID.TID 0000.0001)     Wall clock time:   346.46100163459778
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5827636718750000
-(PID.TID 0000.0001)         System time:   1.0104179382324219E-003
-(PID.TID 0000.0001)     Wall clock time:   5.5884103775024414
+(PID.TID 0000.0001)           User time:   5.4433593750000000
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   5.4557538032531738
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8798828125000000E-002
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.9501209259033203E-002
+(PID.TID 0000.0001)           User time:   2.0019531250000000E-002
+(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
+(PID.TID 0000.0001)     Wall clock time:   1.8821954727172852E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   307.28979492187500
-(PID.TID 0000.0001)         System time:   6.2110424041748047E-002
-(PID.TID 0000.0001)     Wall clock time:   307.59557843208313
+(PID.TID 0000.0001)           User time:   304.71826171875000
+(PID.TID 0000.0001)         System time:   7.7772140502929688E-002
+(PID.TID 0000.0001)     Wall clock time:   305.61288905143738
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.9128417968750000
-(PID.TID 0000.0001)         System time:  0.33000802993774414
-(PID.TID 0000.0001)     Wall clock time:   6.5658130645751953
+(PID.TID 0000.0001)           User time:   5.8908691406250000
+(PID.TID 0000.0001)         System time:  0.32171344757080078
+(PID.TID 0000.0001)     Wall clock time:   6.5572729110717773
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   2.1972656250000000E-003
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   2.4797916412353516E-003
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3858547210693359E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   26.708984375000000
-(PID.TID 0000.0001)         System time:  0.70706129074096680
-(PID.TID 0000.0001)     Wall clock time:   27.931826353073120
+(PID.TID 0000.0001)           User time:   26.827148437500000
+(PID.TID 0000.0001)         System time:  0.69658565521240234
+(PID.TID 0000.0001)     Wall clock time:   28.019211769104004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.9541015625000000E-002
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   3.3944129943847656E-002
+(PID.TID 0000.0001)           User time:  0.15039062500000000
+(PID.TID 0000.0001)         System time:   2.0008087158203125E-003
+(PID.TID 0000.0001)     Wall clock time:  0.15749573707580566
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -5240,9 +5222,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         906982
+(PID.TID 0000.0001) //            No. barriers =         879510
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         906982
+(PID.TID 0000.0001) //     Total barrier spins =         879510
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecco_v4.txt
+++ b/global_oce_llc90/results/output_adm.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node113.cm.cluster
-(PID.TID 0000.0001) // Build date:        Tue Apr 20 00:47:29 EDT 2021
+(PID.TID 0000.0001) // Build host:        node016
+(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node113.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -5145,7 +5145,6 @@
  cg2d: Sum(rhs),rhsMax =   3.01472254612810E+00  1.07091042398987E+00
  cg2d: Sum(rhs),rhsMax =   3.01809829994306E+00  1.05630803624323E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.01809804902057E+00  1.05630806396422E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5218,7 +5217,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01809804902057E+00  1.05630806396422E+00
  Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   2.71050543121376E-18  1.83998182747982E-04
 (PID.TID 0000.0001) // =======================================================
@@ -5226,26 +5224,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.8758899944093E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.6687260487571E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0738515859087E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0034051380603E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7911886396875E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2851323147728E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.2899846240936E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4325526956349E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8185245122417E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6464240396467E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.8758899369461E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.6687258099322E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0738515875897E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0034051363709E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7911886422220E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2851323347224E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.2899846458991E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4325526564714E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8185245114819E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6464240404793E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4801456261814E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4079817633290E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.8226351576354E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0664897132867E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2870936147529E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1079833601173E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.8431569807894E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6682919103039E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4392367813246E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1823452133083E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1079833601456E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.8431569788541E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6682919101314E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4392367811590E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1823452132892E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5254,16 +5252,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4531182470143E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0740346588457E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0311218633673E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7346589970054E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7106493225952E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.9875791140356E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9336594475522E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.3093939909887E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5677189105597E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7880724030072E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4531181932778E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0740345742281E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0311218656433E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7346589953662E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7106493136070E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.9875791185885E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9336593364647E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.3093939516737E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5677189093854E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7880723996945E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5287,26 +5285,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6126392479852E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9676557169184E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.3677977195106E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9752703985594E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6880315589966E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0663746526609E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.1881558299920E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9098481609017E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3204884505038E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6539349142385E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6126396016881E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9676558494346E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.3677977672729E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9752704117103E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6880315603269E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0663747102484E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.1881558296345E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9098481616668E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3204884507762E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6539349149534E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.8431569807894E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1079833601173E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6682919103039E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4392367813246E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1823452133083E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.8431569788541E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1079833601456E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6682919101314E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4392367811590E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1823452132892E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -5322,15 +5320,14 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.7679561029063E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.8544950218881E-05
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2484808063103E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.8431569807894E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1079833601173E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6682919103039E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4392367813246E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1823452133083E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.8431569788541E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1079833601456E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6682919101314E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4392367811590E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1823452132892E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01472242461314E+00  1.07091042206398E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5341,31 +5338,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9135930285760E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.6551971142765E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3895549288318E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544229106221E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4448086160703E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2879846643740E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4246597946933E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5577525077514E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2799629093749E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.2897168577273E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.1637904746707E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.6643201107018E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   7.3241495398418E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4515807847302E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2286869679818E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580719837536E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705323600729E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557545958155E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247710503106E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1000350673115E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475534218077E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752403227063E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5936296997758E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306503522356E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0380578674787E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9135930596408E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.6551970829961E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3895548809321E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544229111382E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4448086269833E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2879846510821E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4246597837622E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5577525868682E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2799629156548E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.2897168701688E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.1637905010133E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.6643200153683E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   7.3241495356222E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4515807843473E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2286869688428E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580719837999E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705323600726E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557545958153E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247710503101E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1000350673150E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475534218075E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752403227068E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5936296997748E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306503522320E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0380578674820E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5402,34 +5399,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01472242461314E+00  1.07091042206398E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.46655994240452E-18  3.43198702012042E-04
+ cg2d: Sum(rhs),rhsMax =   1.97866896478605E-18  3.43198734061423E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9995028873870E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1176522311530E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1377715084435E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9719156484910E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9228170308918E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4388953226933E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9384174758494E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6629102811290E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3362660195365E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4641771436579E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.9189952672066E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8072001484397E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.8429890696398E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4053262908030E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5588195400448E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1865934340179E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -5.7561083888994E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.2813928406459E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0840648399117E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3528772209678E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9995028854331E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1176522333010E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1377715007240E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9719156506581E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9228170512808E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4388953106296E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9384174643432E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6629102784185E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3362660182616E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4641771469180E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.9189952674226E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8072001481306E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.8429890693585E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4053262908028E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5588195400337E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1865934339719E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -5.7561083877836E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.2813928390479E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0840648398440E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3528772208326E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5438,16 +5434,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4983255929916E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.1725264946601E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0098741459677E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2573906554990E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5311786286164E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3773949827433E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5327290926537E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6295665796038E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6821767177635E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4874920401333E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4983255957851E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.1725264302623E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0098741384199E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2573906551208E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5311786322997E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3773949691577E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5327290878263E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6295665766392E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6821767165086E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4874920424319E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5471,50 +5467,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3691294472177E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6769990661561E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1633999980328E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7791270322262E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3381184122630E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7208213177780E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3639019421710E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0229979001103E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6020684821267E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2026105446232E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3691284724346E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6769991280096E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1633999955376E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7791270322055E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3381184017690E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7208213159439E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3639019426031E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0229978976175E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6020684821232E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2026105427586E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   5.7561083888994E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1865934340179E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.2813928406459E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0840648399117E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3528772209678E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   5.7561083877836E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1865934339719E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.2813928390479E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0840648398440E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3528772208326E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9419234174030E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6582871503355E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.5551493233828E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2168656333783E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1805693780180E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5429841439865E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.7114254091904E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   7.6076993975505E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3631665020789E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4820549538435E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   5.7561083888994E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1865934340179E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.2813928406459E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0840648399117E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3528772209678E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9419234171854E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6582871504927E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.5551493232197E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2168656333782E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1805693780096E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5429841436867E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.7114254093999E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   7.6076993972776E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3631665020787E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4820549538327E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   5.7561083877836E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1865934339719E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.2813928390479E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0840648398440E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3528772208326E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01200061493434E+00  1.08234535716197E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5525,31 +5520,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0667655370873E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3542603823550E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5750431592997E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8196315167270E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7875723106352E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255694023116E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2647771166755E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1391402378636E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6491561799057E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7707143273543E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.1022639980875E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -9.9682470265663E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.8201405738599E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4698082029798E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   7.6286861302862E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826306859060E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046795622961E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336343615923E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362557213252E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6406366628141E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211604918394E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164899184868E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902020131842E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9451818924769E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5556511146889E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0667656109274E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3542603781008E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5750442943458E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8196315148899E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7875723133133E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255694116981E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2647771242968E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1391401975753E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6491561781347E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7707143276532E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.1022640078354E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -9.9682470814772E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.8201405529672E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4698082046678E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   7.6286861433825E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826306858980E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046795622960E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336343615909E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362557213243E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6406366628015E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211604918392E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164899184870E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902020131784E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9451818924714E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5556511146799E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5586,34 +5581,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01200061493434E+00  1.08234535716197E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.39679281766448E-18  8.65048493731531E-04
+ cg2d: Sum(rhs),rhsMax =   8.40256683676266E-18  8.65048531509537E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.6279083337773E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2237190983607E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0107788915643E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1604310070050E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9416583463184E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9189793694288E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0084405091682E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2474846126997E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0182171254440E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0469870784975E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0316555898193E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3197624097976E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.6684796466531E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0987064433762E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8188223226728E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2279701453904E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.7213238160628E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.8532385201715E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6216682739661E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5133726353408E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.6279083248426E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2237190967463E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0107788777493E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1604310068420E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9416583620302E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9189793717794E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0084405005862E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2474846284866E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0182171253877E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0469870820264E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0316555898603E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3197624098651E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.6684796466827E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0987064433763E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8188223226663E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2279701454202E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.7213238184832E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.8532385169142E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6216682738011E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5133726350699E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5622,16 +5616,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8660503853293E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2677776390122E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7712569439353E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0342282669672E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.8072899296444E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6300632862032E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3105539455593E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1892072020604E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0434719554551E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6526693685399E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8660503833875E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2677776380290E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7712569301726E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0342282665224E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.8072899298828E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6300632829017E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3105539347820E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1892072175880E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0434719546211E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6526693723497E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5655,50 +5649,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4260705407422E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299403121514E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8660940040240E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6519235869196E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9727963817909E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5396233231947E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.6079777351722E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2773239599436E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8726639870964E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3750212176846E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4260707228637E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299403720935E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8660940078146E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6519235855505E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9727963797760E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5396233221289E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.6079777333666E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2773239566631E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8726639869267E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3750212175373E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   8.7213238160628E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2279701453904E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.8532385201715E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6216682739661E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5133726353408E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   8.7213238184832E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2279701454202E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.8532385169142E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6216682738011E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5133726350699E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1898259256809E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.4457269200539E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1647857166340E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8189004908414E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2584400678410E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2801695375037E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0007059221247E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.6184252572535E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1898259257292E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.4457269203445E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1647857166616E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8189004908415E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2584400678367E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2801695375692E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0007059221645E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.6184252572823E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0357452500750E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.7042576529926E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   8.7213238160628E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2279701453904E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.8532385201715E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6216682739661E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5133726353408E+02
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.7042576529863E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   8.7213238184832E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2279701454202E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.8532385169142E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6216682738011E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5133726350699E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01016033991108E+00  1.08987441826371E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5709,31 +5702,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4777670117211E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6379963989741E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7758012481773E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2388282775073E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3373516415180E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327163960223E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4171258846775E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3669397964911E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9848877028504E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3440475824406E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.7470318926042E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6633751423424E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.5009382476422E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.1286094985534E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3555815497010E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084958526612E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379699085843E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1115200817198E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4469809850108E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171616611121E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946318020102E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557085891731E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864639509238E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2591519378395E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721071046190E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4777670008827E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6379963814218E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7758013576422E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2388282729193E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3373516450593E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327164350506E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4171259132144E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3669397309840E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9848876949320E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3440475820800E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.7470318870572E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6633751594756E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.5009381491078E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.1286095000319E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3555815509055E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084958526493E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379699085804E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1115200817193E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4469809850095E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171616611024E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946318020123E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557085891735E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864639509249E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2591519378424E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721071046217E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5770,34 +5763,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01016033991108E+00  1.08987441826371E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -8.78203759713259E-18  1.48391646097158E-03
+ cg2d: Sum(rhs),rhsMax =  -7.80625564189563E-18  1.48391655861559E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4797679039613E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5828915571717E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5330685291092E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8655548675021E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3543817912149E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.3070758857629E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7729335802374E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3828597177461E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6179167808756E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2159854768985E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3672268094779E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7578669898305E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6579729702723E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7881285077715E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0700771561403E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2107420057664E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.1734356276710E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0397899306695E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1564325751319E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6673068727518E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4797678974140E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5828915613610E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5330685316710E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8655548672628E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3543817914778E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.3070758890077E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7729335862215E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3828597235329E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6179167814681E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2159854774284E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3672268095354E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7578669897267E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6579729703412E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7881285077753E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0700771561458E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2107420058163E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.1734356274896E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0397899305024E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1564325750820E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6673068727494E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5806,16 +5798,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3659945184127E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0756656139853E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1624626167208E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6776052275576E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5621138971697E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5667418069489E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0623118170882E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2990546711644E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4506904203092E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2901259010438E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3659944976062E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0756656129737E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1624626179823E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6776052272880E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5621138970655E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5667418153337E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0623118062154E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2990546760450E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4506904208674E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2901259132320E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5839,46 +5831,46 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9278831152349E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898435619579E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.6014649103686E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5234785768513E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6290764726580E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3320791523024E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.9683216643926E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6228732344573E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1513647443913E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8387734696619E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9278830449193E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898435444952E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.6014648993513E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5234785785145E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6290764725961E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3320791532239E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.9683216645617E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6228732309785E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1513647445910E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8387734693235E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.1734356276710E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2107420057664E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0397899306695E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1564325751319E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6673068727518E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.1734356274896E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2107420058163E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0397899305024E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1564325750820E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6673068727494E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5844814147559E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1204297640794E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.8466998055394E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4182636893737E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3304466554726E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7051309801356E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3262100051936E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.5782337811641E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7044846525383E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.9179748414561E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.1734356276710E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2107420057664E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0397899306695E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1564325751319E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6673068727518E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5844814146830E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1204297641203E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.8466998055916E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4182636893775E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3304466554771E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7051309800349E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3262100052493E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.5782337812310E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7044846525421E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.9179748414614E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.1734356274896E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2107420058163E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0397899305024E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1564325750820E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6673068727494E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5887,7 +5879,6 @@
  cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
  cg2d: Sum(rhs),rhsMax =   3.01041588518803E+00  1.09558808552461E+00
  cg2d: Sum(rhs),rhsMax =   3.00954214495678E+00  1.09443701612858E+00
- cg2d: Sum(rhs),rhsMax =   3.00954232920302E+00  1.09443700049974E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5898,31 +5889,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2469354166945E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2827672405172E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7078644826867E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1467055029260E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2121766241245E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6981947475454E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8501439625593E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0358564636476E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174223887304E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2709865644928E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.5883803778173E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.8625067660505E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.3886581991659E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.4340888952001E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.1162587759168E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332480671555E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703351750631E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893861396588E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5568871250679E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692310569414E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679408844953E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952061633548E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9823399124682E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572618291162E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5877246890001E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2469354087709E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2827672314149E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7078645293542E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1467055019812E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2121766218041E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6981947415104E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8501439738455E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0358563944396E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174223872684E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2709865632243E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.5883803668365E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.8625067421442E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.3886582070263E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.4340888957800E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.1162587750100E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332480671457E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703351750621E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893861396555E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5568871250668E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692310569296E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679408844988E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952061633547E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9823399124595E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572618291171E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5877246890138E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5959,34 +5950,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00954232920302E+00  1.09443700049974E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.90312782094782E-18  2.12700167827571E-03
+ cg2d: Sum(rhs),rhsMax =  -8.89045781438114E-18  2.12700156386073E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8600140991266E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0950997352977E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3456554162412E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6891297878276E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8470429177999E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2093532631231E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2255014887377E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859405853366E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3201761137066E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6647799825807E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6982575705955E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1949357757375E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.5859782805042E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4747508567759E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.3122109520889E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.1075160385284E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.4805373147263E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2912231247731E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6854309914756E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8094767331110E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8600140943421E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0950997398100E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3456554186319E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6891297881857E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8470429159115E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2093532620038E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2255014968746E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859405838521E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3201761144393E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6647799832291E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6982575706626E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1949357757113E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.5859782808232E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4747508567802E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.3122109521037E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.1075160385497E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.4805373146061E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2912231244552E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6854309912259E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8094767327777E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5995,16 +5985,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.3156635230211E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.9626217880464E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2939112602545E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4355264207871E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0677597501115E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8696397426425E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.7983720781837E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752421691230E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0973908559090E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0340397683196E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.3156635253562E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.9626217883980E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2939112627101E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4355264215678E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0677597505367E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8696397461624E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.7983720860548E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752421676536E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0973908565850E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0340397688450E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -6028,50 +6018,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4415691420596E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3556006756951E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.3366007559011E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4000624962168E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3150836063264E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.0989870082780E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.1475728540320E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.1006438849410E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1453352329029E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3198492640123E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4415695500091E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3556007363895E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.3366007472245E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4000624961638E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3150836075995E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.0989870122305E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.1475728542463E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.1006438844960E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1453352328803E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3198492638159E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.4805373147263E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.1075160385284E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2912231247731E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6854309914756E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8094767331110E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.4805373146061E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.1075160385497E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2912231244552E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6854309912259E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8094767327778E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9781199624624E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3931505711563E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.4879427668121E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0157291516163E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3963744595564E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1290877024653E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6473098434777E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.4783989320891E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3705083310727E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.1228446235262E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.4805373147263E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.1075160385284E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2912231247731E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6854309914756E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8094767331110E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9781199624435E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3931505712049E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.4879427670648E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0157291516211E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3963744595650E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1290877024399E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6473098435427E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.4783989323985E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3705083310768E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.1228446235406E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.4805373146061E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.1075160385497E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2912231244552E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6854309912259E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8094767327778E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01041588832618E+00  1.09558808150575E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6082,31 +6071,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0415637787646E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2587745738562E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6445721124423E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6328915657379E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3261127721881E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745027571986E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5167262562934E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0862954151459E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6057007443546E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4609070640010E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.8144905733999E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3089173233442E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.6809553847730E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3351696277020E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0254493636852E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567483818974E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017181540515E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6672169755772E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6659746682309E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202292879049E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410546849756E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349671545442E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777756090208E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0415637361552E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2587745507645E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6445719276007E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6328915667709E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3261127709471E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745027702195E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5167261964454E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0862956193087E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6057007444720E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4609070615323E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.8144905637407E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3089173043266E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.6809554475260E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3351696278040E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0254493633048E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567483818839E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017181540489E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6672169755761E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6659746682313E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202292878963E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410546849798E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349671545443E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777756090213E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885584216966E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1029198270756E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1029198270915E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6143,34 +6132,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01041588832618E+00  1.09558808150575E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.90819582357449E-17  2.73193000324363E-03
+ cg2d: Sum(rhs),rhsMax =  -2.79724160501260E-17  2.73193028507770E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0254693506428E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6475876190170E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7489072501109E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6057944773134E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3476559247219E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1433198042827E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3983880938737E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5460354801932E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1113165576955E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1332084239128E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0174887573768E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6308728297572E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3962373377045E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1583406159135E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5450427071343E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.6025636549994E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.7646974303318E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5401201978463E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2098958059756E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9408959291318E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0254693517014E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6475876268829E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7489072544012E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6057944782375E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3476559269881E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1433198042228E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3983881100957E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5460354760838E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1113165580782E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1332084251991E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0174887574244E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6308728293783E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3962373380901E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1583406159201E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5450427071305E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.6025636545436E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.7646974313196E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5401201974998E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2098958057846E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9408959289305E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -6179,16 +6167,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2767467745263E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.8573819600508E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6818471650546E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2854439485610E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4024872862566E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3846641218600E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7442291451388E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5333608194581E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8324104016109E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3707274337436E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2767468005799E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.8573819609290E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6818471692760E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2854439494387E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4024872869128E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3846641300051E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7442291655488E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5333608152384E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8324104018058E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3707274332473E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -6212,50 +6200,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9664371953862E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660911546794E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.0266587564925E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2875882239667E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0140266982944E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8407625448977E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.4164896587699E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3399752836110E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3795626772255E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8267447423657E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9664372514837E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660911753061E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.0266587578439E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2875882210522E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0140267016203E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8407625530913E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.4164896586704E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3399752832635E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3795626771864E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8267447427287E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.7646974303318E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.6025636549994E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5401201978463E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2098958059756E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9408959291318E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.7646974313196E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.6025636545436E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5401201974998E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2098958057846E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9408959289305E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3707065442375E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6582605286730E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.0521957959175E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6111496503565E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4565247134130E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5519466448645E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9569640946555E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.2643502175733E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0335903974361E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.3186914259202E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.7646974303318E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.6025636549994E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5401201978463E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2098958059756E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9408959291318E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3707065439655E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6582605287081E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.0521957962119E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6111496503640E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4565247133964E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5519466444970E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9569640947017E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.2643502179474E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0335903974425E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.3186914259166E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.7646974313196E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.6025636545436E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5401201974998E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2098958057846E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9408959289305E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01104383800070E+00  1.09179583702524E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6266,31 +6253,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7943507063985E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5366734069047E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4567528913338E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1647452074605E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5956858007518E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190134808630E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3751278784101E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4180961404427E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1451313416266E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8168504008297E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0205314922809E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.9658933300613E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.0469243155680E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7840899881221E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0201487681784E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788639750732E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320716935090E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449660099232E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743073136476E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7702490121006E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139344090610E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749415509852E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572525557658E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6198390900177E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6182356443620E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7943506924813E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5366733568503E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4567527158862E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1647452082352E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5956858087584E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190134564256E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3751277819551E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4180962979348E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1451313419764E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8168504071997E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0205314912310E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.9658933016879E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.0469243138794E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7840899889130E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0201487748772E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788639750645E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320716935130E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449660099298E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743073136511E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7702490120993E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139344090621E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749415509853E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572525557696E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6198390900189E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6182356444269E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6327,34 +6314,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01104383800070E+00  1.09179583702524E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   8.67361737988404E-18  3.23777153727352E-03
+ cg2d: Sum(rhs),rhsMax =   1.49619899803000E-17  3.23777135165434E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2507345372296E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.1084287204570E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1327366403350E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5947252574042E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8432475929509E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4724407299443E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4414086039232E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.8987699123837E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9779499272732E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6127899630105E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3321984982226E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0655626365276E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.4218849806755E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8370920473222E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7692026766676E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.1683477301428E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.0765888382223E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7809190811658E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7240878983172E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0293016239265E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2507345381697E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.1084287222895E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1327366439986E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5947252578721E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8432475922299E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4724407312723E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4414086134162E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.8987699078360E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9779499273613E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6127899630873E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3321984982391E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0655626361390E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.4218849807799E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8370920473367E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7692026766278E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.1683477299418E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.0765888387199E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7809190809761E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7240878982131E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0293016237734E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -6363,16 +6349,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0101319177454E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.9992771495502E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0501375818688E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2070937720027E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7482912804134E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1920864799059E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6382739340974E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8848206568340E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6417644648197E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7283513339186E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0101319186962E+01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.9992771397770E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0501375853708E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2070937724444E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7482912799120E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1920864816418E+01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6382739401770E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8848206521569E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6417644648835E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7283513337642E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -6396,51 +6382,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4700405202211E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2823644388143E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.8215042118805E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1289980667906E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1622042188876E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.6944745984139E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.6500396853259E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5591839332977E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5969349849512E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2553506718963E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4700406747830E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2823643751000E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.8215042253110E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1289980625213E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1622042207730E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.6944745974094E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.6500396856167E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5591839332732E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5969349848657E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2553506720180E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.0765888382223E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.1683477301428E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7809190811658E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7240878983172E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0293016239265E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.0765888387199E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.1683477299418E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7809190809761E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7240878982131E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0293016237734E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7621988030266E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9205314374027E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.7718437040336E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2034708089618E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.5127567717839E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9735957574318E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2622325432759E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   5.2592284312552E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6919792859025E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.5061265963676E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.0765888382223E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.1683477301428E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7809190811658E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7240878983172E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0293016239265E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7621988027388E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9205314374157E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.7718437040968E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2034708089762E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.5127567717328E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9735957570548E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2622325432919E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   5.2592284313566E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6919792859166E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.5061265963290E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.0765888387199E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.1683477299418E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7809190809761E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7240878982131E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0293016237734E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.01093922340877E+00  1.08516769462177E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6451,31 +6435,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807630573172E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090809411445E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0355509159526E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7262274947941E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1952240537976E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926434703471E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3864967951420E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0908725539314E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7179522391045E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2249499298359E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.4587774889849E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.8540262198886E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2587995463037E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2932642790133E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.1235016728613E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994855309324E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613578314946E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2226213422858E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8819659636802E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0192668984394E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865369717247E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150565491999E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4366613156720E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8511194737137E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1340807092307E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807630490666E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090809427146E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0355508108109E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7262274936797E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1952240537119E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926435291812E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3864969354766E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0908725722583E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7179522391696E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2249499301408E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.4587774885268E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.8540262592182E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2587995442944E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2932642793558E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.1235016730716E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994855308564E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613578314888E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2226213423125E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8819659636798E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0192668984356E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865369717264E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150565491997E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4366613156865E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8511194737161E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1340807092819E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6512,35 +6496,33 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.01093922340877E+00  1.08516769462177E+00
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.38777878078145E-17  3.72673458855032E-03
+ cg2d: Sum(rhs),rhsMax =  -1.12757025938492E-17  3.72673471234007E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4545958682076E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.3369310623899E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4643102919115E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6396674771154E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3271216117413E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7866586906018E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2469960799678E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2301161028249E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9071578948402E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0997066454602E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6583926569214E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4987111716265E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.3444568939903E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.5041939341894E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9872243379164E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.7860817873893E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4242589723155E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0093233283832E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2331028811302E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1338335925709E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4545958681058E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.3369310670651E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4643102906605E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6396674780877E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3271216113108E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7866586909897E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2469960835762E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2301160971679E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9071578952467E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0997066468141E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6583926569315E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4987111711512E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.3444568936127E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.5041939342121E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9872243378374E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.7860817870414E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4242589731628E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0093233282469E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2331028810641E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1338335923600E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -6549,16 +6531,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1712977040014E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.0696866066360E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3666033752752E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1847842191871E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0967458123562E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4335199823633E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3172472974821E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2156776942102E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5124465675131E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0975185717933E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1712977020685E+01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.0696866045695E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3666033740404E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1847842200861E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0967458120037E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4335199820468E+01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3172472907549E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2156776885053E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5124465678026E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0975185724295E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -6582,46 +6564,46 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9762165919682E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6904107838303E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.6624519534001E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9612344083540E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3195850519947E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1607758377469E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.8908601772713E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7888985737796E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8125676075437E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.6926688340859E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9762168707699E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6904108825147E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.6624519357389E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9612343971917E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3195850526538E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1607758413598E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.8908601771760E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7888985732665E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8125676073953E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.6926688341971E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4242589723155E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.7860817873893E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0093233283832E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2331028811302E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1338335925709E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4242589731628E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.7860817870414E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0093233282469E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2331028810641E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1338335923600E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1523762551178E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1900080426104E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.1031775503748E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7880199880062E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5643499657206E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3937498364777E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5786408772138E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   7.1241231871706E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3390681161637E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6876076077790E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4242589723155E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.7860817873893E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0093233283832E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2331028811302E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1338335925709E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1523762547593E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1900080426187E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.1031775500117E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7880199880287E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5643499656384E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3937498360167E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5786408772236E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   7.1241231868042E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3390681161857E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6876076077023E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4242589731628E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.7860817870414E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0093233282469E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2331028810641E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1338335923600E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -6670,31 +6652,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9937273797126E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982179273185E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6438638968421E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473986552713E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3980350322018E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936322461336E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1469868327358E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3128261420357E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140779507865E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4308824554738E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0565947711144E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5025326518138E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3778443592664E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1859472219880E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8584518551716E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185076543232E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895466643876E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0001120198282E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9890506800892E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2674787360955E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588118224446E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552270981121E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6159714472633E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0824151555908E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516877201310E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9937273313224E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982179268149E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6438639231062E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473986543199E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3980350325314E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936322362497E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1469868352105E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3128261631226E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140779491590E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4308824554782E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0565947628821E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5025326360709E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3778443659886E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1859472226760E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8584518595009E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185076543007E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895466644077E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0001120198805E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9890506801006E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2674787361101E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588118224445E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552270981094E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6159714472906E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0824151555926E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516877202095E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -7354,249 +7336,249 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5704.8920384049416
-(PID.TID 0000.0001)         System time:   10.373547166585922
-(PID.TID 0000.0001)     Wall clock time:   5738.8781177997589
+(PID.TID 0000.0001)           User time:   5165.1794047355652
+(PID.TID 0000.0001)         System time:   11.897560656070709
+(PID.TID 0000.0001)     Wall clock time:   5212.7467699050903
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.740797311067581
-(PID.TID 0000.0001)         System time:  0.74348902702331543
-(PID.TID 0000.0001)     Wall clock time:   14.411890029907227
+(PID.TID 0000.0001)           User time:   11.813695073127747
+(PID.TID 0000.0001)         System time:  0.77099692821502686
+(PID.TID 0000.0001)     Wall clock time:   15.315376043319702
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2562.3960676193237
-(PID.TID 0000.0001)         System time:   3.9169287681579590
-(PID.TID 0000.0001)     Wall clock time:   2579.8987669944763
+(PID.TID 0000.0001)           User time:   2044.1891679763794
+(PID.TID 0000.0001)         System time:   5.0608608722686768
+(PID.TID 0000.0001)     Wall clock time:   2072.1896901130676
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   546.78155517578125
-(PID.TID 0000.0001)         System time:  0.76006650924682617
-(PID.TID 0000.0001)     Wall clock time:   550.53804063796997
+(PID.TID 0000.0001)           User time:   543.32949829101562
+(PID.TID 0000.0001)         System time:  0.77621769905090332
+(PID.TID 0000.0001)     Wall clock time:   547.69349408149719
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2818298339843750
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   8.2891182899475098
+(PID.TID 0000.0001)           User time:   8.1670227050781250
+(PID.TID 0000.0001)         System time:   7.1525573730468750E-006
+(PID.TID 0000.0001)     Wall clock time:   8.1779236793518066
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.6350097656250000
-(PID.TID 0000.0001)         System time:  0.12283730506896973
-(PID.TID 0000.0001)     Wall clock time:   6.6525926589965820
+(PID.TID 0000.0001)           User time:   5.4613342285156250
+(PID.TID 0000.0001)         System time:  0.12379193305969238
+(PID.TID 0000.0001)     Wall clock time:   6.0460829734802246
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.2631835937500000
-(PID.TID 0000.0001)         System time:   9.9893569946289062E-002
-(PID.TID 0000.0001)     Wall clock time:   6.2298748493194580
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   4.6246032714843750
+(PID.TID 0000.0001)         System time:   9.0894222259521484E-002
+(PID.TID 0000.0001)     Wall clock time:   5.1373019218444824
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.5776367187500000E-004
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.0178089141845703E-003
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   1.7395019531250000E-003
+(PID.TID 0000.0001)         System time:   3.0994415283203125E-006
+(PID.TID 0000.0001)     Wall clock time:   9.1481208801269531E-004
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.62588500976562500
-(PID.TID 0000.0001)         System time:   1.0149478912353516E-003
-(PID.TID 0000.0001)     Wall clock time:  0.62652444839477539
+(PID.TID 0000.0001)           User time:  0.61761474609375000
+(PID.TID 0000.0001)         System time:   1.0118484497070312E-003
+(PID.TID 0000.0001)     Wall clock time:  0.62047076225280762
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25997924804687500
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25896024703979492
+(PID.TID 0000.0001)           User time:  0.25448608398437500
+(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
+(PID.TID 0000.0001)     Wall clock time:  0.25467181205749512
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   132.36624145507812
-(PID.TID 0000.0001)         System time:   4.2981147766113281E-002
-(PID.TID 0000.0001)     Wall clock time:   132.84733581542969
+(PID.TID 0000.0001)           User time:   131.00946044921875
+(PID.TID 0000.0001)         System time:   4.7953367233276367E-002
+(PID.TID 0000.0001)     Wall clock time:   131.30906605720520
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   44.625244140625000
-(PID.TID 0000.0001)         System time:   2.1972179412841797E-002
-(PID.TID 0000.0001)     Wall clock time:   44.956450939178467
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   39.916198730468750
+(PID.TID 0000.0001)         System time:   3.1941890716552734E-002
+(PID.TID 0000.0001)     Wall clock time:   40.046990394592285
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   41.803710937500000
-(PID.TID 0000.0001)         System time:   1.7969369888305664E-002
-(PID.TID 0000.0001)     Wall clock time:   42.125032901763916
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   37.345123291015625
+(PID.TID 0000.0001)         System time:   3.0938863754272461E-002
+(PID.TID 0000.0001)     Wall clock time:   37.447960138320923
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   38.710083007812500
-(PID.TID 0000.0001)         System time:   7.0197582244873047E-003
-(PID.TID 0000.0001)     Wall clock time:   38.763372659683228
-(PID.TID 0000.0001)          No. starts:         264
-(PID.TID 0000.0001)           No. stops:         264
+(PID.TID 0000.0001)           User time:   35.230316162109375
+(PID.TID 0000.0001)         System time:   5.0070285797119141E-003
+(PID.TID 0000.0001)     Wall clock time:   35.288981676101685
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   117.59622192382812
-(PID.TID 0000.0001)         System time:   1.0111331939697266E-003
-(PID.TID 0000.0001)     Wall clock time:   117.77258801460266
+(PID.TID 0000.0001)           User time:   117.83224487304688
+(PID.TID 0000.0001)         System time:   1.9931793212890625E-003
+(PID.TID 0000.0001)     Wall clock time:   118.01213693618774
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7101440429687500
-(PID.TID 0000.0001)         System time:   1.0037422180175781E-003
-(PID.TID 0000.0001)     Wall clock time:   3.7220280170440674
+(PID.TID 0000.0001)           User time:   2.0010375976562500
+(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
+(PID.TID 0000.0001)     Wall clock time:   2.0052335262298584
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.102081298828125
-(PID.TID 0000.0001)         System time:   5.9924125671386719E-003
-(PID.TID 0000.0001)     Wall clock time:   14.130888700485229
+(PID.TID 0000.0001)           User time:   13.214050292968750
+(PID.TID 0000.0001)         System time:   9.9849700927734375E-003
+(PID.TID 0000.0001)     Wall clock time:   13.245513439178467
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6220092773437500
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.6296439170837402
+(PID.TID 0000.0001)           User time:   2.6199340820312500
+(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
+(PID.TID 0000.0001)     Wall clock time:   2.6209673881530762
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8881530761718750
-(PID.TID 0000.0001)         System time:   2.3841857910156250E-006
-(PID.TID 0000.0001)     Wall clock time:   4.8989729881286621
+(PID.TID 0000.0001)           User time:   4.8642272949218750
+(PID.TID 0000.0001)         System time:   3.3378601074218750E-006
+(PID.TID 0000.0001)     Wall clock time:   4.8720912933349609
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.33761596679687500
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:  0.33727741241455078
+(PID.TID 0000.0001)           User time:  0.35101318359375000
+(PID.TID 0000.0001)         System time:   2.3841857910156250E-006
+(PID.TID 0000.0001)     Wall clock time:  0.34997868537902832
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0783081054687500
-(PID.TID 0000.0001)         System time:   4.9808025360107422E-003
-(PID.TID 0000.0001)     Wall clock time:   8.0955572128295898
+(PID.TID 0000.0001)           User time:   10.298889160156250
+(PID.TID 0000.0001)         System time:   1.2979745864868164E-002
+(PID.TID 0000.0001)     Wall clock time:   10.325238704681396
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   119.69201660156250
-(PID.TID 0000.0001)         System time:   5.9928894042968750E-003
-(PID.TID 0000.0001)     Wall clock time:   120.02181005477905
+(PID.TID 0000.0001)           User time:   119.93411254882812
+(PID.TID 0000.0001)         System time:   5.9981346130371094E-003
+(PID.TID 0000.0001)     Wall clock time:   120.58659982681274
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8310546875000000E-003
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.2673301696777344E-004
+(PID.TID 0000.0001)           User time:   1.3122558593750000E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.4151496887207031E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0640869140625000
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.0648763179779053
+(PID.TID 0000.0001)           User time:   1.0609741210937500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.0620980262756348
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2397460937500000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9359283447265625E-004
+(PID.TID 0000.0001)           User time:   7.0190429687500000E-004
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   9.1886520385742188E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9318847656250000
-(PID.TID 0000.0001)         System time:  0.13804697990417480
-(PID.TID 0000.0001)     Wall clock time:   2.2516052722930908
+(PID.TID 0000.0001)           User time:   1.9947509765625000
+(PID.TID 0000.0001)         System time:  0.14292597770690918
+(PID.TID 0000.0001)     Wall clock time:   2.7924988269805908
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8957519531250000
-(PID.TID 0000.0001)         System time:  0.43219017982482910
-(PID.TID 0000.0001)     Wall clock time:   4.0296204090118408
+(PID.TID 0000.0001)           User time:   3.0741882324218750
+(PID.TID 0000.0001)         System time:  0.42458105087280273
+(PID.TID 0000.0001)     Wall clock time:   4.4294097423553467
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   30.870880126953125
-(PID.TID 0000.0001)         System time:  0.75295591354370117
-(PID.TID 0000.0001)     Wall clock time:   32.778409957885742
+(PID.TID 0000.0001)           User time:   30.889190673828125
+(PID.TID 0000.0001)         System time:  0.83730268478393555
+(PID.TID 0000.0001)     Wall clock time:   33.231549263000488
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7328796386718750
-(PID.TID 0000.0001)         System time:  0.14299869537353516
-(PID.TID 0000.0001)     Wall clock time:   7.8971140384674072
+(PID.TID 0000.0001)           User time:   7.7100830078125000
+(PID.TID 0000.0001)         System time:  0.15589308738708496
+(PID.TID 0000.0001)     Wall clock time:   7.9045157432556152
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5810546875000000
-(PID.TID 0000.0001)         System time:  0.12999343872070312
-(PID.TID 0000.0001)     Wall clock time:   3.7821021080017090
+(PID.TID 0000.0001)           User time:   3.6647949218750000
+(PID.TID 0000.0001)         System time:  0.12486314773559570
+(PID.TID 0000.0001)     Wall clock time:   3.9548799991607666
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5686035156250000
-(PID.TID 0000.0001)         System time:   9.3002796173095703E-002
-(PID.TID 0000.0001)     Wall clock time:   3.6848249435424805
+(PID.TID 0000.0001)           User time:   3.6435546875000000
+(PID.TID 0000.0001)         System time:   8.5922241210937500E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8356411457061768
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3123.6054687500000
-(PID.TID 0000.0001)         System time:   5.4901151657104492
-(PID.TID 0000.0001)     Wall clock time:   3137.1004219055176
+(PID.TID 0000.0001)           User time:   3101.8679199218750
+(PID.TID 0000.0001)         System time:   5.8539824485778809
+(PID.TID 0000.0001)     Wall clock time:   3117.4510459899902
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2639.7033691406250
-(PID.TID 0000.0001)         System time:   3.8233318328857422
-(PID.TID 0000.0001)     Wall clock time:   2649.5757052898407
+(PID.TID 0000.0001)           User time:   2620.0974121093750
+(PID.TID 0000.0001)         System time:   3.9986462593078613
+(PID.TID 0000.0001)     Wall clock time:   2630.8883817195892
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   473.43212890625000
-(PID.TID 0000.0001)         System time:   1.2088346481323242
-(PID.TID 0000.0001)     Wall clock time:   476.23288035392761
+(PID.TID 0000.0001)           User time:   471.04101562500000
+(PID.TID 0000.0001)         System time:   1.3747816085815430
+(PID.TID 0000.0001)     Wall clock time:   474.67646813392639
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5402832031250000
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   5.5514481067657471
+(PID.TID 0000.0001)           User time:   5.5078125000000000
+(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
+(PID.TID 0000.0001)     Wall clock time:   5.5181679725646973
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1972656250000000E-002
-(PID.TID 0000.0001)         System time:   1.4305114746093750E-006
-(PID.TID 0000.0001)     Wall clock time:   1.9476652145385742E-002
+(PID.TID 0000.0001)           User time:   1.8798828125000000E-002
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   1.8887519836425781E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   427.00463867187500
-(PID.TID 0000.0001)         System time:  0.13489961624145508
-(PID.TID 0000.0001)     Wall clock time:   427.92526078224182
+(PID.TID 0000.0001)           User time:   424.62548828125000
+(PID.TID 0000.0001)         System time:  0.15482330322265625
+(PID.TID 0000.0001)     Wall clock time:   425.55639529228210
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8564453125000000
-(PID.TID 0000.0001)         System time:  0.32196187973022461
-(PID.TID 0000.0001)     Wall clock time:   6.4794306755065918
+(PID.TID 0000.0001)           User time:   5.9020996093750000
+(PID.TID 0000.0001)         System time:  0.34568786621093750
+(PID.TID 0000.0001)     Wall clock time:   6.7598059177398682
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.4881362915039062E-003
+(PID.TID 0000.0001)           User time:   2.4414062500000000E-003
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3720264434814453E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   34.345947265625000
-(PID.TID 0000.0001)         System time:  0.75195550918579102
-(PID.TID 0000.0001)     Wall clock time:   35.588753461837769
+(PID.TID 0000.0001)           User time:   34.313232421875000
+(PID.TID 0000.0001)         System time:  0.87125778198242188
+(PID.TID 0000.0001)     Wall clock time:   36.141815900802612
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.0761718750000000E-002
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:   3.4248113632202148E-002
+(PID.TID 0000.0001)           User time:   3.1738281250000000E-002
+(PID.TID 0000.0001)         System time:   2.9973983764648438E-003
+(PID.TID 0000.0001)     Wall clock time:   3.9803981781005859E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -7636,9 +7618,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =        1031172
+(PID.TID 0000.0001) //            No. barriers =         998836
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =        1031172
+(PID.TID 0000.0001) //     Total barrier spins =         998836
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecmwf.txt
+++ b/global_oce_llc90/results/output_adm.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node113.cm.cluster
-(PID.TID 0000.0001) // Build date:        Tue Apr 20 00:47:29 EDT 2021
+(PID.TID 0000.0001) // Build host:        node016
+(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node113.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -4308,7 +4308,6 @@
  cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.69565508448963E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69262228492823E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.00377979745864E+00  1.69262224221707E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4348,7 +4347,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377979745864E+00  1.69262224221707E-01
  Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   1.30104260698261E-18  1.83696321991956E-04
 (PID.TID 0000.0001) // =======================================================
@@ -4356,26 +4354,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537872207400E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928200132777E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716869361226E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500665156E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610561928E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271184670408E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135526201679E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006108345517E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948341597E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093951450E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537871882173E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928199448871E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716869365749E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500674852E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610669970E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271184883060E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135526403712E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006108230685E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948336626E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093945894E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4491391571296E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4213901650299E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.4232914060995E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0607201288096E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2806591451425E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644806382E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276851354E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457644545E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307438143E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366413E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644806866E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276838944E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457646704E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307437995E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366161E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4384,16 +4382,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4124591867539E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2051174544580E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0288811367901E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7339517507323E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7089493310666E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.8234327845037E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9176186428152E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2780163061445E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5665230944089E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7807579456064E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4124591383664E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2051174578904E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0288811373486E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7339517497195E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7089493461287E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.8234328232951E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9176186413066E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2780162917685E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5665230940282E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7807579435038E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4417,26 +4415,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6266648361797E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9675003052977E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2517097471545E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9867314813905E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6908028314622E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0705289004311E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.2717672238161E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9043092035218E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3235522584885E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6633245056806E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6266651909072E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9675004378102E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2517097963546E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9867314944239E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6908028322818E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0705289579313E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.2717672234884E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9043092046148E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3235522587504E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6633245063969E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.9869276851354E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1093644806382E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6859457644545E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4619307438143E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1917372366413E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.9869276838944E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1093644806866E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6859457646704E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4619307437995E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1917372366161E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4452,15 +4450,14 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.3805926639165E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.8488985249453E-05
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2422393707882E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.9869276851354E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1093644806382E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6859457644545E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4619307438143E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1917372366413E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.9869276838944E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1093644806866E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6859457646704E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4619307437995E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1917372366161E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377989299128E+00  1.69565513071464E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4471,62 +4468,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161606541636E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383871400776E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787133256326E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089859114E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551180920241E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880516501884E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226711483660E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448807318976E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162740156E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802357224E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028926221013E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878766646748E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153497281664E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5160664059477E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792288101104E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856391E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325209950E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557379819761E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920632768E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185522E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129472E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440441378E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937450960223E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306043983606E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946803586E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161606952157E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383871293354E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787134832556E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089852746E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551181006983E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880516821790E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226711472448E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448805759555E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162729551E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802143629E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028926122318E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878766652545E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153501760430E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5160664053478E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792288044704E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856410E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325209947E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557379819760E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920632770E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185559E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129465E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440441345E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937450960217E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306043983627E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946803566E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377989299128E+00  1.69565513071464E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.68628738645072E-18  3.43370981823956E-04
+ cg2d: Sum(rhs),rhsMax =  -1.35525271560688E-19  3.43370995140402E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496063695572E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121848276630E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330078209207E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662138941219E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122667804557E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702295031E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005571746969E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556257682537E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937499607E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250237100E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221538654E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296551154716E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607474722E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724911E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556843E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256871649E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029922235E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171355181088E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204553259E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177001773E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496063720032E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121848319825E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330078190104E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662138950966E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122667912060E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702195395E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005571766007E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556257537162E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937495452E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250277815E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221540597E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296551151225E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607470801E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724898E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556920E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256871217E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029922162E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171355217331E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204554913E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177003768E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4535,16 +4531,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4703497612779E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2278256842086E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0046148471081E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2534461775050E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5259435739315E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3380766220695E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5293519634465E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6221770739313E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6785252295943E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4843821999102E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4703497646094E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2278257800177E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0046148454958E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2534461779322E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5259435756236E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3380766183822E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5293519661213E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6221770591335E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6785252295025E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4843822011443E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4568,50 +4564,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3929939819353E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6767659887415E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1408786782535E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7814429272338E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3467041839737E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7214525703690E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.5931770565454E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0133044475374E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6092760896920E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2312581846897E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3929930045893E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6767660506591E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1408786763025E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7814429272374E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3467041792972E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7214525686844E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.5931770570242E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0133044511764E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6092760897678E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2312581831825E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.0015029922235E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1889256871649E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.3171355181088E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0886204553259E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3715177001773E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.0015029922162E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1889256871217E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.3171355217331E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0886204554913E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3715177003768E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9623062392675E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6115254364383E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.2299476510529E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2157758186409E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1711883943454E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5647654620074E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.6450064892494E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8153759250480E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3620911423163E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4700963240137E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.0015029922235E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1889256871649E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.3171355181088E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0886204553259E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3715177001773E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9623062390186E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6115254365767E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.2299476507869E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2157758186398E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1711883943509E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5647654616689E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.6450064894379E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8153759246678E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3620911423151E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4700963240212E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.0015029922162E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1889256871217E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.3171355217331E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0886204554913E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3715177003768E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377996481688E+00  1.70388042400059E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4622,62 +4617,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685037686448E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822396074E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327700296980E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959611651E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625081533E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255788419619E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329112270E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383166705662E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495836764332E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006628806E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268756280797E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543243657953E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140787633874E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978429790E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079084257786E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328845812E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799214819E+03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685037695644E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822503610E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327695700561E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959498686E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625054144E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255788321852E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329195002E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383167091818E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495836618633E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006634207E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268756297071E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543243011240E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140786431335E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978414917E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079083939402E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328845791E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799214818E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336113363660E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362871274448E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905019E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612435E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682657E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903702051877E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694349E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790262501E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362871274457E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905004E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612417E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682656E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903702051871E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694339E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790262907E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377996481688E+00  1.70388042400059E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   9.59518922649671E-18  8.65061349485884E-04
+ cg2d: Sum(rhs),rhsMax =  -8.07730618501701E-18  8.65061323491060E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281408355E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124326342622E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021970619593E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718184587E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168901148081E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238428144540E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646479641767E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398904651044E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617743875E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464875517E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184579750E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510911923E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621941E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424466E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828636E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866220238E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105156479E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366099362E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962192096E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312602347E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281455139E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124326332343E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021970381425E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718187311E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168901356681E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238428190263E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646479610014E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398904506363E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617743918E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464781283E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184580149E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510912567E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621755E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424463E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828705E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866219723E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105090455E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366123214E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962193061E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312603950E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4686,16 +4680,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8044968067158E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2224813377306E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7618810234016E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0332107012242E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.7957185622763E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6206673160905E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3156506146870E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1819086016105E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0358523495701E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6467141297321E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8044967982099E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2224813395829E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7618809992857E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0332107011880E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.7957185637048E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6206673102942E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3156506148069E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1819085872552E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0358523505268E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6467141308659E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4719,50 +4713,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4289747992336E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299078831793E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8341559999509E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6552846581706E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9922636510254E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5405228959626E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -7.0038977959025E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2643857751313E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8846167019907E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3803018480519E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4289749817226E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299079429754E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8341573178415E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6552845173467E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9922656332166E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5405228950944E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -7.0038977941325E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2643857784824E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8846167018313E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3803018479560E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.0593105156479E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2307866220238E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.9066366099362E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6283962192096E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5377312602347E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.0593105090455E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2307866219723E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.9066366123214E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6283962193061E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5377312603950E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1922706918283E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.3739934931115E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1149415742240E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8173163940752E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2448339473584E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2827775584565E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -9.9038790423573E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.4997677913283E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0341847131732E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.6869949123777E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.0593105156479E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2307866220238E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.9066366099362E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6283962192096E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5377312602347E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1922706918741E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.3739934933956E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1149415742127E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8173163940751E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2448339473633E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2827775585190E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -9.9038790427450E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.4997677913103E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0341847131729E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.6869949123844E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.0593105090455E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2307866219723E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.9066366123214E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6283962193061E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5377312603950E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377990029912E+00  1.71227093289936E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4773,62 +4766,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897118852E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381512041713E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686559025035E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743303185E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580641874E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327696177483E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160265764629E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349130834E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852117247092E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467133920676E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005160750344E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201925273651E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324676880600E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335576186377E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484546132920E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990351940E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704100850E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114861866495E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4470273742457E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171764059910E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275750926E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595526E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882548136E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880772803E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285295712E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897081493E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381512142520E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686560635463E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743287061E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580634015E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327696097868E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160265952173E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349641155E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852117030298E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467133888688E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005160991748E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201925840583E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324677100171E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335576182287E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484546100148E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990351892E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704100870E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114861866459E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4470273742491E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171764059947E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275750892E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595522E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882547952E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880772747E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285296286E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377990029912E+00  1.71227093289936E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.25260651745651E-18  1.48334043825518E-03
+ cg2d: Sum(rhs),rhsMax =  -3.16587034365767E-17  1.48334044816748E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641272257896E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655500078956E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181323419839E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916364425E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693190221E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981238661412E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342790048E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781611566333E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976536275E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041830231E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632467842E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272603937E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253206789E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628348555E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105033555E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558694120E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070832954E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703480508E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980616311E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893196478E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641272223411E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655500095125E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181323095085E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916359579E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693177571E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981238656637E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342836961E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781611589525E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976538984E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041832530E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632468381E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272602793E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253153480E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628349386E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105032443E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558694354E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070826643E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703481572E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980616631E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893196783E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4837,16 +4829,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3306631491515E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0051568938778E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1466843195881E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6757945254550E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5448649418362E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5469007905193E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0981057592120E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2944778914051E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4494904538038E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2765394833493E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3306631366382E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0051568922098E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1466842869733E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6757945249379E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5448649368904E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5469007810072E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0981057825570E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2944778932297E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4494904540993E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2765394973471E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4870,46 +4862,46 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9310266517042E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898037082111E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.5592615176740E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5279149345438E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6496294700644E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3331355829115E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.5320305287013E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6021684409415E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1680510640773E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8462983125424E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9310265812611E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898036906033E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.5592615046159E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5279149357995E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6496294615298E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3331355840000E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.5320305286898E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6021684400208E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1680510643729E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8462983121648E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2180070832954E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2137558694120E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0464703480508E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1649980616311E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6944893196478E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2180070826643E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2137558694354E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0464703481572E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1649980616631E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6944893196783E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5870853621529E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1111568121467E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.7759752470054E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4162149330257E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3126658993242E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7079054425819E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3127623493807E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.4145485610586E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7024809498098E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.8954061882549E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2180070832954E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2137558694120E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0464703480508E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1649980616311E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6944893196478E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5870853620716E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1111568121848E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.7759752427335E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4162149330914E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3126658992286E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7079054424709E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3127623494329E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.4145485558875E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7024809498905E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.8954061881469E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2180070826643E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2137558694354E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0464703481572E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1649980616631E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6944893196783E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4918,7 +4910,6 @@
  cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102232E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75680295094020E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.72004253669388E-01
- cg2d: Sum(rhs),rhsMax =   3.00377980958177E+00  1.72004249833187E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4929,62 +4920,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474015761183E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829546556156E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975520179377E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041357161E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996426290E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982023277749E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483497610150E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417921617388E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430140442E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735853627642E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451470840581E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839514828787E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077774418136E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614826655049E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101974211030E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517548258E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357649037E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893440285409E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5569455531155E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692764136567E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679359017290E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952179668960E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9826126717090E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572376244586E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5878588703805E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474015568385E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829546507554E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975521585322E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041358251E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996434685E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982022933774E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483497606706E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417922096607E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430119474E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735853616483E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451470655497E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839515511624E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077774763583E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614826636147E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101974201167E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517548347E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357649139E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893440285351E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5569455531206E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692764136646E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679359017226E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952179668944E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9826126716833E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572376244580E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5878588704357E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377980958177E+00  1.72004249833187E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.62630325872826E-18  2.12603799167945E-03
+ cg2d: Sum(rhs),rhsMax =  -4.11996825544492E-18  2.12603795188989E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517552960692E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705416847588E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042295625E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436321469E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800246318E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842635432861E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926761919713E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540606065E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630305921E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394650484E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337261E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329151188E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938864928E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675374773E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112880041E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406303192E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395107485E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819123E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026994605E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835685641E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517552897538E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705416864449E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042262651E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436317880E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800242389E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842635458151E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926762044072E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540619617E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630307706E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394656736E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337859E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329150855E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938814644E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675375570E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112879214E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406303056E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395101562E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819441E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026994638E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835686556E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4993,16 +4983,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.2906767266322E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.8725864417062E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2907591354777E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4329974373698E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0654125028564E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8387472700170E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8454620666079E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752178329768E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0960183453426E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0316853441874E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.2906767175756E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.8725864415701E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2907591321776E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4329974369218E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0654125031147E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8387472732496E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8454620748074E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752178341008E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0960183454999E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0316853458808E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5026,50 +5016,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4448157524871E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3555551944881E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.2848082971257E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4053420966847E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3226008093871E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.1001117224593E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.2196664779076E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0975407773988E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1474625890608E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3297657717528E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4448161609679E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3555552545932E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.2848082883294E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4053420967340E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3226008173670E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.1001117266372E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.2196664781195E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0975407772886E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1474625890475E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3297657716052E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5082395107485E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.0867406303192E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2989634819123E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6959026994605E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8362835685641E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5082395101562E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.0867406303056E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2989634819441E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6959026994638E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8362835686556E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9807581253868E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3825921722907E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3927967424642E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0132453669732E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3747543629363E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1318979276652E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6319237647143E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.2645290698981E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3680995113530E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.0955879493640E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5082395107485E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.0867406303192E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2989634819123E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6959026994605E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8362835685641E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9807581253621E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3825921723331E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3927967384366E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0132453670357E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3747543628579E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1318979276329E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6319237647723E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.2645290650205E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3680995114303E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.0955879492838E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5082395101562E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.0867406303056E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2989634819441E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6959026994638E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8362835686556E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378025578974E+00  1.75680293333988E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5080,62 +5069,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425155605437E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589439382147E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340959856438E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802142350E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285752734182E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745259430553E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151327648367E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968623714981E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789042320E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634370551664E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626404214252E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529941745538E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210929894917E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913746599E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971826152E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522232848E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187746988E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671810637037E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6660388588111E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202407688183E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410493730108E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107045E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778046107849E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885253164187E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787564541E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425155767178E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589439067664E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340960843444E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802139836E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285752713108E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745259635614E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151327349550E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968625252728E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789020188E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634370471568E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626404185710E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529941972298E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210930280096E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913744525E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971818512E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522233007E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187747064E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671810636985E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6660388588201E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202407688280E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410493730073E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107032E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778046107829E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885253164189E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787564968E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378025578974E+00  1.75680293333988E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   4.55364912443912E-17  2.73283095417327E-03
+ cg2d: Sum(rhs),rhsMax =  -3.68628738645072E-18  2.73283074969244E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399433334E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139803694898E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049059161E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557162700E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413278159468E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387091062272E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3685382207875E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273439830E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668859463E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264290089843E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730846262E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337443250E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392256728E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830780368E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723211230E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863415791E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389035027E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660750541E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936314779E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513477098E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399429311E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139803806685E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049017724E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557161887E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413278150375E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387091063845E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3685382021798E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273450328E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668862882E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264290092361E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730846679E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337439364E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392208254E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830781118E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723210650E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863409634E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389033245E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660751043E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936314346E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513476871E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5144,16 +5132,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2588614532976E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.7669334972941E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6763112710266E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2825051154643E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.3996845640497E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3409969418085E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7225299216243E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5349613122352E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8307617521291E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3674917067335E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2588614595935E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.7669334972189E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6763112668072E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2825051154002E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.3996845638727E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3409969387472E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7225299070019E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5349613130890E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8307617524694E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3674917085095E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5177,50 +5165,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9699415454914E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660119403324E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.9665576957428E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2935701814589E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0154213327330E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8419642287650E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5016676257973E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3363167777528E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3820627271141E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8390101431846E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9699416016528E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660119617301E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.9665576970778E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2935701786004E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0154213361561E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8419642370774E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5016676256215E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3363167777718E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3820627270878E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8390101435587E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.8133389035027E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.5434863415791E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5490660750541E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2226936314779E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9666513477098E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.8133389033245E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.5434863409634E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5490660751043E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2226936314346E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9666513476871E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3734855912968E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6511898712148E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.9338323000417E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6082515365006E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4320812898128E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5549157319953E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9470548920874E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.0022580489027E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0308185856957E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.2881651514893E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.8133389035027E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.5434863415791E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5490660750541E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2226936314779E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9666513477098E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3734855910169E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6511898712448E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.9338322961445E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6082515365589E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4320812897495E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5549157316183E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9470548921279E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.0022580442006E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0308185857685E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.2881651514330E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.8133389033245E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.5434863409634E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5490660751043E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2226936314346E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9666513476871E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378000363407E+00  1.78451863862818E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5231,62 +5218,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944538515868E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368257189270E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518038091043E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646487949498E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993208948115E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190311602900E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736983883667E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351315943953E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614204958E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121384848E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055216453663E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809616779690E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505844375784E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923726459413E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132685797977E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678518360E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723190506E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449499478880E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743774000517E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701806423304E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289834584E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599912257E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572883346296E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197963359058E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664205104E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944538023644E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368256751510E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518039278152E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646487941971E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993208928796E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190311478388E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736983028498E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351318863615E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614200057E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121318761E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055216348275E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809616712303E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505844261074E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923726462418E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132685764963E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678518482E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723190623E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449499478872E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743774000585E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701806423360E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289834558E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599912256E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572883346295E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197963359057E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664206474E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378000363407E+00  1.78451863862818E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   5.20417042793042E-18  3.23837034665976E-03
+ cg2d: Sum(rhs),rhsMax =   2.77555756156289E-17  3.23837038282624E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517219092516E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678953508822E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247835036722E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028227150E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118521579E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700505846E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4147058828944E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551561809E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108790160E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122384323E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062646E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197068912E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380627567E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767735371E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518070509E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560460516482E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039946873014E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905896343613E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825568123E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274078035E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517219089569E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678953690223E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247834999630E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028226116E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118514080E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700512941E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4147058633491E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551574615E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108795923E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122378963E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062759E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197065021E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380578579E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767736220E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518069889E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560460519767E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039946869875E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905896340912E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825566351E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274072208E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5295,16 +5281,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0091220270862E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.8071855571448E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0422583388870E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2041854210154E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7457064126182E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1876275737564E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6132851260823E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8884616799705E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6404864965191E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7252366960945E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0091220260516E+01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.8071855732161E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0422583353064E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2041854210078E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7457064122464E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1876275744945E+01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6132851196205E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8884616810137E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6404864972240E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7252366973476E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5328,51 +5314,49 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4742613293934E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2822758064676E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.7553801306021E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1353647567686E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1634237505374E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.7203070206243E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.7373424282360E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5552667616193E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5993440091828E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2684017905040E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4742614841407E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2822757440575E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.7553801432967E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1353647526334E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1634237533872E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.7203070198809E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.7373424284160E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5552667614647E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5993440090867E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2684017906201E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1039946873014E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.2560460516482E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7905896343613E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7379825568123E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0619274078035E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1039946869875E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.2560460519767E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7905896340912E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7379825566351E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0619274072208E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7655009360817E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9169793563714E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.6465385821068E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2000209697047E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.4855036311480E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9771431156844E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2580126630766E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.9746819208741E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6886664703310E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.4734852528393E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1039946873014E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.2560460516482E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7905896343613E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7379825568123E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0619274078035E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7655009357933E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9169793563799E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.6465385781653E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2000209697720E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.4855036310877E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9771431153070E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2580126630876E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.9746819161222E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6886664704133E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.4734852527792E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1039946869875E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.2560460519767E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7905896340912E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7379825566351E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0619274072208E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00378020379739E+00  1.73784633995647E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5383,63 +5367,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807007366344E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950526215E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429211057698E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288473561E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650063793E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926601128998E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852188966691E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991561492E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823753255E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888247169E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436490684505E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034400232384E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766166815565E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051437491E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493698726854E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894401757E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584521402E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225890454851E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8820574721596E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0191745259164E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865315018606E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755468670E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367080723586E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510742378998E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528797438E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807006857426E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950544278E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429212904999E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288457150E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650052235E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926601876886E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852190465847E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991951721E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823750031E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888235528E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436490681683E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034400142847E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766166847741E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051441233E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493698731537E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894401203E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584521391E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225890455076E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8820574721601E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0191745259197E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865315018597E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755468695E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367080723706E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510742378978E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528797546E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00378020379739E+00  1.73784633995647E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.30104260698261E-18  3.71564342938055E-03
+ cg2d: Sum(rhs),rhsMax =   2.51534904016637E-17  3.71564340237301E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597027190597E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972455430442E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298833476E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076526544E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115836080E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935671301E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312407197805E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634757670E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316919629E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926863345879E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067364E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380591109E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240618800E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138087834E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884989112E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705832379322E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963107415E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170691880E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056206913E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127907938E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597027185572E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972455574338E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298772533E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076530295E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115830722E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935668909E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312407178392E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634710476E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316921924E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926863353116E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067432E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380586348E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240565717E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138088748E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884988490E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705832378493E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963105154E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170690048E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056205427E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127905128E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5448,16 +5430,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1731881502018E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8598866136625E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3579618518477E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1822263528715E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0932176947435E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4285698378696E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3053083201526E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2222270422295E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5116848108304E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0936731478575E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1731881480925E+01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8598866324025E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3579618458266E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1822263532823E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0932176943800E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4285698367528E+01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3053083101965E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2222270374871E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5116848110572E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0936731491549E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5481,46 +5463,46 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9807909510092E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7276686672262E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.5925846011366E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9674226720843E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3201854006791E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1909750432965E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9726921972170E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7862018721040E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8145643274139E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7023038390110E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9807912301336E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7276688771280E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.5925845829687E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9674226609735E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3201854015369E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1909750487665E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9726921970047E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7862018714926E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8145643272658E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7023038391068E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4343963107415E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.9705832379322E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0202170691880E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2483056206913E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1696127907938E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4343963105154E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.9705832378493E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0202170690048E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2483056205427E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1696127905128E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1559273747230E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1847879183436E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.9888301086976E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7836915630715E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5310000587330E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3975589173376E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5720511335343E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8483203400236E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3347223945199E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6483848439439E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4343963107415E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.9705832379322E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0202170691880E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2483056206913E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1696127907938E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1559273743638E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1847879183491E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.9888301043664E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7836915631461E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5310000586702E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3975589168757E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5720511335409E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8483203348746E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3347223946085E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6483848438835E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4343963105154E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.9705832378493E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0202170690048E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2483056205427E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1696127905128E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5554,31 +5536,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301549476E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318684055E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618137022072E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498379523E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703433404E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936337318512E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736299812E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154478598678E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748654222E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449449636E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358413906941E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053718871111E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797660776203E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892584099661E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976334007555E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116396968E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472775670E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000453875525E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891644629781E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756981930E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063317134E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452420672E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160350960784E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823662134517E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502580594E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301269086E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318675401E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618140694400E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498356057E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703432007E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936337232144E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736327815E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154479197331E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748630562E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449441276E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358413850784E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053718714309E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797660747977E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892584101297E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976334030015E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116396947E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472775894E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000453876063E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891644629901E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756982118E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063317121E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452420690E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160350961058E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823662134474E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502580454E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6077,237 +6059,237 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5643.9114280045033
-(PID.TID 0000.0001)         System time:   9.9946044385433197
-(PID.TID 0000.0001)     Wall clock time:   5678.4401021003723
+(PID.TID 0000.0001)           User time:   5111.5817078351974
+(PID.TID 0000.0001)         System time:   10.824318259954453
+(PID.TID 0000.0001)     Wall clock time:   5145.3603131771088
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.767270892858505
-(PID.TID 0000.0001)         System time:  0.69828596711158752
-(PID.TID 0000.0001)     Wall clock time:   17.331967115402222
+(PID.TID 0000.0001)           User time:   11.820705235004425
+(PID.TID 0000.0001)         System time:  0.71322399377822876
+(PID.TID 0000.0001)     Wall clock time:   15.042571067810059
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2537.5432825088501
-(PID.TID 0000.0001)         System time:   3.7952290773391724
-(PID.TID 0000.0001)     Wall clock time:   2555.2332592010498
+(PID.TID 0000.0001)           User time:   2027.2730340957642
+(PID.TID 0000.0001)         System time:   4.4183551073074341
+(PID.TID 0000.0001)     Wall clock time:   2047.5890860557556
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   506.68228149414062
-(PID.TID 0000.0001)         System time:  0.70989727973937988
-(PID.TID 0000.0001)     Wall clock time:   508.85947084426880
+(PID.TID 0000.0001)           User time:   500.18560791015625
+(PID.TID 0000.0001)         System time:  0.72972249984741211
+(PID.TID 0000.0001)     Wall clock time:   502.41252017021179
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2702026367187500
-(PID.TID 0000.0001)         System time:   2.7418136596679688E-005
-(PID.TID 0000.0001)     Wall clock time:   8.2758436203002930
+(PID.TID 0000.0001)           User time:   8.1679687500000000
+(PID.TID 0000.0001)         System time:   1.0371208190917969E-003
+(PID.TID 0000.0001)     Wall clock time:   8.1748692989349365
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7063293457031250
-(PID.TID 0000.0001)         System time:  0.11598134040832520
-(PID.TID 0000.0001)     Wall clock time:   7.2240912914276123
+(PID.TID 0000.0001)           User time:   5.0643920898437500
+(PID.TID 0000.0001)         System time:  0.11590719223022461
+(PID.TID 0000.0001)     Wall clock time:   5.4132673740386963
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.3782653808593750
-(PID.TID 0000.0001)         System time:   9.6014261245727539E-002
-(PID.TID 0000.0001)     Wall clock time:   6.8613021373748779
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   4.2337341308593750
+(PID.TID 0000.0001)         System time:   8.1948280334472656E-002
+(PID.TID 0000.0001)     Wall clock time:   4.5119521617889404
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.8824501037597656E-004
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   1.6479492187500000E-003
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.3269348144531250E-004
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60589599609375000
-(PID.TID 0000.0001)         System time:   1.0058879852294922E-003
-(PID.TID 0000.0001)     Wall clock time:  0.60623526573181152
+(PID.TID 0000.0001)           User time:  0.62551879882812500
+(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
+(PID.TID 0000.0001)     Wall clock time:  0.62511038780212402
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25906372070312500
-(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25884175300598145
+(PID.TID 0000.0001)           User time:  0.25320434570312500
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:  0.25474786758422852
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   88.218200683593750
-(PID.TID 0000.0001)         System time:   1.7046689987182617E-002
-(PID.TID 0000.0001)     Wall clock time:   88.309863090515137
+(PID.TID 0000.0001)           User time:   88.423187255859375
+(PID.TID 0000.0001)         System time:   1.5058755874633789E-002
+(PID.TID 0000.0001)     Wall clock time:   88.717790842056274
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   38.721405029296875
-(PID.TID 0000.0001)         System time:   8.0325603485107422E-003
-(PID.TID 0000.0001)     Wall clock time:   38.774389505386353
-(PID.TID 0000.0001)          No. starts:         264
-(PID.TID 0000.0001)           No. stops:         264
+(PID.TID 0000.0001)           User time:   35.245056152343750
+(PID.TID 0000.0001)         System time:   3.0300617218017578E-003
+(PID.TID 0000.0001)     Wall clock time:   35.273555517196655
+(PID.TID 0000.0001)          No. starts:         240
+(PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   117.57226562500000
-(PID.TID 0000.0001)         System time:   2.0320415496826172E-003
-(PID.TID 0000.0001)     Wall clock time:   117.67275714874268
+(PID.TID 0000.0001)           User time:   117.89065551757812
+(PID.TID 0000.0001)         System time:   4.0619373321533203E-003
+(PID.TID 0000.0001)     Wall clock time:   117.97315931320190
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0478210449218750
-(PID.TID 0000.0001)         System time:   2.0015239715576172E-003
-(PID.TID 0000.0001)     Wall clock time:   3.0520033836364746
+(PID.TID 0000.0001)           User time:   2.0870056152343750
+(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
+(PID.TID 0000.0001)     Wall clock time:   2.0876865386962891
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   17.775177001953125
-(PID.TID 0000.0001)         System time:   9.9749565124511719E-003
-(PID.TID 0000.0001)     Wall clock time:   17.798310041427612
+(PID.TID 0000.0001)           User time:   16.687316894531250
+(PID.TID 0000.0001)         System time:   1.5988826751708984E-002
+(PID.TID 0000.0001)     Wall clock time:   16.720104932785034
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6186828613281250
-(PID.TID 0000.0001)         System time:   1.1682510375976562E-005
-(PID.TID 0000.0001)     Wall clock time:   2.6197402477264404
+(PID.TID 0000.0001)           User time:   2.6148376464843750
+(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
+(PID.TID 0000.0001)     Wall clock time:   2.6158945560455322
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8969421386718750
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   4.9041011333465576
+(PID.TID 0000.0001)           User time:   4.8687133789062500
+(PID.TID 0000.0001)         System time:   2.0081996917724609E-003
+(PID.TID 0000.0001)     Wall clock time:   4.9775328636169434
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.27142333984375000
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.27183389663696289
+(PID.TID 0000.0001)           User time:  0.72027587890625000
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:  0.72071671485900879
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.1633300781250000
-(PID.TID 0000.0001)         System time:   6.0017108917236328E-003
-(PID.TID 0000.0001)     Wall clock time:   7.1848971843719482
+(PID.TID 0000.0001)           User time:   6.3933410644531250
+(PID.TID 0000.0001)         System time:   9.0038776397705078E-003
+(PID.TID 0000.0001)     Wall clock time:   6.4084742069244385
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   120.14520263671875
-(PID.TID 0000.0001)         System time:   5.0129890441894531E-003
-(PID.TID 0000.0001)     Wall clock time:   120.26139998435974
+(PID.TID 0000.0001)           User time:   118.89852905273438
+(PID.TID 0000.0001)         System time:   6.0353279113769531E-003
+(PID.TID 0000.0001)     Wall clock time:   118.98976731300354
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2207031250000000E-004
+(PID.TID 0000.0001)           User time:   4.2724609375000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.2244148254394531E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0861320495605469E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0648193359375000
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.0645885467529297
+(PID.TID 0000.0001)           User time:   1.1171264648437500
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   1.1191802024841309
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.7983398437500000E-004
+(PID.TID 0000.0001)           User time:   1.8615722656250000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.2148780822753906E-004
+(PID.TID 0000.0001)     Wall clock time:   9.4270706176757812E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9008789062500000
-(PID.TID 0000.0001)         System time:  0.14490461349487305
-(PID.TID 0000.0001)     Wall clock time:   2.2460870742797852
+(PID.TID 0000.0001)           User time:   1.9912414550781250
+(PID.TID 0000.0001)         System time:  0.12691783905029297
+(PID.TID 0000.0001)     Wall clock time:   2.2766737937927246
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.9567260742187500
-(PID.TID 0000.0001)         System time:  0.40181565284729004
-(PID.TID 0000.0001)     Wall clock time:   3.7730305194854736
+(PID.TID 0000.0001)           User time:   3.0539245605468750
+(PID.TID 0000.0001)         System time:  0.43056607246398926
+(PID.TID 0000.0001)     Wall clock time:   3.9467799663543701
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.332244873046875
-(PID.TID 0000.0001)         System time:  0.61895585060119629
-(PID.TID 0000.0001)     Wall clock time:   23.503208160400391
+(PID.TID 0000.0001)           User time:   22.572570800781250
+(PID.TID 0000.0001)         System time:  0.66355156898498535
+(PID.TID 0000.0001)     Wall clock time:   23.869168519973755
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7329101562500000
-(PID.TID 0000.0001)         System time:  0.13798928260803223
-(PID.TID 0000.0001)     Wall clock time:   7.8831112384796143
+(PID.TID 0000.0001)           User time:   7.7321472167968750
+(PID.TID 0000.0001)         System time:  0.12990546226501465
+(PID.TID 0000.0001)     Wall clock time:   7.8813838958740234
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5854492187500000
-(PID.TID 0000.0001)         System time:   9.7992897033691406E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8615369796752930
+(PID.TID 0000.0001)           User time:   3.6812744140625000
+(PID.TID 0000.0001)         System time:  0.12189579010009766
+(PID.TID 0000.0001)     Wall clock time:   3.8751480579376221
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5747070312500000
-(PID.TID 0000.0001)         System time:   8.4996223449707031E-002
-(PID.TID 0000.0001)     Wall clock time:   3.7276749610900879
+(PID.TID 0000.0001)           User time:   3.6630859375000000
+(PID.TID 0000.0001)         System time:   8.4928989410400391E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8298480510711670
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3087.4406738281250
-(PID.TID 0000.0001)         System time:   5.3180832862854004
-(PID.TID 0000.0001)     Wall clock time:   3098.2855558395386
+(PID.TID 0000.0001)           User time:   3065.1433105468750
+(PID.TID 0000.0001)         System time:   5.4858994483947754
+(PID.TID 0000.0001)     Wall clock time:   3075.0235419273376
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2642.1994628906250
-(PID.TID 0000.0001)         System time:   3.8110318183898926
-(PID.TID 0000.0001)     Wall clock time:   2649.8123874664307
+(PID.TID 0000.0001)           User time:   2623.0270996093750
+(PID.TID 0000.0001)         System time:   3.8775625228881836
+(PID.TID 0000.0001)     Wall clock time:   2629.7570412158966
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   434.74487304687500
-(PID.TID 0000.0001)         System time:   1.0960578918457031
-(PID.TID 0000.0001)     Wall clock time:   437.16684103012085
+(PID.TID 0000.0001)           User time:   431.56762695312500
+(PID.TID 0000.0001)         System time:   1.1536321640014648
+(PID.TID 0000.0001)     Wall clock time:   433.91242384910583
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5729980468750000
-(PID.TID 0000.0001)         System time:   8.1062316894531250E-006
-(PID.TID 0000.0001)     Wall clock time:   5.5800573825836182
+(PID.TID 0000.0001)           User time:   5.4562988281250000
+(PID.TID 0000.0001)         System time:   2.0980834960937500E-005
+(PID.TID 0000.0001)     Wall clock time:   5.4602704048156738
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.6113281250000000E-002
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.9441127777099609E-002
+(PID.TID 0000.0001)           User time:   2.0507812500000000E-002
+(PID.TID 0000.0001)         System time:   1.4305114746093750E-005
+(PID.TID 0000.0001)     Wall clock time:   1.8797397613525391E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   395.86596679687500
-(PID.TID 0000.0001)         System time:  0.12109136581420898
-(PID.TID 0000.0001)     Wall clock time:   396.33772826194763
+(PID.TID 0000.0001)           User time:   392.67993164062500
+(PID.TID 0000.0001)         System time:  0.13312530517578125
+(PID.TID 0000.0001)     Wall clock time:   393.08689403533936
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8745117187500000
-(PID.TID 0000.0001)         System time:  0.31796455383300781
-(PID.TID 0000.0001)     Wall clock time:   6.6734349727630615
+(PID.TID 0000.0001)           User time:   5.9294433593750000
+(PID.TID 0000.0001)         System time:  0.32184839248657227
+(PID.TID 0000.0001)     Wall clock time:   6.6858644485473633
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   2.4414062500000000E-003
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   2.4240016937255859E-003
+(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3939609527587891E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   26.752197265625000
-(PID.TID 0000.0001)         System time:  0.65398216247558594
-(PID.TID 0000.0001)     Wall clock time:   27.885728120803833
+(PID.TID 0000.0001)           User time:   26.811767578125000
+(PID.TID 0000.0001)         System time:  0.69660711288452148
+(PID.TID 0000.0001)     Wall clock time:   27.984028816223145
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.8076171875000000E-002
-(PID.TID 0000.0001)         System time:   2.0003318786621094E-003
-(PID.TID 0000.0001)     Wall clock time:   3.5096406936645508E-002
+(PID.TID 0000.0001)           User time:   3.3447265625000000E-002
+(PID.TID 0000.0001)         System time:   1.0042190551757812E-003
+(PID.TID 0000.0001)     Wall clock time:   3.8821935653686523E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6347,9 +6329,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         907452
+(PID.TID 0000.0001) //            No. barriers =         882800
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         907452
+(PID.TID 0000.0001) //     Total barrier spins =         882800
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.txt
+++ b/global_oce_llc90/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node113.cm.cluster
-(PID.TID 0000.0001) // Build date:        Tue Apr 20 00:47:29 EDT 2021
+(PID.TID 0000.0001) // Build host:        node016
+(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node113.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -4141,7 +4141,6 @@
  cg2d: Sum(rhs),rhsMax =   3.00378026546634E+00  1.68833965208670E-01
  cg2d: Sum(rhs),rhsMax =   3.00378026546621E+00  1.68579734841341E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- cg2d: Sum(rhs),rhsMax =   3.00378011557755E+00  1.68579734623964E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4181,7 +4180,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378011557755E+00  1.68579734623964E-01
  Calling cg2d from S/R CG2D_SAD
  cg2d: Sum(rhs),rhsMax =   1.61275073157219E-18  1.84309793280673E-04
 (PID.TID 0000.0001) // =======================================================
@@ -4189,26 +4187,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.1459156968487E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5768950431652E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0778407637918E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0303724261330E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8329322504719E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   6.0051175911274E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.7231133201368E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.5426525051561E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8463706409708E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6989254192459E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.1459157266172E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5768947429147E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0778407570678E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0303724211808E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8329322382120E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   6.0051175616281E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.7231133109931E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.5426525259823E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8463706384763E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6989254141816E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4400857037059E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.3997217673701E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   6.0303766892184E-08
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0756317462372E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2962614968558E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1376260634579E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.0173058318762E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7754842482954E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.6566382319938E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.2588466885282E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1376260634596E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.0173058327527E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7754842496061E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.6566382327324E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.2588466886380E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4217,16 +4215,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4926240264042E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2093696809537E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0340932392455E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7576682082898E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.9854267779756E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.5964314252637E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.1301260874831E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.4012061681178E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5893070472942E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   9.0547833439886E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4926240172157E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2093696762948E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0340932335030E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7576682060163E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.9854267399134E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.5964313899566E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.1301260310331E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.4012061901736E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5893070450991E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   9.0547833100011E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4250,36 +4248,36 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   4.7390577008878E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4079805690295E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.7997308945969E-05
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1283518335611E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.2741597518670E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2626742932153E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -9.8414148897638E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.9115964096115E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1378753306050E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0069238327888E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.7986909029450E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5721520879310E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   7.3610192102801E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.0212236167711E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.8751918630871E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0691363064462E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5764551703805E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   3.4869700739422E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3913526120091E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.5579407304195E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   4.7390577319326E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4079805758563E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.7997309443571E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1283518347187E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.2741597707080E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2626743143404E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -9.8414145940823E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.9115964108825E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1378753304560E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0069238210469E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.7986913909438E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5721521903667E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   7.3610191082746E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.0212236159262E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.8751918542409E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0691363055666E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5764551692943E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   3.4869700733562E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3913526118533E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.5579407284827E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.0173058318762E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1376260634579E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7754842482954E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.6566382319938E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.2588466885282E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.0173058327527E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1376260634596E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7754842496061E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.6566382327324E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.2588466886380E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4295,15 +4293,14 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -6.0303766892184E-08
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   7.0756317462372E-05
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2962614968558E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.0173058318762E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1376260634579E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7754842482954E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.6566382319938E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.2588466885282E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.0173058327527E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1376260634596E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7754842496061E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.6566382327324E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.2588466886380E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378034347295E+00  1.68833969994134E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4314,62 +4311,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9117485744931E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7454198266381E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3731275467863E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3556688474187E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4883111648398E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2895318911306E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4212412521595E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5274855945423E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2810480679013E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3335518682648E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3433380107245E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2697687012889E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.4912887122097E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6781620709666E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.3552182482256E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5615209119080E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4711018659196E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5553183696538E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2251419914249E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1087861514753E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5477231234608E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7817415615289E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937353013387E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6310813382474E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0397259044042E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9117486616015E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7454196650692E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3731275410618E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3556688496225E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4883111564997E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2895318693689E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4212412417729E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5274851585108E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2810480685808E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3335518767151E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3433380102214E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2697686979440E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.4912887039538E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6781620686622E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.3552182163229E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5615209118999E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4711018659199E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5553183696541E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2251419914253E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1087861514701E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5477231234611E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7817415615290E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937353013399E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6310813382494E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0397259044080E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378034347295E+00  1.68833969994134E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.57786716920216E-18  3.47579967951732E-04
+ cg2d: Sum(rhs),rhsMax =   2.35813972515597E-18  3.47579959862135E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0826448485842E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1068039415701E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1349654355577E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.0759649164852E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.0639808330348E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7087891849248E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.0761072790609E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.7531790371315E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.4496886619206E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6293525434685E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8766512616781E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.7913596979170E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.5796208116360E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4135978531541E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5854685211052E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.2752931688509E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.3847670889840E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.5474837458405E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1306429659252E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.5119787035216E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0826448515962E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1068039445752E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1349654174105E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.0759649132488E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.0639808318968E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7087891877348E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.0761072798695E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.7531790357449E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.4496886598908E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6293525429575E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8766512619839E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.7913596973606E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.5796208114520E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4135978531540E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5854685211075E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.2752931689100E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.3847670882831E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.5474837458220E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1306429659152E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.5119787035075E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4378,16 +4374,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5423675015339E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.9687356737621E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0034243742875E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3438616287589E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.6212294575345E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.6593483758161E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5939888653720E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.7114761483675E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.7745462350258E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.5903484299053E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5423674947313E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.9687356592927E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0034243573893E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3438616264823E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.6212294563615E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.6593483782744E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5939888674658E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.7114761468944E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.7745462324557E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.5903484281049E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4411,60 +4407,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.7427766195692E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.7628912851596E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -2.1900201938953E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.3797358411063E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   9.0986756630454E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.5562675301450E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -7.2766319915227E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   3.9517140180665E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.4493901308750E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   9.5752907105698E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.1186837460172E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.0016006219313E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.4524957750910E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.0339156346369E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.7341456808550E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.0759224532928E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.0214853870775E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.8742213967085E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.7338735428340E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   8.9917303245778E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.7427766138802E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.7628912926801E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -2.1900201969050E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.3797358375161E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   9.0986756562004E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.5562675365605E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -7.2766320053453E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   3.9517140252784E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.4493901322055E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   9.5752907325362E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.1186836141373E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.0016008873685E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.4524958129649E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.0339156351268E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.7341456387174E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.0759224675336E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.0214853860816E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.8742214038900E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.7338735429159E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   8.9917303253818E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.3847670889840E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.2752931688509E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.5474837458405E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1306429659252E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.5119787035216E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.3847670882831E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.2752931689100E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.5474837458220E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1306429659152E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.5119787035075E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   8.2188530526861E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.7519920555181E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0102639386914E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   8.2188530522840E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.7519920557392E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0102639385449E-07
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2432690719471E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.2546489062500E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.7913596979170E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.8766512616781E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.5796208116360E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.4135978531541E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.5854685211052E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.3847670889840E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.2752931688509E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.5474837458405E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.1306429659252E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.5119787035216E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.2546489062501E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.7913596973606E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.8766512619839E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.5796208114520E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.4135978531540E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.5854685211075E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.3847670882831E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.2752931689100E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.5474837458220E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.1306429659152E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.5119787035075E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378027666448E+00  1.69702013317171E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4475,62 +4470,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0561995913257E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3540688590234E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5304784275784E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8232640846932E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.8004086195374E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2266329277942E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2641972616936E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1332469519789E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6532379397344E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7841649323173E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.3223619038707E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7501907452083E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.5007042717813E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.6485213665968E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.9449100973877E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2836283860389E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2063681966260E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3329302251483E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3369995061536E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6587095914989E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3215904243119E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3173268546987E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902741084265E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9460617360408E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5588538851744E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0561996595418E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3540688584464E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5304791573644E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8232640876279E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.8004086179113E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2266329275386E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2641972662361E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1332468918363E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6532379526252E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7841649291039E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.3223619088173E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7501907477882E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.5007039220133E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.6485213659307E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.9449101009037E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2836283860417E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2063681966264E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3329302251454E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3369995061549E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6587095915397E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3215904243118E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3173268546986E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902741084102E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9460617360449E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5588538851762E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378027666448E+00  1.69702013317171E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.55040910665427E-17  8.80668387412304E-04
+ cg2d: Sum(rhs),rhsMax =  -2.71050543121376E-19  8.80668375056054E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7976097911227E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2135977510900E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.9714441173887E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1842583241517E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   9.2689170584941E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.0844002544237E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0606679299066E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.5086888772908E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0442055679251E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.4120772439500E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0308972150512E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3174487585441E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.9034129355834E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1183573645606E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8676110580267E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.4145321147891E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5817471460334E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.3191293358643E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6944373479984E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7573187071473E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7976098019584E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2135977548036E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.9714440900136E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1842583242348E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   9.2689170655634E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.0844002577364E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0606679251681E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.5086888761409E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0442055676531E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.4120772456273E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0308972150266E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3174487583539E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.9034129379788E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1183573645595E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8676110580278E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.4145321147638E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5817471491673E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.3191293384115E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6944373481319E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7573187073554E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4539,16 +4533,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.9997093388909E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.4684380552434E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7237204208926E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0537456334733E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   5.0146221857409E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   3.0037927440689E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.4140012160545E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.4316987659631E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.2569376330049E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.8966286535184E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.9997093368432E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.4684380549056E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7237203949097E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0537456335688E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   5.0146221858090E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   3.0037927364582E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.4140012187572E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.4316987638814E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.2569376300921E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.8966286528782E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4572,60 +4566,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.8416615879927E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4327658987679E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.7124645318951E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.9908449581943E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.7060355494787E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.4912767944793E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.1394848358528E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   6.1368404182652E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.9774801999488E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.5956009912765E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.6153250970390E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.3791032024209E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.1633797041882E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.0536942389037E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.5940829024598E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.2409840078938E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3429518923576E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0248605969549E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   7.0684859618537E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3395056768179E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.8416616138935E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4327658893664E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.7124645128850E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.9908449545201E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.7060355488205E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.4912774951071E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.1394848576257E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   6.1368404244974E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.9774802028272E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.5956010038105E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.6153251642495E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.3791028724843E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.1633796775580E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.0536942433156E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.5940828956783E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.2409840041336E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3429519030116E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0248605966867E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   7.0684859625184E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3395056773892E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.5817471460334E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.4145321147891E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   8.3191293358643E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6944373479984E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7573187071473E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.5817471491673E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.4145321147638E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   8.3191293384115E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6944373481319E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7573187073554E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.2318355804615E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.6243720790112E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -3.4091528996915E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8633926760949E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.3743216399661E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.3174487585441E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0308972150512E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.9034129355834E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1183573645606E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.8676110580267E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.5817471460334E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.4145321147891E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   8.3191293358643E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6944373479984E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.7573187071473E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.2318355803247E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.6243720788377E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -3.4091529013518E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8633926760940E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.3743216399652E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.3174487583539E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0308972150266E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.9034129379788E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1183573645595E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.8676110580278E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.5817471491673E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.4145321147638E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   8.3191293384115E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6944373481319E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.7573187073554E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378026551559E+00  1.70650733721647E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4636,62 +4629,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4751732620274E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6384567647910E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7700899541954E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2462809248958E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3638388853383E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3354000556886E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4168044046817E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3580185441439E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9941142500188E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3710040205744E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.0373840244355E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.5986120383260E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -3.6348534183227E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4290399701266E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2646826090596E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7104659779447E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9413302430167E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1105120028697E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4482265450321E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0202671210318E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0954411272538E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7565347798252E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864538210313E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2606434158018E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0771789013081E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4751732629202E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6384567615239E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7700900354839E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2462809259939E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3638388891987E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3354000238444E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4168044263030E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3580184660549E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9941142518252E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3710040233013E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.0373840770037E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.5986120845033E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -3.6348536710106E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4290399699383E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2646826093220E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7104659779683E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9413302430201E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1105120028603E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4482265450343E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0202671210364E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0954411272537E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7565347798251E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864538209807E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2606434158198E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0771789013722E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378026551559E+00  1.70650733721647E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.85398571495021E-17  1.51546583833687E-03
+ cg2d: Sum(rhs),rhsMax =   1.07336015076065E-17  1.51546581641259E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.0577020405818E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5876807921171E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.4270645392241E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9073327628889E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.4122280943571E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2909803005333E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.8371015963022E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.8891801233356E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6635187087317E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2813377745137E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3735851358010E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7547136280770E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.8808548121330E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.8224341868573E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.1467725714537E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.5548563851331E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2777653021189E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1093103800153E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.2567175716011E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.9995714010211E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.0577020339422E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5876807936801E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.4270644922532E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9073327634385E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.4122280962304E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2909803107599E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.8371015933055E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.8891801269478E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6635187082128E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2813377740891E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3735851357031E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7547136295613E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.8808548109069E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.8224341868546E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.1467725714849E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.5548563850827E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2777653024341E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1093103800706E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.2567175716356E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.9995714010001E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4700,16 +4692,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.7257442067610E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.4309744153105E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.0404074899863E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7119594381707E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.9278419114874E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5903812150882E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.1168595196420E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.7752572829182E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4880501863231E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.7242819506298E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.7257442119561E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.4309744156462E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.0404074431268E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7119594385032E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.9278419146822E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5903812224157E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.1168595132654E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.7752572861982E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4880501858542E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.7242819432707E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4733,56 +4725,56 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   9.1824175984120E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.6250517136871E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -5.3313409164007E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.4926079729483E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.0966500390164E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   6.7918413627126E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0181606808212E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   8.4742235786670E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.6918195249300E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2634582550692E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.0694507955716E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8527241350052E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.9086159584682E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.0906346579615E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.5734749860471E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.4951623382954E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.6193350203920E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3703447915904E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.4353997826944E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.7886433534892E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   9.1824176356980E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.6250517295265E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -5.3313408931166E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.4926079723771E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.0966500564388E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   6.7918415948465E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0181606828033E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   8.4742235996720E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.6918195271136E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2634582674848E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.0694512362815E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8527242050059E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.9086159738230E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.0906346613472E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.5734749676491E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.4951623641191E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.6193350253027E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3703447916824E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.4353997837165E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.7886433543293E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2777653021189E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.5548563851331E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1093103800153E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.2567175716011E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.9995714010211E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2777653024341E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.5548563850827E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1093103800706E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.2567175716356E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.9995714010001E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.6410223448753E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1492923740650E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -5.2436357372917E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4830026746760E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.4917537556589E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7547136280770E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3735851358010E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.8808548121330E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.8224341868573E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.1467725714537E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2777653021189E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.5548563851331E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1093103800153E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.2567175716011E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.9995714010211E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.6410223459431E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1492923739945E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -5.2436357361206E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4830026746734E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.4917537556849E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7547136295613E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3735851357031E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.8808548109069E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.8224341868546E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.1467725714849E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2777653024341E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.5548563850827E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1093103800706E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.2567175716356E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.9995714010001E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4791,7 +4783,6 @@
  cg2d: Sum(rhs),rhsMax =   3.00378020371974E+00  1.78237451821771E-01
  cg2d: Sum(rhs),rhsMax =   3.00378020371954E+00  1.75379603205384E-01
  cg2d: Sum(rhs),rhsMax =   3.00378020371976E+00  1.71568757909502E-01
- cg2d: Sum(rhs),rhsMax =   3.00378021282381E+00  1.71568754799472E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4802,62 +4793,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2432870889418E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2844634621222E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7026332279110E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1481047947230E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2567810979189E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.7037751557498E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8509373276164E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0242984103528E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1190722020514E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.3158922635451E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.5012340533312E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -6.6448132463157E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0179185468367E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.9860703303598E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.6298314039636E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1365102143196E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6759162929646E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8880493660315E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5587619587371E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2739332549551E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8692505169742E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1957828487069E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9821738688609E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1574885639688E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5945817325064E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2432870860343E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2844634833995E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7026334660107E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1481047957200E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2567811016850E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.7037751393118E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8509373500392E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0242982973920E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1190722026242E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.3158922628466E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.5012340652953E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -6.6448132444299E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0179185441214E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.9860703309402E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.6298314062947E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1365102143413E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6759162929704E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8880493660145E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5587619587375E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2739332549599E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8692505169756E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1957828487074E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9821738687757E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1574885639697E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5945817326229E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378021282381E+00  1.71568754799472E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.68628738645072E-18  2.18167388881427E-03
+ cg2d: Sum(rhs),rhsMax =  -1.36609473733174E-17  2.18167383062251E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   8.7366134535611E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.1443455870345E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3220506350249E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7536756216139E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.9377030226465E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2722161474212E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2868110832127E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.2653834866154E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3904079166699E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7654124854530E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.7151599616521E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1911272770538E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   7.0626241654112E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.5246864410646E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.4193444977898E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.6945034382308E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5973136677667E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.3859909457472E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8185654218120E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.2295349035191E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   8.7366134616177E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.1443455900466E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3220506297482E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7536756220200E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.9377030247220E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2722161421302E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2868110797519E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.2653834876564E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3904079166686E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7654124854872E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.7151599609709E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1911272802602E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   7.0626241640559E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.5246864410613E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.4193444978206E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.6945034381852E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5973136681176E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.3859909459740E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8185654219917E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.2295349037619E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4866,16 +4856,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.8760112162635E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.5106179425512E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2680707034031E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4884831756428E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.1243592674070E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.9563193466516E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8823589034898E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.2503318502286E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.1546037107915E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1016905383496E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.8760112102570E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.5106179433836E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2680706978912E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4884831756642E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.1243592671393E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.9563193428764E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8823589096814E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.2503318510095E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.1546037107866E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1016905386424E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4899,60 +4889,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3491019417853E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.0446918280210E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -7.0746238169251E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.4450043163638E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.9642441251720E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2643492293384E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.4930898791885E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.0971736279857E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   7.6918727198736E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   3.1183356572993E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9008053071786E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.2853300489971E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.6985049552800E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.1554346806001E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   9.6006966172183E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.8404489393110E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.9070770456580E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7327623714729E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1868890827891E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.2530265412176E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3491019451470E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.0446918283930E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -7.0746238356535E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.4450043098216E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.9642441310602E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2643492381711E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.4930898782573E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.0971736288666E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   7.6918727134650E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   3.1183356528911E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9008052527149E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.2853302085913E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.6985049766863E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.1554346765436E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   9.6006965732799E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.8404489312082E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.9070770333836E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7327623721723E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1868890827137E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.2530265427026E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5973136677667E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.6945034382308E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.3859909457472E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8185654218120E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.2295349035191E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5973136681176E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.6945034381852E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.3859909459740E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8185654219917E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.2295349037619E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.0495876425798E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.4353225019083E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -7.1854619007681E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.1012698036388E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.6040784611377E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1911272770538E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.7151599616521E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -7.0626241654112E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.5246864410646E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.4193444977898E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5973136677667E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.6945034382308E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.3859909457472E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.8185654218120E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.2295349035191E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.0495876448868E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.4353225014184E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -7.1854618991611E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.1012698036356E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.6040784611632E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1911272802602E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.7151599609709E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -7.0626241640559E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.5246864410613E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.4193444978206E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5973136681176E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.6945034381852E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.3859909459740E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.8185654219917E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.2295349037619E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378024346087E+00  1.75379598835901E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4963,62 +4952,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0380334614513E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2620269511981E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6421125458609E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6351421363386E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3933746533410E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2845422782319E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5206864451445E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0748744768915E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6083141746610E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.5275265099309E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0177503415430E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.1993088264680E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.7491354246633E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.4257401157916E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.7826383151088E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5616239404765E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4100651327694E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6655422354445E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6685804581934E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5267599673840E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6429856671417E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6350141654765E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777398274141E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3888710409122E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1122193655654E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0380334664304E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2620269948289E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6421129749048E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6351421370065E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3933746541990E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2845422820657E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5206865943205E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0748743185451E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6083141748584E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.5275265029046E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0177503448332E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.1993088416087E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.7491354620636E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.4257401153411E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.7826383195274E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5616239404707E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4100651327787E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6655422354161E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6685804581885E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5267599673796E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6429856671437E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6350141654768E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777398274000E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3888710409113E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1122193656988E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378024346087E+00  1.75379598835901E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.93889390390723E-18  2.82609686028075E-03
+ cg2d: Sum(rhs),rhsMax =  -2.75387351811318E-17  2.82609713947500E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.1447898411751E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.7823959636005E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7061866808470E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6985448738954E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.4798547357477E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1611998159847E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.9315029093390E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6626424474581E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.2096690268388E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.2820199137604E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0558694836011E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6269044321344E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0044747352056E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.2262075105975E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.6871740764402E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.8300591709450E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.9177857926748E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.6628313888833E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.3776276880425E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4477338617658E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.1447898412872E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.7823959594880E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7061866717853E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6985448749220E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.4798547335866E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1611998146931E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.9315029261928E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6626424481915E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.2096690268434E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.2820199144440E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0558694825367E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6269044368759E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0044747350297E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.2262075105979E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.6871740764644E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.8300591709878E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.9177857932782E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.6628313894493E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.3776276883887E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4477338623452E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5027,16 +5015,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.0427739194198E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.7020038682475E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6359871038284E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.3609711800775E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4831604293502E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.5556847623218E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.2227367532767E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6440278316636E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.9118710925706E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4692515107095E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.0427739179541E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.7020038691980E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6359870947128E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.3609711811883E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4831604288080E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.5556847484580E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.2227367659466E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6440278323699E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.9118710925988E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4692515120443E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5060,60 +5048,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.2858076044233E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3195984106190E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.7488305581353E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   9.6799978072280E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.0066615722177E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.0435770372386E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.0099630156467E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.3507536671158E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.0122036393985E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.4814968510925E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8312660004833E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.7782719217103E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.5617016870888E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.2587748397800E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1750737012098E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2805798970474E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.1512516320901E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.1169684720958E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.4406254326455E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.7452827021778E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.2858074860995E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3195984052221E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.7488305379373E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   9.6799978016299E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.0066615487695E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.0435769315793E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.0099630190156E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.3507536634889E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.0122036375152E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.4814968224405E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8312662762439E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.7782714100333E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.5617016986106E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.2587748395846E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1750736913140E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2805799319818E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.1512516282770E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.1169684730169E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.4406254326817E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.7452827022975E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.9177857926748E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.8300591709450E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.6628313888833E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.3776276880425E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   7.4477338617658E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.9177857932782E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.8300591709878E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.6628313894493E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.3776276883887E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   7.4477338623452E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4577177536749E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.7206628948170E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -9.6533719982355E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.7189885909461E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.7136219743112E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.6269044321344E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.0558694836011E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0044747352056E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.2262075105975E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.6871740764402E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.9177857926748E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8300591709450E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.6628313888833E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.3776276880425E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   7.4477338617658E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4577177570865E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.7206628940516E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -9.6533719958165E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.7189885909455E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.7136219743436E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.6269044368759E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.0558694825367E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0044747350297E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.2262075105979E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.6871740764644E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.9177857932782E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8300591709878E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.6628313894493E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.3776276883887E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   7.4477338623452E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378032094023E+00  1.78237455897093E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5124,62 +5111,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.8086732817124E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5420285841104E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4650537638594E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1680725296254E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.6912086213413E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0353826343667E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3834190077181E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4120649221950E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1488698633012E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.9098021737786E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.1012662152143E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.0319098747574E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.6156090472773E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6601822872347E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4248987975370E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9856773640044E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1437252225157E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4429366507058E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7777563412293E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7788857847563E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4166072393470E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0801723270611E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572014009744E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6202632702729E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6299671104964E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.8086732723368E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5420286125689E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4650543262320E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1680725286813E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.6912086193067E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0353827009285E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3834189791713E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4120646861847E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1488698631098E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.9098021761860E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.1012662162274E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.0319098769142E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.6156090729797E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6601822884976E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4248987967739E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9856773639198E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1437252225059E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4429366506704E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7777563412218E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7788857847487E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4166072393493E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0801723270609E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572014009561E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6202632702739E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6299671106402E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00378032094023E+00  1.78237455897093E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -8.67361737988404E-18  3.42522117786633E-03
+ cg2d: Sum(rhs),rhsMax =   3.25260651745651E-17  3.42522118314560E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4016871141429E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.3793603665193E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0670308595971E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.7177641852816E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.0197074540486E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.5051609033384E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.0650998443179E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.0630693539188E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.1051441721262E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.8127329029439E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3957376777241E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0621964078758E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3722963181558E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.9257168393641E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.9488050427828E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.9506657664789E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1914202809131E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.9390346181779E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9337219632755E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.6667219583677E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4016871132294E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.3793603695123E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0670308517639E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.7177641864611E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.0197074527429E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.5051609013028E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.0650998614665E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.0630693527409E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.1051441717087E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.8127329035485E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3957376764461E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0621964139827E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3722963180532E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.9257168393705E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.9488050427940E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.9506657665906E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1914202818700E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.9390346185319E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9337219635444E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.6667219588768E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5188,16 +5174,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1057338276210E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8089743639125E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.9805540963474E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.3071162958296E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.8581769775193E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.2189809285546E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3613018617176E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.0417141231521E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.7448059308299E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.8593110589061E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1057338263959E+01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8089743671607E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.9805540890675E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.3071162971227E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.8581769772503E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.2189809260795E+01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3613018748410E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.0417141220617E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.7448059303804E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.8593110593308E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5221,61 +5207,59 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.0994674436344E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.6776741863546E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.0111809058421E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1674370373697E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.8146327853739E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.2189962563443E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.2850893603066E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.6125346741007E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2313598849815E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   5.3990766261339E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4954948635897E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2426724382302E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2079201093692E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   7.2522732826374E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3581007335887E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.0549419939345E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.2714988931182E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.4464082854157E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6541989309034E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.1315206683500E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.0994674469706E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.6776741761546E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.0111809045645E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1674370380606E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.8146327681422E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.2189962627341E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.2850893624038E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.6125346691185E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2313598834382E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   5.3990765971843E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4954945259575E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2426731936596E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2079200944062E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   7.2522732877226E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3581007502996E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.0549419916004E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.2714988944028E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.4464082856939E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6541989309916E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.1315206705097E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1914202809131E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -7.9506657664789E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.9390346181779E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9337219632755E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.6667219583677E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1914202818700E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -7.9506657665906E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.9390346185319E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9337219635444E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.6667219588768E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.8655613571027E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.0052410992073E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.2554994554842E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.3352680648727E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.8189548124645E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.0621964078758E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.3957376777241E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.3722963181558E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.9257168393641E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.9488050427828E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1914202809131E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.9506657664789E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.9390346181779E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9337219632755E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.6667219583677E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.8655613614961E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.0052410982882E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.2554994552803E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.3352680648762E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.8189548124886E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.0621964139827E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.3957376764461E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.3722963180532E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.9257168393705E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.9488050427940E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1914202818700E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.9506657665906E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.9390346185319E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9337219635444E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.6667219588768E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00378020377713E+00  1.73700014741903E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5286,63 +5270,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.6378469037306E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1098471702858E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0631811434862E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7308407736839E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.2081372656437E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.9186744984413E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4003282809773E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0912853361901E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7230382584008E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2376629629111E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3942763903565E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1746802121840E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3466395904869E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.7354734122042E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4806128042620E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.4085618123946E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8768537728312E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2201749195499E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8863893725055E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0303562113338E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1900711844636E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5315513303745E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4365860510163E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8516761247151E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1485740095421E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.6378469228709E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1098471635779E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0631814251585E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7308407751873E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.2081372647199E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.9186744354765E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4003283040805E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0912853539266E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7230382604165E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2376629621558E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3942763893914E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1746802126295E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3466395998635E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.7354734120577E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4806128039695E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.4085618123630E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8768537728430E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2201749195106E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8863893724921E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0303562113250E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1900711844653E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5315513303741E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4365860509956E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8516761247145E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1485740096081E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.00378020377713E+00  1.73700014741903E-01
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -3.77302356024956E-17  3.92697911526307E-03
+ cg2d: Sum(rhs),rhsMax =  -1.38777878078145E-17  3.92697912649663E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.6283012445710E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.0087133030321E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.3744942665584E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.7932884454196E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.5462566161061E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.8346989624737E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.5261977611216E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.4531000507977E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.0601541488820E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.3395357311453E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.7350576265284E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4965139200384E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0631441130740E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.6164096033004E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.0202880125380E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.0353237358972E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4445215702130E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.2147933050962E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.4870470556818E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.8690123543699E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.6283012430406E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.0087133045335E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.3744942537972E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.7932884456614E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.5462566128312E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.8346989606242E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.5261977737427E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.4531000527073E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.0601541489691E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.3395357313055E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.7350576244154E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4965139256334E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0631441124045E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.6164096032959E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.0202880125332E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.0353237359624E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4445215701599E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.2147933048579E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.4870470556466E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.8690123544422E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5351,16 +5333,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2794981337425E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.7708791023799E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.2726852377148E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3106490988349E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2363438315614E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4723238311215E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -7.3631828515091E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.4300506686664E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6394393276366E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.2593043649955E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2794981308728E+01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.7708791035136E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.2726852254384E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3106490993385E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2363438308640E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4723238290970E+01
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -7.3631828603253E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.4300506702726E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6394393276867E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.2593043644948E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5384,56 +5366,56 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.3296246280441E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -2.0285589322264E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.1385808451275E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3747730420045E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.6970539603683E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.7901268133771E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.4201662050912E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.8565281681633E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.4658789836729E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.3219896570926E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8223596910473E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7284428183821E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.9739067405393E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.2537407581036E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.5499475521069E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.6068435656499E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0337375880830E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.8099342050996E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8694063194703E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.5311314433960E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.3296246264526E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -2.0285589283237E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.1385808402104E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3747730421767E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.6970539792847E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.7901268317750E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.4201662027517E-01
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.8565281691426E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.4658789822476E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.3219896641642E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8223603400273E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7284431957257E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.9739067140200E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.2537407503042E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.5499475437001E-05
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.6068436276226E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0337375874268E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.8099342041846E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8694063193673E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.5311314422428E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4445215702130E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.0353237358972E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.2147933050962E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.4870470556818E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.8690123543700E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4445215701599E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.0353237359624E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.2147933048579E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.4870470556466E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.8690123544422E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.2725190161215E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2893380018539E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.0981091360908E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9460156486813E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.9182120555084E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.4965139200384E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.7350576265284E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0631441130740E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.6164096033004E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.0202880125380E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4445215702130E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.0353237358972E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.2147933050962E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.4870470556818E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.8690123543700E+02
+(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.2725190201466E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2893380003346E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.0981091354794E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9460156486765E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.9182120554959E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.4965139256334E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.7350576244154E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0631441124045E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.6164096032959E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.0202880125332E-06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4445215701599E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.0353237359624E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.2147933048579E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.4870470556466E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.8690123544422E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5467,31 +5449,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9930191517414E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3992997239194E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6850179028490E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2534889805943E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4146503295455E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0974561358359E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1490405657211E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3151605924225E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2205418149828E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4469794577719E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3465575472872E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.6017285875117E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4297605660508E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2052529107863E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.9928256073700E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8301821699160E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.6094158880674E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.9972563627032E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9946125163775E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2811436513340E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9633266087539E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9834690484517E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6158823668365E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0831251998487E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6675933323565E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9930191378122E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3992997238554E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6850185585680E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2534889798707E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4146503297223E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0974561368860E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1490405641979E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3151606009567E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2205418146382E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4469794571268E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3465575413422E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.6017286219914E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4297605825441E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2052529111163E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.9928256123641E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8301821699540E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.6094158880793E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.9972563626566E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9946125163716E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2811436513420E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9633266087554E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9834690484516E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6158823668121E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0831251998477E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6675933323492E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5990,231 +5972,231 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4995.5911988615990
-(PID.TID 0000.0001)         System time:   9.4825889766216278
-(PID.TID 0000.0001)     Wall clock time:   5027.3204360008240
+(PID.TID 0000.0001)           User time:   4945.0948987007141
+(PID.TID 0000.0001)         System time:   12.372582137584686
+(PID.TID 0000.0001)     Wall clock time:   4995.3486869335175
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.294506281614304
-(PID.TID 0000.0001)         System time:  0.74418604373931885
-(PID.TID 0000.0001)     Wall clock time:   15.707523822784424
+(PID.TID 0000.0001)           User time:   10.745999336242676
+(PID.TID 0000.0001)         System time:  0.75707700848579407
+(PID.TID 0000.0001)     Wall clock time:   14.001218080520630
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1992.8331480026245
-(PID.TID 0000.0001)         System time:   3.8318581581115723
-(PID.TID 0000.0001)     Wall clock time:   2010.0955300331116
+(PID.TID 0000.0001)           User time:   1961.2864618301392
+(PID.TID 0000.0001)         System time:   5.7622342109680176
+(PID.TID 0000.0001)     Wall clock time:   1992.6940820217133
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   390.59078979492188
-(PID.TID 0000.0001)         System time:  0.56201362609863281
-(PID.TID 0000.0001)     Wall clock time:   393.58670735359192
+(PID.TID 0000.0001)           User time:   386.83706665039062
+(PID.TID 0000.0001)         System time:  0.78070592880249023
+(PID.TID 0000.0001)     Wall clock time:   392.23709225654602
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2698059082031250
-(PID.TID 0000.0001)         System time:   3.1948089599609375E-005
-(PID.TID 0000.0001)     Wall clock time:   8.2826902866363525
+(PID.TID 0000.0001)           User time:   8.1643981933593750
+(PID.TID 0000.0001)         System time:   2.6464462280273438E-005
+(PID.TID 0000.0001)     Wall clock time:   8.1712260246276855
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1921997070312500
-(PID.TID 0000.0001)         System time:   5.6959390640258789E-002
-(PID.TID 0000.0001)     Wall clock time:   4.7067661285400391
+(PID.TID 0000.0001)           User time:   3.5802307128906250
+(PID.TID 0000.0001)         System time:  0.10396933555603027
+(PID.TID 0000.0001)     Wall clock time:   6.7239351272583008
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.8701782226562500
-(PID.TID 0000.0001)         System time:   3.0969142913818359E-002
-(PID.TID 0000.0001)     Wall clock time:   4.3200485706329346
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)           User time:   2.7502746582031250
+(PID.TID 0000.0001)         System time:   5.0013065338134766E-002
+(PID.TID 0000.0001)     Wall clock time:   5.8019824028015137
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.1035156250000000E-004
+(PID.TID 0000.0001)           User time:   3.9672851562500000E-004
 (PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.0470867156982422E-002
-(PID.TID 0000.0001)          No. starts:          88
-(PID.TID 0000.0001)           No. stops:          88
+(PID.TID 0000.0001)     Wall clock time:   9.0932846069335938E-004
+(PID.TID 0000.0001)          No. starts:          80
+(PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60583496093750000
-(PID.TID 0000.0001)         System time:   1.0192394256591797E-003
-(PID.TID 0000.0001)     Wall clock time:  0.60548090934753418
+(PID.TID 0000.0001)           User time:  0.62063598632812500
+(PID.TID 0000.0001)         System time:   1.0187625885009766E-003
+(PID.TID 0000.0001)     Wall clock time:  0.62208986282348633
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25634765625000000
-(PID.TID 0000.0001)         System time:   1.0066032409667969E-003
-(PID.TID 0000.0001)     Wall clock time:  0.25841999053955078
+(PID.TID 0000.0001)           User time:  0.25405883789062500
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:  0.25731134414672852
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.667083740234375
-(PID.TID 0000.0001)         System time:   1.0016441345214844E-002
-(PID.TID 0000.0001)     Wall clock time:   13.701555490493774
+(PID.TID 0000.0001)           User time:   13.724822998046875
+(PID.TID 0000.0001)         System time:   4.4958114624023438E-002
+(PID.TID 0000.0001)     Wall clock time:   13.776080131530762
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   116.53939819335938
-(PID.TID 0000.0001)         System time:   7.0607662200927734E-003
-(PID.TID 0000.0001)     Wall clock time:   116.97150588035583
+(PID.TID 0000.0001)           User time:   116.77218627929688
+(PID.TID 0000.0001)         System time:   4.3990135192871094E-002
+(PID.TID 0000.0001)     Wall clock time:   117.16535949707031
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5968017578125000
-(PID.TID 0000.0001)         System time:   1.0085105895996094E-003
-(PID.TID 0000.0001)     Wall clock time:   2.6031224727630615
+(PID.TID 0000.0001)           User time:   1.8263854980468750
+(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
+(PID.TID 0000.0001)     Wall clock time:   1.8281579017639160
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.793701171875000
-(PID.TID 0000.0001)         System time:   1.1001348495483398E-002
-(PID.TID 0000.0001)     Wall clock time:   17.007144451141357
+(PID.TID 0000.0001)           User time:   16.069671630859375
+(PID.TID 0000.0001)         System time:   1.8993377685546875E-002
+(PID.TID 0000.0001)     Wall clock time:   16.094737291336060
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6116333007812500
-(PID.TID 0000.0001)         System time:   7.1525573730468750E-006
-(PID.TID 0000.0001)     Wall clock time:   2.6163344383239746
+(PID.TID 0000.0001)           User time:   2.6146545410156250
+(PID.TID 0000.0001)         System time:   1.0037422180175781E-003
+(PID.TID 0000.0001)     Wall clock time:   2.6172778606414795
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8361511230468750
-(PID.TID 0000.0001)         System time:   1.2636184692382812E-005
-(PID.TID 0000.0001)     Wall clock time:   4.8402025699615479
+(PID.TID 0000.0001)           User time:   4.8610534667968750
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:   4.8636279106140137
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.36407470703125000
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:  0.36574506759643555
+(PID.TID 0000.0001)           User time:  0.35488891601562500
+(PID.TID 0000.0001)         System time:   4.2915344238281250E-006
+(PID.TID 0000.0001)     Wall clock time:  0.35491299629211426
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0365295410156250
-(PID.TID 0000.0001)         System time:   7.0095062255859375E-003
-(PID.TID 0000.0001)     Wall clock time:   7.0685672760009766
+(PID.TID 0000.0001)           User time:   6.8042907714843750
+(PID.TID 0000.0001)         System time:   1.2951135635375977E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8223547935485840
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   84.048278808593750
-(PID.TID 0000.0001)         System time:   5.0265789031982422E-003
-(PID.TID 0000.0001)     Wall clock time:   84.140844106674194
+(PID.TID 0000.0001)           User time:   84.279052734375000
+(PID.TID 0000.0001)         System time:   2.3995637893676758E-002
+(PID.TID 0000.0001)     Wall clock time:   84.365673542022705
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7138671875000000E-004
+(PID.TID 0000.0001)           User time:   1.0681152343750000E-003
 (PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.2148780822753906E-004
+(PID.TID 0000.0001)     Wall clock time:   9.1767311096191406E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0618286132812500
-(PID.TID 0000.0001)         System time:   9.9611282348632812E-004
-(PID.TID 0000.0001)     Wall clock time:   1.0640563964843750
+(PID.TID 0000.0001)           User time:   1.0666503906250000
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   1.0684475898742676
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1596679687500000E-003
-(PID.TID 0000.0001)         System time:   1.4305114746093750E-006
-(PID.TID 0000.0001)     Wall clock time:   9.1361999511718750E-004
+(PID.TID 0000.0001)           User time:   1.6479492187500000E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.2124938964843750E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9408264160156250
-(PID.TID 0000.0001)         System time:   9.8946809768676758E-002
-(PID.TID 0000.0001)     Wall clock time:   2.2379043102264404
+(PID.TID 0000.0001)           User time:   1.9259033203125000
+(PID.TID 0000.0001)         System time:  0.14692902565002441
+(PID.TID 0000.0001)     Wall clock time:   2.4052197933197021
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5701904296875000
-(PID.TID 0000.0001)         System time:  0.35483908653259277
-(PID.TID 0000.0001)     Wall clock time:   3.7951872348785400
+(PID.TID 0000.0001)           User time:   2.6810302734375000
+(PID.TID 0000.0001)         System time:  0.38082790374755859
+(PID.TID 0000.0001)     Wall clock time:   3.8175435066223145
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.390899658203125
-(PID.TID 0000.0001)         System time:  0.64393734931945801
-(PID.TID 0000.0001)     Wall clock time:   25.957055807113647
+(PID.TID 0000.0001)           User time:   22.260650634765625
+(PID.TID 0000.0001)         System time:  0.95163130760192871
+(PID.TID 0000.0001)     Wall clock time:   24.734815835952759
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7213134765625000
-(PID.TID 0000.0001)         System time:  0.15502047538757324
-(PID.TID 0000.0001)     Wall clock time:   7.9029772281646729
+(PID.TID 0000.0001)           User time:   7.6747436523437500
+(PID.TID 0000.0001)         System time:  0.20191764831542969
+(PID.TID 0000.0001)     Wall clock time:   8.1376705169677734
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5783691406250000
-(PID.TID 0000.0001)         System time:  0.10397815704345703
-(PID.TID 0000.0001)     Wall clock time:   3.7544729709625244
+(PID.TID 0000.0001)           User time:   3.6733398437500000
+(PID.TID 0000.0001)         System time:  0.12093257904052734
+(PID.TID 0000.0001)     Wall clock time:   4.1185531616210938
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5690917968750000
-(PID.TID 0000.0001)         System time:  0.10497760772705078
-(PID.TID 0000.0001)     Wall clock time:   3.7288699150085449
+(PID.TID 0000.0001)           User time:   3.6583251953125000
+(PID.TID 0000.0001)         System time:   8.0995082855224609E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8370978832244873
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2984.3160400390625
-(PID.TID 0000.0001)         System time:   4.6975741386413574
-(PID.TID 0000.0001)     Wall clock time:   2994.0339159965515
+(PID.TID 0000.0001)           User time:   2965.7307128906250
+(PID.TID 0000.0001)         System time:   5.6513342857360840
+(PID.TID 0000.0001)     Wall clock time:   2980.6976151466370
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2639.1602783203125
-(PID.TID 0000.0001)         System time:   3.6202440261840820
-(PID.TID 0000.0001)     Wall clock time:   2646.4455978870392
+(PID.TID 0000.0001)           User time:   2621.5328369140625
+(PID.TID 0000.0001)         System time:   4.1308150291442871
+(PID.TID 0000.0001)     Wall clock time:   2630.4715878963470
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   344.88061523437500
-(PID.TID 0000.0001)         System time:   1.0523352622985840
-(PID.TID 0000.0001)     Wall clock time:   347.25436401367188
+(PID.TID 0000.0001)           User time:   343.15673828125000
+(PID.TID 0000.0001)         System time:   1.4145469665527344
+(PID.TID 0000.0001)     Wall clock time:   349.02947521209717
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5783691406250000
-(PID.TID 0000.0001)         System time:   1.0223388671875000E-003
-(PID.TID 0000.0001)     Wall clock time:   5.5834748744964600
+(PID.TID 0000.0001)           User time:   5.4567871093750000
+(PID.TID 0000.0001)         System time:   4.9943923950195312E-003
+(PID.TID 0000.0001)     Wall clock time:   5.4652261734008789
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1728515625000000E-002
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.9469976425170898E-002
+(PID.TID 0000.0001)           User time:   1.7822265625000000E-002
+(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
+(PID.TID 0000.0001)     Wall clock time:   1.8765687942504883E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   305.95800781250000
-(PID.TID 0000.0001)         System time:   7.1219444274902344E-002
-(PID.TID 0000.0001)     Wall clock time:   306.35665249824524
+(PID.TID 0000.0001)           User time:   304.11865234375000
+(PID.TID 0000.0001)         System time:  0.10696983337402344
+(PID.TID 0000.0001)     Wall clock time:   307.28824234008789
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8920898437500000
-(PID.TID 0000.0001)         System time:  0.29903078079223633
-(PID.TID 0000.0001)     Wall clock time:   6.6246118545532227
+(PID.TID 0000.0001)           User time:   5.9353027343750000
+(PID.TID 0000.0001)         System time:  0.33490228652954102
+(PID.TID 0000.0001)     Wall clock time:   6.5914144515991211
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.9296875000000000E-003
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.4492740631103516E-003
+(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
+(PID.TID 0000.0001)         System time:   4.2915344238281250E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3622512817382812E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   26.769042968750000
-(PID.TID 0000.0001)         System time:  0.67904090881347656
-(PID.TID 0000.0001)     Wall clock time:   28.001445293426514
+(PID.TID 0000.0001)           User time:   26.623779296875000
+(PID.TID 0000.0001)         System time:  0.96367597579956055
+(PID.TID 0000.0001)     Wall clock time:   28.651564836502075
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.7587890625000000E-002
-(PID.TID 0000.0001)         System time:   2.0036697387695312E-003
-(PID.TID 0000.0001)     Wall clock time:   3.3760070800781250E-002
+(PID.TID 0000.0001)           User time:  0.36450195312500000
+(PID.TID 0000.0001)         System time:   1.9955635070800781E-003
+(PID.TID 0000.0001)     Wall clock time:  0.37312412261962891
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6254,9 +6236,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         899768
+(PID.TID 0000.0001) //            No. barriers =         875380
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         899768
+(PID.TID 0000.0001) //     Total barrier spins =         875380
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,10 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #446 (store directives): update all 6 output_adm (oce_cs32 & llc90);
+    since these 2 experiments use real*4 storage (isbyte=4), get changes (for
+    all 6) in AD-monitor and in AD-grad for oce_cs32 primary test.
+
 checkpoint67y (2021/05/05) synchronised with main MITgcm code.
   - post PR #456 (fix shelfice pLoc): update shelfice_remeshing alternative
     "vrm" output (output_vrm.txt).


### PR DESCRIPTION
Changes in AD output are due to single-prec storage (isbyte=4) used in AD
experiments global_oce_cs32 & llc90; most show only changes in AD-monitor
except global_oce_cs32 primary test with also AD-gradient differences:
before update:
Y Y Y Y 16> 7<16 10  9  7  9  6  9  7  8  7  8  5  8  7  7  7  8 FAIL  global_oce_cs32  (e=0, w=44)
Y Y Y Y 16>16<16  8  9  7  8  9  8  8  8  8  9  8  9  9  8  7  8 pass  global_oce_cs32.sens
Y Y Y Y 16>16<16 12 11 11 12 13 12 11 12  7  8  7  9  8  8  7  8 pass  global_oce_llc90  (e=0, w=44)
Y Y Y Y 16>16<16 11 10 10 11 10 11 10 10  8  8  6  8  8  8  7  8 pass  global_oce_llc90.core2
Y Y Y Y 16>16<16 12 11 11 12 12 12 11 12  8  8  7  9  8  8  7  8 pass  global_oce_llc90.ecco_v4
Y Y Y Y 16>16<16 11 11 11 12 12 12 11 12  8  8  7  9  8  8  7  8 pass  global_oce_llc90.ecmwf