### PR TITLE
add missing ALLOW_DIFFKR_CONTROL CPP option (needed since checkpoint67x)

### DIFF
--- a/global_oce_cs32/code/CTRL_OPTIONS.h
+++ b/global_oce_cs32/code/CTRL_OPTIONS.h
@@ -37,6 +37,9 @@ C This allows for GMREDI controls
 #define ALLOW_KAPREDI_CONTROL
 # undef ALLOW_KAPREDI_CONTROL_OLD
 
+C This allows for DIFFKR controls
+#define ALLOW_DIFFKR_CONTROL
+
 C o sets of controls
 #define ALLOW_GENTIM2D_CONTROL
 #define ALLOW_GENARR2D_CONTROL

--- a/global_oce_cs32/code/CTRL_OPTIONS.h
+++ b/global_oce_cs32/code/CTRL_OPTIONS.h
@@ -55,7 +55,7 @@ C    This CPP option just sets the default for ctrlSmoothCorrel2D to .TRUE.
 C  o impose bounds on controls
 #define ALLOW_ADCTRLBOUND
 
-C   o rotate u/v vector control to zonal/meridional 
+C   o rotate u/v vector control to zonal/meridional
 C   components
 #define ALLOW_ROTATE_UV_CONTROLS
 

--- a/global_oce_llc90/code/CTRL_OPTIONS.h
+++ b/global_oce_llc90/code/CTRL_OPTIONS.h
@@ -37,6 +37,9 @@ C This allows for GMREDI controls
 #define ALLOW_KAPREDI_CONTROL
 # undef ALLOW_KAPREDI_CONTROL_OLD
 
+C This allows for DIFFKR controls
+#define ALLOW_DIFFKR_CONTROL
+
 C o sets of controls
 #define ALLOW_GENTIM2D_CONTROL
 #define ALLOW_GENARR2D_CONTROL

--- a/global_oce_llc90/code/CTRL_OPTIONS.h
+++ b/global_oce_llc90/code/CTRL_OPTIONS.h
@@ -55,7 +55,7 @@ C    This CPP option just sets the default for ctrlSmoothCorrel2D to .TRUE.
 C  o impose bounds on controls
 #define ALLOW_ADCTRLBOUND
 
-C   o rotate u/v vector control to zonal/meridional 
+C   o rotate u/v vector control to zonal/meridional
 C   components
 #define ALLOW_ROTATE_UV_CONTROLS
 

--- a/update_history
+++ b/update_history
@@ -1,6 +1,11 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - define ALLOW_DIFFKR_CONTROL in experiment global_oce_cs32 & llc90:
+    with generic-control and ALLOW_3D_DIFFKR, diffKr was available as a control
+    without ALLOW_DIFFKR_CONTROL defined (not well documented); this was dropped
+    in https://github.com/MITgcm/MITgcm/pull/447 (ctrl_map_ini_genarr.F) and is
+    put back here ; results unchanged (ctrl "xx_diffkr" only set in FWD tests).
   - post PR #471 (pkg/ctrl cleanup): update few local source code, mainly for
     experiment global_oce_cs32 & llc90.
 


### PR DESCRIPTION
This became needed between checkpoint67w and checkpoint67x when a test for ALLOW_DIFFKR_CONTROL was added in ctrl_map_ini_genarr.F (see https://github.com/MITgcm/MITgcm/pull/447)