### PR TITLE
Post pr502 output update

### DIFF
--- a/global_oce_llc90/input_ad/data.smooth
+++ b/global_oce_llc90/input_ad/data.smooth
@@ -1,12 +1,16 @@
+# =======================
+# pkg SMOOTH parameters :
+# =======================
  &SMOOTH_NML
- smooth2Dnbt(1)=300
- smooth2Dtype(1)=1
- smooth2Dsize(1)=2
- smooth2Dfilter(1)=0
- smooth3Dnbt(1)=300
- smooth3DtypeH(1)=1
- smooth3DsizeH(1)=3
- smooth3DtypeZ(1)=1
- smooth3DsizeZ(1)=3
- smooth3Dfilter(1)=0
+ smooth2Dnbt(1)=300,
+ smooth2Dtype(1)=1,
+ smooth2Dsize(1)=2,
+ smooth2Dfilter(1)=0,
+ smooth3Dnbt(1)=300,
+#-
+ smooth3DtypeH(1)=1,
+ smooth3DsizeH(1)=3,
+ smooth3DtypeZ(1)=1,
+ smooth3DsizeZ(1)=3,
+ smooth3Dfilter(1)=0,
  &

--- a/global_oce_llc90/results/output_adm.core2.txt
+++ b/global_oce_llc90/results/output_adm.core2.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node016
-(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
+(PID.TID 0000.0001) // Build host:        node104.cm.cluster
+(PID.TID 0000.0001) // Build date:        Sat Jul 24 00:27:03 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
+(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node104.cm.cluster
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -844,24 +844,25 @@
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) > &SMOOTH_NML
-(PID.TID 0000.0001) > smooth2Dnbt(1)=300
-(PID.TID 0000.0001) > smooth2Dtype(1)=1
-(PID.TID 0000.0001) > smooth2Dsize(1)=2
-(PID.TID 0000.0001) > smooth2Dfilter(1)=0
-(PID.TID 0000.0001) > smooth3Dnbt(1)=300
-(PID.TID 0000.0001) > smooth3DtypeH(1)=1
-(PID.TID 0000.0001) > smooth3DsizeH(1)=3
-(PID.TID 0000.0001) > smooth3DtypeZ(1)=1
-(PID.TID 0000.0001) > smooth3DsizeZ(1)=3
-(PID.TID 0000.0001) > smooth3Dfilter(1)=0
+(PID.TID 0000.0001) > smooth2Dnbt(1)=300,
+(PID.TID 0000.0001) > smooth2Dtype(1)=1,
+(PID.TID 0000.0001) > smooth2Dsize(1)=2,
+(PID.TID 0000.0001) > smooth2Dfilter(1)=0,
+(PID.TID 0000.0001) > smooth3Dnbt(1)=300,
+(PID.TID 0000.0001) >#-
+(PID.TID 0000.0001) > smooth3DtypeH(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeH(1)=3,
+(PID.TID 0000.0001) > smooth3DtypeZ(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeZ(1)=3,
+(PID.TID 0000.0001) > smooth3Dfilter(1)=0,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SMOOTH_READPARMS: finished reading data.smooth
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // pkg/smooth configuration
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.
-(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.
+(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.maskC
+(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.maskC
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of pkg/smooth config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -3866,36 +3867,36 @@
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.49800180540660E-15  4.10108399308005E-02
  cg2d: Sum(rhs),rhsMax =   8.13932254928318E-15  4.56571171210609E-02
- cg2d: Sum(rhs),rhsMax =   6.13398221105399E-14  4.87116106299301E-02
- cg2d: Sum(rhs),rhsMax =   7.01660951563099E-14  4.97483791440217E-02
-(PID.TID 0000.0001)      cg2d_init_res =   9.93399750641660E-01
+ cg2d: Sum(rhs),rhsMax =   4.16333634234434E-15  4.87116106300475E-02
+ cg2d: Sum(rhs),rhsMax =   5.81756864903582E-14  4.97483791442106E-02
+(PID.TID 0000.0001)      cg2d_init_res =   9.93399749302064E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.75453136367995E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.75453135926721E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8060854233341E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.7918081070342E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.3638612997617E-18
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8060854233343E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.7918081070334E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.3784896317110E-17
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1409256560334E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   5.1088121792116E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   5.1088121792205E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0665659652438E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.4256109404308E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4181289501778E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6614700619684E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.3670552154893E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4181289501773E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6614700619685E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.3670552154852E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.1511904128415E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.7363255031433E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.0695100308809E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.0695100308805E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7534551759163E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.0981943684207E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2433201206539E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3205031408473E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.9104168694007E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.0993822406237E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.8596347332605E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2433201206538E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3205031408480E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.9104168695979E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.0993822406243E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.8596347332717E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1204684539200E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.2946458960917E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920477194107E+00
@@ -3908,14 +3909,14 @@
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.9013015655253E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.6743354024056E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   4.9089681400269E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1742733333597E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1742733333596E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5955795651774E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.9075542202485E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2669437366250E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3831413081034E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2976978710808E-04
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2669437366249E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3831413081033E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.2976978710809E-04
 (PID.TID 0000.0001) %MON ke_max                       =   5.7099259686328E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.9283847528411E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.9283847528412E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.6427268774134E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.3643627904247E-05
@@ -3923,8 +3924,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540902359369E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526771441E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236592023201E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6274609256294E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3884138568777E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.6274609256235E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.3884138568985E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4021,13 +4022,13 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.08322289710850E-14  4.91676482715791E-02
- cg2d: Sum(rhs),rhsMax =  -3.19744231092045E-14  4.78829731715785E-02
- cg2d: Sum(rhs),rhsMax =   3.10862446895044E-14  4.62868955957220E-02
- cg2d: Sum(rhs),rhsMax =  -1.18571819029967E-13  4.51184359657494E-02
-(PID.TID 0000.0001)      cg2d_init_res =   7.82319367974788E-01
+ cg2d: Sum(rhs),rhsMax =  -4.50750547997814E-14  4.91676482716689E-02
+ cg2d: Sum(rhs),rhsMax =  -1.33226762955019E-15  4.78829731714095E-02
+ cg2d: Sum(rhs),rhsMax =  -1.00364161426114E-13  4.62868955955138E-02
+ cg2d: Sum(rhs),rhsMax =  -1.95399252334028E-14  4.51184359657809E-02
+(PID.TID 0000.0001)      cg2d_init_res =   7.82319367973915E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     130
-(PID.TID 0000.0001)      cg2d_last_res =   6.66427672695694E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.66427672686560E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4035,44 +4036,44 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1214096725276E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1261924566269E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.7277225995235E-18
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.8198013582846E-18
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7810049690507E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   5.3579032563554E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0487084454776E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3650695879128E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.6334205748778E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   5.3579032563553E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0487084454777E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.3650695879129E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.6334205748780E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2776864036780E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2111881477638E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5694772611533E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2111881477653E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5694772611535E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.2604074559222E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.0349029860833E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1939371919169E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.9660738191083E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3927016210278E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5660908876769E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.8881960032782E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.3887499207894E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0426459769231E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.9660738191090E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3927016210279E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5660908876781E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.8881960032805E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.3887499207895E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0426459769230E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1195451834562E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.5758076712841E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920777877063E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4367038994261E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1278552330369E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1278552330370E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0703560242073E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8973684261594E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725639033975E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8131861578503E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.8694300364534E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6053322417164E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6053322417165E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7386377519771E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8232969028095E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.5369815211814E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8232969028096E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.5369815211815E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.7228497142266E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8626612102179E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8626612102180E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9080297412123E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.8804975605477E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.1026408783223E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9645948051512E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.1026408783225E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9645948051513E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -3.6645361650928E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.4053559755895E-05
@@ -4080,8 +4081,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004630547E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760531618942E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229217982295E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.1721143621866E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.0848472768326E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.1721143621874E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.0848472768777E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4106,25 +4107,25 @@
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.49800180540660E-15  4.10108399308005E-02
  cg2d: Sum(rhs),rhsMax =   8.13932254928318E-15  4.56571171210609E-02
- cg2d: Sum(rhs),rhsMax =   6.13398221105399E-14  4.87116106299301E-02
- cg2d: Sum(rhs),rhsMax =   7.01660951563099E-14  4.97483791440217E-02
+ cg2d: Sum(rhs),rhsMax =   4.16333634234434E-15  4.87116106300475E-02
+ cg2d: Sum(rhs),rhsMax =   5.81756864903582E-14  4.97483791442106E-02
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =  -7.08322289710850E-14  4.91676482715791E-02
- cg2d: Sum(rhs),rhsMax =  -3.19744231092045E-14  4.78829731715785E-02
- cg2d: Sum(rhs),rhsMax =   3.10862446895044E-14  4.62868955957220E-02
- cg2d: Sum(rhs),rhsMax =  -1.18571819029967E-13  4.51184359657494E-02
+ cg2d: Sum(rhs),rhsMax =  -4.50750547997814E-14  4.91676482716689E-02
+ cg2d: Sum(rhs),rhsMax =  -1.33226762955019E-15  4.78829731714095E-02
+ cg2d: Sum(rhs),rhsMax =  -1.00364161426114E-13  4.62868955955138E-02
+ cg2d: Sum(rhs),rhsMax =  -1.95399252334028E-14  4.51184359657809E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =  -7.08322289710850E-14  4.91676482715791E-02
- cg2d: Sum(rhs),rhsMax =  -3.19744231092045E-14  4.78829731715785E-02
- cg2d: Sum(rhs),rhsMax =   3.10862446895044E-14  4.62868955957220E-02
- cg2d: Sum(rhs),rhsMax =  -1.18571819029967E-13  4.51184359657494E-02
+ cg2d: Sum(rhs),rhsMax =  -4.50750547997814E-14  4.91676482716689E-02
+ cg2d: Sum(rhs),rhsMax =  -1.33226762955019E-15  4.78829731714095E-02
+ cg2d: Sum(rhs),rhsMax =  -1.00364161426114E-13  4.62868955955138E-02
+ cg2d: Sum(rhs),rhsMax =  -1.95399252334028E-14  4.51184359657809E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.04346698525100E-20  1.81186037021313E-06
+ cg2d: Sum(rhs),rhsMax =   1.97993951420693E-20  1.81186037021313E-06
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   9.12254484192881E-19  1.23068566104377E-05
+ cg2d: Sum(rhs),rhsMax =   2.80367905541173E-19  1.23068566104391E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4132,22 +4133,22 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   4.4571683586574E-01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -4.0186052717060E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.1540487620546E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9078633884519E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7694594030478E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.1540487620562E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9078633884453E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7694594030457E-04
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.2085842632029E-01
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.3752631121034E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.3857908368587E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   6.1608297157288E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7916543227447E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.3857908368593E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   6.1608297157204E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7916543227416E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.2687831845393E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.7809532006091E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.2726244088977E-06
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4691455247990E-06
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.4461703126962E-08
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1740797016350E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.3164062465618E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1061352560617E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.3164062465617E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1061352560603E-01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9655041103660E+00
 (PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.2643527757197E-02
 (PID.TID 0000.0001) // =======================================================
@@ -4158,16 +4159,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5634269679666E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5634269679665E-01
 (PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5753676363565E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.0532180582874E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.9805567730133E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   6.0464969961820E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.0532180582892E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.9805567730096E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   6.0464969961708E-05
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8943492126884E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3003412912397E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.3726217552723E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.1361468931790E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   6.2368938257675E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3003412912396E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.3726217552727E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.1361468931768E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   6.2368938257609E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4193,22 +4194,22 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.6579409017662E-03
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -3.8494692280799E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.8125589991265E-07
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.4897267232904E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   8.4699933476077E-07
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.8125589991346E-07
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.4897267232905E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   8.4699933476012E-07
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   5.0938287535020E-03
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.7400160153450E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.3620094424913E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1989209600181E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   8.7761197429853E-07
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.3620094424907E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1989209600184E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   8.7761197429835E-07
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1635525616149E-04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2062814299230E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.3226276717849E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.6011301269939E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.0977909704077E-07
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.3226276717845E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.6011301269943E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.0977909704075E-07
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.1454848447969E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3637531487921E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.4810049415889E-03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.4810049415879E-03
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6085257236130E-01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.9707313108573E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
@@ -4216,9 +4217,9 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.3164062465618E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.3164062465617E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1740797016350E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1061352560617E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1061352560603E+02
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9655041103660E+03
 (PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.2643527757197E+01
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
@@ -4236,9 +4237,9 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.2726244088977E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.4691455247990E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.4461703126962E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.3164062465618E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.3164062465617E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1740797016350E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1061352560617E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1061352560603E+02
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9655041103660E+03
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.2643527757197E+01
 (PID.TID 0000.0001) // =======================================================
@@ -4255,59 +4256,59 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.8249138386130E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.5665824775745E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.5813599490544E-04
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2001156865418E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.7429094803342E-05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.5665824775746E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.5813599491459E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2001156865405E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.7429094803190E-05
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.1352585605422E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5693330193281E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.9690478564684E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.1983359684082E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.3635197224581E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5693330193283E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.9690478564843E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.1983359684059E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.3635197224360E-05
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.4406350647829E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6147328447246E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.0774920080750E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.0774920079800E-05
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.0384297738190E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.2135314246563E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.2135314246503E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.1986378239452E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.4908277499962E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5104279261470E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8446396354585E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.3428222959638E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.3428222959637E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.8995007291426E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.2725005955509E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.3847122538803E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4221299017207E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0819365065793E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4221299017206E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0819365065796E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   4.23516473627150E-19  3.35616017148429E-05
+ cg2d: Sum(rhs),rhsMax =  -3.02729575348687E-18  3.35616017148734E-05
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   8.40256683676266E-19  6.11359000645173E-05
+ cg2d: Sum(rhs),rhsMax =   2.20228566286118E-19  6.11359000645135E-05
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.49800180540660E-15  4.10108399308005E-02
  cg2d: Sum(rhs),rhsMax =   8.13932254928318E-15  4.56571171210609E-02
- cg2d: Sum(rhs),rhsMax =   6.13398221105399E-14  4.87116106299301E-02
- cg2d: Sum(rhs),rhsMax =   7.01660951563099E-14  4.97483791440217E-02
+ cg2d: Sum(rhs),rhsMax =   4.16333634234434E-15  4.87116106300475E-02
+ cg2d: Sum(rhs),rhsMax =   5.81756864903582E-14  4.97483791442106E-02
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.25360876193636E-19  9.30047782264482E-05
+ cg2d: Sum(rhs),rhsMax =   2.34458719799990E-18  9.30047782264631E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2968520425816E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2968520425815E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3026968300815E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.3529122708443E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.1809944414171E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.7545877499121E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.3648772662891E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2506065199872E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.9215034472189E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.2014084911927E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.6382169408844E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.3529122708652E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.1809944414110E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.7545877498985E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.3648772662890E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2506065199873E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.9215034472236E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.2014084911962E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.6382169409038E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.5670848722458E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -7.2377541696784E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.9532722711877E-06
@@ -4315,7 +4316,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.4549437963973E-08
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.9353426736058E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.5428003612819E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7235698831913E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7235698831929E-01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   9.9088366079390E+00
 (PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.1579604660209E-02
 (PID.TID 0000.0001) // =======================================================
@@ -4327,15 +4328,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.4162955458749E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.5376181486670E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.9177748311692E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2641880883245E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2194745174510E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.5376181486675E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.9177748311900E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2641880883227E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2194745174504E-04
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.1478404641807E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -8.9299614628041E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -6.8483237892249E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2792498236829E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.1846962694663E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -8.9299614628048E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -6.8483237892299E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2792498236802E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.1846962694637E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4360,23 +4361,23 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   6.4288096993120E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.8321997857039E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -6.1369484376287E-06
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   4.1984103000164E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.7293879002082E-06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.8321997858223E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -6.1369484376053E-06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   4.1984103000219E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.7293879002085E-06
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2354117946729E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0880555277910E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -3.7545685524903E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.4161814413118E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.3993963436684E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0880555277913E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -3.7545685524965E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.4161814413093E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.3993963436667E-06
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.3982762471406E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.0727939397142E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.6132091641362E-08
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.0727939397178E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.6132091641608E-08
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.6776488198521E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.1961073215847E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.0054896816329E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.1961073215845E-07
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.0054896816330E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.4828998332013E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3692142454920E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3692142454921E-02
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.0331777931957E-01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.4295596801843E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
@@ -4386,7 +4387,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.5428003612819E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.9353426736058E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7235698831913E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7235698831929E+02
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   9.9088366079390E+03
 (PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.1579604660209E+01
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
@@ -4406,7 +4407,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.4549437963973E-08
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.5428003612819E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.9353426736058E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7235698831913E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7235698831929E+02
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   9.9088366079390E+03
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.1579604660209E+01
 (PID.TID 0000.0001) // =======================================================
@@ -4422,63 +4423,63 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   9.8684724638322E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   9.8684724638398E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.5719136759881E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2894635856059E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3046265209382E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.6586792889005E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.2020065022478E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4525244942799E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.7810194304817E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.3611651244607E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5473179714160E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.4481346902183E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2115989654777E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.5123088779715E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2894635856365E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3046265209375E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.6586792888977E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.2020065022480E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4525244942818E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.7810194304361E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.3611651244599E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5473179714194E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.4481346902186E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2115989654778E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.5123088779555E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2418504823442E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.3722101782101E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.3722101782079E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.3386038462999E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.0459457937453E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.5316367236351E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.7187172191311E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3557626917883E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.8893419449307E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.8543531257133E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.7813099602464E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.8543531257136E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.7813099602465E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.7865830173724E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2996390520220E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2996390520225E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.30054148474268E-18  1.27414982274337E-04
+ cg2d: Sum(rhs),rhsMax =   6.79659236876851E-18  1.27414982274332E-04
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.74149973955484E-18  1.62830216162880E-04
+ cg2d: Sum(rhs),rhsMax =  -3.41862497511836E-18  1.62830216162888E-04
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.96800344717907E-18  1.98180025122208E-04
+ cg2d: Sum(rhs),rhsMax =   1.37219337455197E-17  1.98180025122224E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.8714602162422E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.0201515592667E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.6134242542401E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.8778462981716E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9058031098013E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.0201515592666E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.6134242542414E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.8778462981686E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9058031097945E-04
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.0965922523405E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.2977258844039E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.2934112161189E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.8524462604125E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.6196848227125E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.2977258844038E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.2934112161131E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.8524462604111E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.6196848227175E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.5044462861154E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.1058019209738E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3123833957083E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3123833957084E-06
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.2174822425960E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.5481850714715E-08
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.1320835171870E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -4.3670395950260E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.1284943137609E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.1284943137608E-01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.4257550460704E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1602879394227E-01
 (PID.TID 0000.0001) // =======================================================
@@ -4489,16 +4490,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.2705668199550E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -8.3048617357172E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   6.7318748963161E-05
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4817992159423E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.8207457849589E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   8.1272545249236E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.2705668199551E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -8.3048617357170E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   6.7318748963269E-05
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4817992159402E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.8207457849559E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   8.1272545249216E-01
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4447340385797E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.2799386680675E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.4768021491332E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.7377752705846E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.2799386680617E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.4768021491284E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.7377752705760E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4523,24 +4524,24 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2023120787073E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.5863286231947E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.4505358607863E-05
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.1594457186374E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.3255083268334E-06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.5863286232020E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.4505358607864E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.1594457186372E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.3255083268320E-06
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7603951700615E-02
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.3683490377210E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.9603382789596E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.8025319702761E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0807262513813E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.9603382789540E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.8025319702747E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0807262513781E-06
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.6105869013262E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8945207670506E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -3.0780436520385E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6514856286127E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2748322056517E-07
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8945207670473E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -3.0780436520416E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6514856286126E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2748322056521E-07
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.5711949919574E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.1155258321159E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4577827539795E-02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.1911132153955E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4577827539794E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.1911132153954E-01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.9845270909134E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
@@ -4549,7 +4550,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   4.3670395950260E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.1320835171870E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.1284943137609E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.1284943137608E+02
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.4257550460704E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1602879394227E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
@@ -4564,12 +4565,12 @@
 (PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.0939230309710E-08
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.1058019209738E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5044462861154E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.3123833957083E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.3123833957084E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.2174822425960E-05
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.5481850714715E-08
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.3670395950260E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.1320835171870E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   4.1284943137609E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   4.1284943137608E+02
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.4257550460704E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1602879394227E+02
 (PID.TID 0000.0001) // =======================================================
@@ -4589,15 +4590,15 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.0229491497922E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.2682717204361E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.7491459258770E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.5173884276572E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.7648169578874E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.5190521237512E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8465168149023E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.7598925100070E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6731943371241E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6505755592513E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.2682717204360E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.7491459258773E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.5173884276569E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.7648169578866E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.5190521237511E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8465168149022E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.7598925099904E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6731943371235E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6505755592517E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
@@ -4607,12 +4608,12 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.4537263516015E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -8.5203014471578E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.6694218416760E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1642437992635E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1642437992636E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   8.6251812063491E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5631803010437E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2214259277537E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   5.6572600988621E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9896294613993E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9896294613994E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4640,12 +4641,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.23789867245705E-14  4.10108399314407E-02
  cg2d: Sum(rhs),rhsMax =   3.68524655236513E-14  4.56571171220423E-02
- cg2d: Sum(rhs),rhsMax =   1.78190795452338E-14  4.87116106316530E-02
- cg2d: Sum(rhs),rhsMax =  -8.77076189453874E-15  4.97483791459640E-02
- cg2d: Sum(rhs),rhsMax =   1.43218770176645E-13  4.91676482732345E-02
- cg2d: Sum(rhs),rhsMax =   1.59872115546023E-14  4.78829731731519E-02
- cg2d: Sum(rhs),rhsMax =   3.68594044175552E-14  4.62868955980300E-02
- cg2d: Sum(rhs),rhsMax =   9.90318937965640E-14  4.51184359683539E-02
+ cg2d: Sum(rhs),rhsMax =  -5.38458166943201E-15  4.87116106316284E-02
+ cg2d: Sum(rhs),rhsMax =  -7.62723217917483E-14  4.97483791460343E-02
+ cg2d: Sum(rhs),rhsMax =  -1.75859327100625E-13  4.91676482732784E-02
+ cg2d: Sum(rhs),rhsMax =   1.82076576038526E-14  4.78829731732695E-02
+ cg2d: Sum(rhs),rhsMax =  -4.44089209850063E-16  4.62868955980613E-02
+ cg2d: Sum(rhs),rhsMax =  -3.50830475781549E-14  4.51184359683463E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4673,13 +4674,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.07889261361061E-14  4.10108399301603E-02
- cg2d: Sum(rhs),rhsMax =   8.88178419700125E-15  4.56571171195286E-02
- cg2d: Sum(rhs),rhsMax =   4.87387907810444E-14  4.87116106284846E-02
- cg2d: Sum(rhs),rhsMax =  -4.69624339416441E-14  4.97483791424958E-02
- cg2d: Sum(rhs),rhsMax =   4.21884749357559E-14  4.91676482699004E-02
- cg2d: Sum(rhs),rhsMax =   4.48530101948563E-14  4.78829731696569E-02
- cg2d: Sum(rhs),rhsMax =  -4.44089209850063E-16  4.62868955937901E-02
- cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-14  4.51184359626600E-02
+ cg2d: Sum(rhs),rhsMax =   8.70484240245162E-15  4.56571171195192E-02
+ cg2d: Sum(rhs),rhsMax =  -1.13464793116691E-13  4.87116106283585E-02
+ cg2d: Sum(rhs),rhsMax =  -1.42996725571720E-13  4.97483791423876E-02
+ cg2d: Sum(rhs),rhsMax =  -5.48450174164827E-14  4.91676482699985E-02
+ cg2d: Sum(rhs),rhsMax =   3.06421554796543E-14  4.78829731695481E-02
+ cg2d: Sum(rhs),rhsMax =   2.66453525910038E-15  4.62868955936768E-02
+ cg2d: Sum(rhs),rhsMax =   1.64313007644523E-14  4.51184359629961E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4713,13 +4714,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   5.06261699229071E-14  4.10108399314239E-02
- cg2d: Sum(rhs),rhsMax =  -6.79768741296272E-14  4.56571171222639E-02
- cg2d: Sum(rhs),rhsMax =   1.06581410364015E-13  4.87116106316128E-02
- cg2d: Sum(rhs),rhsMax =   4.76285677564192E-14  4.97483791458386E-02
- cg2d: Sum(rhs),rhsMax =  -1.82076576038526E-13  4.91676482731958E-02
- cg2d: Sum(rhs),rhsMax =  -3.68594044175552E-14  4.78829731732752E-02
- cg2d: Sum(rhs),rhsMax =  -1.49213974509621E-13  4.62868955980578E-02
- cg2d: Sum(rhs),rhsMax =  -2.75335310107039E-14  4.51184359683770E-02
+ cg2d: Sum(rhs),rhsMax =  -6.92987334183215E-14  4.56571171222985E-02
+ cg2d: Sum(rhs),rhsMax =   3.08642000845794E-14  4.87116106315494E-02
+ cg2d: Sum(rhs),rhsMax =  -2.04281036531029E-14  4.97483791457990E-02
+ cg2d: Sum(rhs),rhsMax =  -2.64233079860787E-14  4.91676482732942E-02
+ cg2d: Sum(rhs),rhsMax =  -2.13162820728030E-14  4.78829731733087E-02
+ cg2d: Sum(rhs),rhsMax =  -5.55111512312578E-14  4.62868955979429E-02
+ cg2d: Sum(rhs),rhsMax =  -3.37507799486048E-14  4.51184359683997E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4748,12 +4749,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -1.37112543541207E-14  4.10108399301771E-02
  cg2d: Sum(rhs),rhsMax =   4.31286950597354E-14  4.56571171197208E-02
- cg2d: Sum(rhs),rhsMax =  -2.59792187762287E-14  4.87116106285100E-02
- cg2d: Sum(rhs),rhsMax =   2.67563748934663E-14  4.97483791424190E-02
- cg2d: Sum(rhs),rhsMax =   2.88657986402541E-15  4.91676482699050E-02
- cg2d: Sum(rhs),rhsMax =  -5.01820807130571E-14  4.78829731695084E-02
- cg2d: Sum(rhs),rhsMax =  -1.33226762955019E-14  4.62868955938073E-02
- cg2d: Sum(rhs),rhsMax =   2.35367281220533E-14  4.51184359628556E-02
+ cg2d: Sum(rhs),rhsMax =  -3.60822483003176E-15  4.87116106285100E-02
+ cg2d: Sum(rhs),rhsMax =  -1.14352971536391E-13  4.97483791424791E-02
+ cg2d: Sum(rhs),rhsMax =   3.93018950717305E-14  4.91676482700080E-02
+ cg2d: Sum(rhs),rhsMax =   1.47437617670221E-13  4.78829731695007E-02
+ cg2d: Sum(rhs),rhsMax =   3.24185123190546E-14  4.62868955937439E-02
+ cg2d: Sum(rhs),rhsMax =  -5.24025267623074E-14  4.51184359629005E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4787,13 +4788,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   5.99520433297585E-15  4.10108399314054E-02
- cg2d: Sum(rhs),rhsMax =  -2.33597863275037E-14  4.56571171219089E-02
- cg2d: Sum(rhs),rhsMax =  -3.73590047786365E-14  4.87116106315011E-02
- cg2d: Sum(rhs),rhsMax =  -2.62012633811537E-14  4.97483791457964E-02
- cg2d: Sum(rhs),rhsMax =   6.08402217494586E-14  4.91676482731216E-02
- cg2d: Sum(rhs),rhsMax =  -1.11910480882216E-13  4.78829731731142E-02
- cg2d: Sum(rhs),rhsMax =  -6.66133814775094E-15  4.62868955978845E-02
- cg2d: Sum(rhs),rhsMax =  -1.19904086659517E-14  4.51184359683172E-02
+ cg2d: Sum(rhs),rhsMax =   7.95474797143925E-14  4.56571171219393E-02
+ cg2d: Sum(rhs),rhsMax =  -6.03406213883773E-14  4.87116106314917E-02
+ cg2d: Sum(rhs),rhsMax =  -1.57651669496772E-13  4.97483791457987E-02
+ cg2d: Sum(rhs),rhsMax =   9.25926002537381E-14  4.91676482732542E-02
+ cg2d: Sum(rhs),rhsMax =  -4.35207425653061E-14  4.78829731732141E-02
+ cg2d: Sum(rhs),rhsMax =  -7.94919685631612E-14  4.62868955977656E-02
+ cg2d: Sum(rhs),rhsMax =   2.97539770599542E-14  4.51184359681917E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4821,34 +4822,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   6.01463323590679E-14  4.10108399301955E-02
- cg2d: Sum(rhs),rhsMax =   1.14457054944950E-14  4.56571171199517E-02
- cg2d: Sum(rhs),rhsMax =  -2.39253061806721E-14  4.87116106283614E-02
- cg2d: Sum(rhs),rhsMax =   1.49324996812084E-13  4.97483791424971E-02
- cg2d: Sum(rhs),rhsMax =  -5.10702591327572E-15  4.91676482698816E-02
- cg2d: Sum(rhs),rhsMax =  -9.28146448586631E-14  4.78829731695995E-02
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  4.62868955938972E-02
- cg2d: Sum(rhs),rhsMax =  -1.08801856413265E-13  4.51184359629235E-02
+ cg2d: Sum(rhs),rhsMax =   7.53563877964325E-14  4.56571171199502E-02
+ cg2d: Sum(rhs),rhsMax =   2.49800180540660E-15  4.87116106283530E-02
+ cg2d: Sum(rhs),rhsMax =  -1.57651669496772E-14  4.97483791423763E-02
+ cg2d: Sum(rhs),rhsMax =  -1.13020703906841E-13  4.91676482701087E-02
+ cg2d: Sum(rhs),rhsMax =  -3.68594044175552E-14  4.78829731697067E-02
+ cg2d: Sum(rhs),rhsMax =   7.23865412055602E-14  4.62868955937770E-02
+ cg2d: Sum(rhs),rhsMax =  -2.70894418008538E-14  4.51184359628499E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_gencost = 0.113024301320625D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.345752270466996D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.345752270462150D+05 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.458776571787622D+05
+(PID.TID 0000.0001)  --> fc               = 0.458776571782775D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.213094980158964D+03
-(PID.TID 0000.0001)  global fc =  0.458776571787622D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  4.58776571787622E+04
+(PID.TID 0000.0001)  global fc =  0.458776571782775D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  4.58776571782775E+04
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  4.58776571875049E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.72744475398213E-04
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  8.89630609890446E-04
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  9.13863186724484E-04
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -4861,13 +4862,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -4.20774526332934E-14  4.10108399313868E-02
- cg2d: Sum(rhs),rhsMax =   1.11292919324768E-13  4.56571171220049E-02
- cg2d: Sum(rhs),rhsMax =   4.24105195406810E-14  4.87116106315097E-02
- cg2d: Sum(rhs),rhsMax =   1.50990331349021E-14  4.97483791458037E-02
- cg2d: Sum(rhs),rhsMax =  -1.55431223447522E-14  4.91676482731859E-02
- cg2d: Sum(rhs),rhsMax =   1.97619698383278E-13  4.78829731728545E-02
- cg2d: Sum(rhs),rhsMax =  -1.34114941374719E-13  4.62868955978623E-02
- cg2d: Sum(rhs),rhsMax =   2.53130849614536E-14  4.51184359681936E-02
+ cg2d: Sum(rhs),rhsMax =  -1.92693083711504E-14  4.56571171220069E-02
+ cg2d: Sum(rhs),rhsMax =  -7.39408534400354E-14  4.87116106315263E-02
+ cg2d: Sum(rhs),rhsMax =   1.00697228333502E-13  4.97483791456821E-02
+ cg2d: Sum(rhs),rhsMax =  -6.66133814775094E-16  4.91676482731808E-02
+ cg2d: Sum(rhs),rhsMax =   8.65973959207622E-14  4.78829731730930E-02
+ cg2d: Sum(rhs),rhsMax =  -2.93098878501041E-14  4.62868955976833E-02
+ cg2d: Sum(rhs),rhsMax =  -1.23012711128467E-13  4.51184359681864E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4895,13 +4896,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.51545442861334E-14  4.10108399302141E-02
- cg2d: Sum(rhs),rhsMax =   2.15452655716319E-15  4.56571171201131E-02
- cg2d: Sum(rhs),rhsMax =   9.10382880192628E-15  4.87116106286657E-02
- cg2d: Sum(rhs),rhsMax =  -2.16493489801906E-14  4.97483791426530E-02
- cg2d: Sum(rhs),rhsMax =  -9.10382880192628E-14  4.91676482701063E-02
- cg2d: Sum(rhs),rhsMax =   3.64153152077051E-14  4.78829731697034E-02
- cg2d: Sum(rhs),rhsMax =  -4.84057238736568E-14  4.62868955939346E-02
- cg2d: Sum(rhs),rhsMax =   1.45217171620970E-13  4.51184359629713E-02
+ cg2d: Sum(rhs),rhsMax =  -4.47246406576340E-14  4.56571171201145E-02
+ cg2d: Sum(rhs),rhsMax =   4.59077220682502E-14  4.87116106286540E-02
+ cg2d: Sum(rhs),rhsMax =  -1.17683640610267E-14  4.97483791426340E-02
+ cg2d: Sum(rhs),rhsMax =   1.46771483855446E-13  4.91676482699513E-02
+ cg2d: Sum(rhs),rhsMax =  -2.30926389122033E-14  4.78829731699852E-02
+ cg2d: Sum(rhs),rhsMax =   7.81597009336110E-14  4.62868955939701E-02
+ cg2d: Sum(rhs),rhsMax =  -9.63673585374636E-14  4.51184359628705E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -4944,245 +4945,245 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output (g):   2     9.1215079009999E-04  7.8255520202219E-04 -1.6560568218434E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  4.5877657187505E+04  4.5877657196555E+04  4.5877657178762E+04
-(PID.TID 0000.0001) grdchk output (g):   3     8.8963060989045E-04  7.7274447539821E-04 -1.5126104192722E-01
+(PID.TID 0000.0001) grdchk output (c):   3  4.5877657187505E+04  4.5877657196555E+04  4.5877657178278E+04
+(PID.TID 0000.0001) grdchk output (g):   3     9.1386318672448E-04  7.7274447539821E-04 -1.8262014911663E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   4  4.5877657187505E+04  4.5877657195349E+04  4.5877657177803E+04
 (PID.TID 0000.0001) grdchk output (g):   4     8.7728149082977E-04  7.6634925790131E-04 -1.4475414673494E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.3802765345293E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.4720457578601E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4916.3673114776611
-(PID.TID 0000.0001)         System time:   9.6577443778514862
-(PID.TID 0000.0001)     Wall clock time:   4961.3287570476532
+(PID.TID 0000.0001)           User time:   5302.3805320560932
+(PID.TID 0000.0001)         System time:   7.5806401371955872
+(PID.TID 0000.0001)     Wall clock time:   5336.7704648971558
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.807338714599609
-(PID.TID 0000.0001)         System time:  0.79642099142074585
-(PID.TID 0000.0001)     Wall clock time:   20.550608873367310
+(PID.TID 0000.0001)           User time:   10.864517003297806
+(PID.TID 0000.0001)         System time:  0.65788000822067261
+(PID.TID 0000.0001)     Wall clock time:   14.472150087356567
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1953.0573348999023
-(PID.TID 0000.0001)         System time:   4.5264140367507935
-(PID.TID 0000.0001)     Wall clock time:   1974.9236829280853
+(PID.TID 0000.0001)           User time:   2297.0269470214844
+(PID.TID 0000.0001)         System time:   3.2292671203613281
+(PID.TID 0000.0001)     Wall clock time:   2315.2598340511322
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   388.95480346679688
-(PID.TID 0000.0001)         System time:  0.60153794288635254
-(PID.TID 0000.0001)     Wall clock time:   392.52657961845398
+(PID.TID 0000.0001)           User time:   393.25616455078125
+(PID.TID 0000.0001)         System time:  0.57544791698455811
+(PID.TID 0000.0001)     Wall clock time:   396.65479445457458
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1662597656250000
-(PID.TID 0000.0001)         System time:   8.9406967163085938E-006
-(PID.TID 0000.0001)     Wall clock time:   8.1766622066497803
+(PID.TID 0000.0001)           User time:   8.1546325683593750
+(PID.TID 0000.0001)         System time:   2.0384788513183594E-005
+(PID.TID 0000.0001)     Wall clock time:   8.1660764217376709
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7137451171875000
-(PID.TID 0000.0001)         System time:   6.7908644676208496E-002
-(PID.TID 0000.0001)     Wall clock time:   4.6315917968750000
+(PID.TID 0000.0001)           User time:   4.7435302734375000
+(PID.TID 0000.0001)         System time:   5.2900791168212891E-002
+(PID.TID 0000.0001)     Wall clock time:   5.4256272315979004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.0557556152343750
-(PID.TID 0000.0001)         System time:   3.8937091827392578E-002
-(PID.TID 0000.0001)     Wall clock time:   3.9136316776275635
+(PID.TID 0000.0001)           User time:   4.0481567382812500
+(PID.TID 0000.0001)         System time:   3.0965685844421387E-002
+(PID.TID 0000.0001)     Wall clock time:   4.4543797969818115
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7089843750000000E-003
-(PID.TID 0000.0001)         System time:   1.0728836059570312E-006
-(PID.TID 0000.0001)     Wall clock time:   9.1743469238281250E-004
+(PID.TID 0000.0001)           User time:   2.2277832031250000E-003
+(PID.TID 0000.0001)         System time:   9.9396705627441406E-004
+(PID.TID 0000.0001)     Wall clock time:   9.7298622131347656E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.63842773437500000
-(PID.TID 0000.0001)         System time:   2.0129680633544922E-003
-(PID.TID 0000.0001)     Wall clock time:  0.64180660247802734
+(PID.TID 0000.0001)           User time:  0.60928344726562500
+(PID.TID 0000.0001)         System time:   1.5735626220703125E-005
+(PID.TID 0000.0001)     Wall clock time:  0.61239385604858398
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25485229492187500
-(PID.TID 0000.0001)         System time:   3.0994415283203125E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25481200218200684
+(PID.TID 0000.0001)           User time:  0.25427246093750000
+(PID.TID 0000.0001)         System time:   7.6293945312500000E-006
+(PID.TID 0000.0001)     Wall clock time:  0.25741982460021973
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.696655273437500
-(PID.TID 0000.0001)         System time:   1.0994911193847656E-002
-(PID.TID 0000.0001)     Wall clock time:   13.732310771942139
+(PID.TID 0000.0001)           User time:   13.722473144531250
+(PID.TID 0000.0001)         System time:   6.9959163665771484E-003
+(PID.TID 0000.0001)     Wall clock time:   13.743909358978271
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   116.59762573242188
-(PID.TID 0000.0001)         System time:   1.9818544387817383E-003
-(PID.TID 0000.0001)     Wall clock time:   117.55935811996460
+(PID.TID 0000.0001)           User time:   116.52664184570312
+(PID.TID 0000.0001)         System time:   4.0315389633178711E-003
+(PID.TID 0000.0001)     Wall clock time:   116.79773449897766
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7053527832031250
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.7102818489074707
+(PID.TID 0000.0001)           User time:   3.5117187500000000
+(PID.TID 0000.0001)         System time:   7.0333480834960938E-006
+(PID.TID 0000.0001)     Wall clock time:   3.5177741050720215
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   18.985900878906250
-(PID.TID 0000.0001)         System time:   1.0937333106994629E-002
-(PID.TID 0000.0001)     Wall clock time:   19.025936365127563
+(PID.TID 0000.0001)           User time:   19.171386718750000
+(PID.TID 0000.0001)         System time:   3.9919614791870117E-003
+(PID.TID 0000.0001)     Wall clock time:   19.198579788208008
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6135559082031250
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   2.6193728446960449
+(PID.TID 0000.0001)           User time:   2.6205749511718750
+(PID.TID 0000.0001)         System time:   1.0251998901367188E-005
+(PID.TID 0000.0001)     Wall clock time:   2.6240954399108887
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8597106933593750
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:   4.8675458431243896
+(PID.TID 0000.0001)           User time:   4.9444580078125000
+(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
+(PID.TID 0000.0001)     Wall clock time:   4.9500520229339600
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.46298217773437500
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:  0.46077632904052734
+(PID.TID 0000.0001)           User time:  0.31677246093750000
+(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
+(PID.TID 0000.0001)     Wall clock time:  0.31554675102233887
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5264282226562500
-(PID.TID 0000.0001)         System time:   5.9270858764648438E-003
-(PID.TID 0000.0001)     Wall clock time:   6.5459289550781250
+(PID.TID 0000.0001)           User time:   7.3288574218750000
+(PID.TID 0000.0001)         System time:   1.0068416595458984E-003
+(PID.TID 0000.0001)     Wall clock time:   7.3390567302703857
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   84.085510253906250
-(PID.TID 0000.0001)         System time:   1.0008811950683594E-003
-(PID.TID 0000.0001)     Wall clock time:   84.212562799453735
+(PID.TID 0000.0001)           User time:   83.738006591796875
+(PID.TID 0000.0001)         System time:   2.0098686218261719E-003
+(PID.TID 0000.0001)     Wall clock time:   83.945553779602051
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.3770027160644531E-004
+(PID.TID 0000.0001)           User time:   6.7138671875000000E-004
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.2005729675292969E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.70907592773437500
+(PID.TID 0000.0001)           User time:  0.70944213867187500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.70825767517089844
+(PID.TID 0000.0001)     Wall clock time:  0.70997309684753418
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5869140625000000E-003
+(PID.TID 0000.0001)           User time:   6.7138671875000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.3722343444824219E-004
+(PID.TID 0000.0001)     Wall clock time:   8.9764595031738281E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9491577148437500
-(PID.TID 0000.0001)         System time:  0.12294709682464600
-(PID.TID 0000.0001)     Wall clock time:   2.2904894351959229
+(PID.TID 0000.0001)           User time:   2.0288085937500000
+(PID.TID 0000.0001)         System time:  0.12384593486785889
+(PID.TID 0000.0001)     Wall clock time:   2.4690527915954590
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7984313964843750
-(PID.TID 0000.0001)         System time:  0.36789083480834961
-(PID.TID 0000.0001)     Wall clock time:   3.5039451122283936
+(PID.TID 0000.0001)           User time:   2.5979309082031250
+(PID.TID 0000.0001)         System time:  0.37156498432159424
+(PID.TID 0000.0001)     Wall clock time:   3.6559841632843018
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.414459228515625
-(PID.TID 0000.0001)         System time:  0.68059468269348145
-(PID.TID 0000.0001)     Wall clock time:   23.673845529556274
+(PID.TID 0000.0001)           User time:   22.447631835937500
+(PID.TID 0000.0001)         System time:  0.61831474304199219
+(PID.TID 0000.0001)     Wall clock time:   24.171561956405640
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7311096191406250
-(PID.TID 0000.0001)         System time:  0.14391803741455078
-(PID.TID 0000.0001)     Wall clock time:   7.9017894268035889
+(PID.TID 0000.0001)           User time:   8.1665649414062500
+(PID.TID 0000.0001)         System time:  0.14186978340148926
+(PID.TID 0000.0001)     Wall clock time:   8.3386709690093994
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.7773437500000000
-(PID.TID 0000.0001)         System time:   8.3970069885253906E-002
-(PID.TID 0000.0001)     Wall clock time:   3.9107668399810791
+(PID.TID 0000.0001)           User time:   3.6640625000000000
+(PID.TID 0000.0001)         System time:   8.8906764984130859E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9102711677551270
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.7657470703125000
-(PID.TID 0000.0001)         System time:   7.7972888946533203E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8754119873046875
+(PID.TID 0000.0001)           User time:   3.6794433593750000
+(PID.TID 0000.0001)         System time:   7.2937011718750000E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8310668468475342
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2944.9594726562500
-(PID.TID 0000.0001)         System time:   4.1729574203491211
-(PID.TID 0000.0001)     Wall clock time:   2958.0681581497192
+(PID.TID 0000.0001)           User time:   2987.1455078125000
+(PID.TID 0000.0001)         System time:   3.5316252708435059
+(PID.TID 0000.0001)     Wall clock time:   2999.2970230579376
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2600.9876708984375
-(PID.TID 0000.0001)         System time:   3.0358805656433105
-(PID.TID 0000.0001)     Wall clock time:   2611.2404878139496
+(PID.TID 0000.0001)           User time:   2641.3352050781250
+(PID.TID 0000.0001)         System time:   2.5106329917907715
+(PID.TID 0000.0001)     Wall clock time:   2650.1996867656708
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   343.68530273437500
-(PID.TID 0000.0001)         System time:   1.0980844497680664
-(PID.TID 0000.0001)     Wall clock time:   346.46100163459778
+(PID.TID 0000.0001)           User time:   345.52856445312500
+(PID.TID 0000.0001)         System time:   1.0070018768310547
+(PID.TID 0000.0001)     Wall clock time:   348.76088094711304
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4433593750000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.4557538032531738
+(PID.TID 0000.0001)           User time:   5.4575195312500000
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   5.4629163742065430
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.0019531250000000E-002
-(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.8821954727172852E-002
+(PID.TID 0000.0001)           User time:   1.7578125000000000E-002
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   1.8658876419067383E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   304.71826171875000
-(PID.TID 0000.0001)         System time:   7.7772140502929688E-002
-(PID.TID 0000.0001)     Wall clock time:   305.61288905143738
+(PID.TID 0000.0001)           User time:   306.14453125000000
+(PID.TID 0000.0001)         System time:   5.3981781005859375E-002
+(PID.TID 0000.0001)     Wall clock time:   306.77607846260071
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8908691406250000
-(PID.TID 0000.0001)         System time:  0.32171344757080078
-(PID.TID 0000.0001)     Wall clock time:   6.5572729110717773
+(PID.TID 0000.0001)           User time:   5.8991699218750000
+(PID.TID 0000.0001)         System time:  0.29467535018920898
+(PID.TID 0000.0001)     Wall clock time:   6.7274930477142334
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
+(PID.TID 0000.0001)           User time:   3.1738281250000000E-003
 (PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3858547210693359E-003
+(PID.TID 0000.0001)     Wall clock time:   2.3689270019531250E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   26.827148437500000
-(PID.TID 0000.0001)         System time:  0.69658565521240234
-(PID.TID 0000.0001)     Wall clock time:   28.019211769104004
+(PID.TID 0000.0001)           User time:   27.239257812500000
+(PID.TID 0000.0001)         System time:  0.65833234786987305
+(PID.TID 0000.0001)     Wall clock time:   28.955294847488403
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.15039062500000000
-(PID.TID 0000.0001)         System time:   2.0008087158203125E-003
-(PID.TID 0000.0001)     Wall clock time:  0.15749573707580566
+(PID.TID 0000.0001)           User time:  0.12744140625000000
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:  0.17822480201721191
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -5222,9 +5223,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         879510
+(PID.TID 0000.0001) //            No. barriers =         901434
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         879510
+(PID.TID 0000.0001) //     Total barrier spins =         901434
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecmwf.txt
+++ b/global_oce_llc90/results/output_adm.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node016
-(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
+(PID.TID 0000.0001) // Build host:        node104.cm.cluster
+(PID.TID 0000.0001) // Build date:        Sat Jul 24 00:27:03 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
+(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node086.cm.cluster
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -947,24 +947,25 @@
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) > &SMOOTH_NML
-(PID.TID 0000.0001) > smooth2Dnbt(1)=300
-(PID.TID 0000.0001) > smooth2Dtype(1)=1
-(PID.TID 0000.0001) > smooth2Dsize(1)=2
-(PID.TID 0000.0001) > smooth2Dfilter(1)=0
-(PID.TID 0000.0001) > smooth3Dnbt(1)=300
-(PID.TID 0000.0001) > smooth3DtypeH(1)=1
-(PID.TID 0000.0001) > smooth3DsizeH(1)=3
-(PID.TID 0000.0001) > smooth3DtypeZ(1)=1
-(PID.TID 0000.0001) > smooth3DsizeZ(1)=3
-(PID.TID 0000.0001) > smooth3Dfilter(1)=0
+(PID.TID 0000.0001) > smooth2Dnbt(1)=300,
+(PID.TID 0000.0001) > smooth2Dtype(1)=1,
+(PID.TID 0000.0001) > smooth2Dsize(1)=2,
+(PID.TID 0000.0001) > smooth2Dfilter(1)=0,
+(PID.TID 0000.0001) > smooth3Dnbt(1)=300,
+(PID.TID 0000.0001) >#-
+(PID.TID 0000.0001) > smooth3DtypeH(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeH(1)=3,
+(PID.TID 0000.0001) > smooth3DtypeZ(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeZ(1)=3,
+(PID.TID 0000.0001) > smooth3Dfilter(1)=0,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SMOOTH_READPARMS: finished reading data.smooth
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // pkg/smooth configuration
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.
-(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.
+(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.maskC
+(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.maskC
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of pkg/smooth config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -3920,10 +3921,10 @@
 (PID.TID 0000.0001) whio : create lev 2 rec   9
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.73784634267033E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102232E-01
-(PID.TID 0000.0001)      cg2d_init_res =   8.42110689871894E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102262E-01
+(PID.TID 0000.0001)      cg2d_init_res =   8.42110689873385E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     125
-(PID.TID 0000.0001)      cg2d_last_res =   6.70544115244528E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70544114698682E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3933,7 +3934,7 @@
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.4507813074373E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3142741714339E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.8461459688208E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.8461459688189E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8797644960057E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1160439696315E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8751337429322E-03
@@ -3945,27 +3946,27 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4169966714680E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9784363149058E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9624667885988E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6818167057292E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6818167057291E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1065996557453E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4782655426664E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6585889998858E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6585889998857E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2641500109445E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0837168093599E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905873652831E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366297440438E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0901476869959E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0901476869958E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711525590917E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8986867148382E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703936814E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856242679817E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6683325249527E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.2235859012254E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.3387263389650E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.2627341169972E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.2235859012255E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.3387263389651E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.2627341169968E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.7829824294028E-02
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.9815452819650E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.2802790417721E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2934217435178E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.2802790417717E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2934217435174E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   7.0372471314428E-04
 (PID.TID 0000.0001) %MON ke_max                       =   6.0292135639696E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   5.2156927573042E-04
@@ -3976,8 +3977,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543464585813E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760536808383E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240340252767E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2459520079969E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0803504895185E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2459520079948E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0803504892748E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4064,12 +4065,12 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75680295094020E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.72004253669388E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.71227088548905E-01
-(PID.TID 0000.0001)      cg2d_init_res =   3.34761256356741E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75680295093998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.72004253669273E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088548885E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.34761256353173E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     109
-(PID.TID 0000.0001)      cg2d_last_res =   6.43504631901029E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.43504631911896E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4085,23 +4086,23 @@
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9653854733048E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2596291192028E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7157648766726E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7380273224434E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7380273224435E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0157968120473E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2903700616301E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4270112535699E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8417784097865E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5800017674624E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.1500698781052E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0611169146920E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5800017674627E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.1500698781053E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0611169146924E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4589737990720E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6294186805595E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6294186805597E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631074310E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.2040245943350E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905860659333E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366146688522E+00
 (PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0870646857508E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711518357434E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8971662933437E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8971662933436E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704105270E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856085911718E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6508313468791E-05
@@ -4114,7 +4115,7 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2517963197744E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.8070138911450E-04
 (PID.TID 0000.0001) %MON ke_max                       =   7.0778256388465E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.3290226046555E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   5.3290226046554E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -5.0252935543686E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   4.2887940187670E-05
@@ -4122,8 +4123,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543496593048E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538363189E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240916499122E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.3347217873084E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.8200551904155E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.3347217873098E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.8200551906177E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4144,12 +4145,12 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.3923581989141E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113393975170E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.6410514359332E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.6410514359328E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3814530395102E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1538111967890E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862175167607E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660324038E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5827541159355E-09
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5827541159356E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7489072545658E-08
 (PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2121523017964E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
@@ -4175,7 +4176,7 @@
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804804312448E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282188107383E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502117282240E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8085513761439E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8085513761440E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   6.9401664772067E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
@@ -4210,12 +4211,12 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.70388041848985E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.69565508448963E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69262228492823E-01
-(PID.TID 0000.0001)      cg2d_init_res =   2.70895734277049E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.70388041848922E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69565508449131E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262228492439E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.70895734274696E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     114
-(PID.TID 0000.0001)      cg2d_last_res =   6.46303427976808E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.46303427977811E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4223,39 +4224,39 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2400000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1076397176587E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.7812866121939E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440444E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1407775354485E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3301204545299E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1019485877665E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2585814055102E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2585814055103E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8613320267765E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2682542001095E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6559089597575E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9151821355826E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3722141322325E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9151821355824E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3722141322324E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.4300783975655E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4342560175021E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7780966273192E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0141778617739E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.9574225248651E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.4311483020829E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0141778617732E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.9574225248649E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.4311483020813E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6192511591609E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.2196145549759E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.2196145549760E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572926072597E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.3182564470805E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905933126927E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366562289445E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0833228875665E-04
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0833228875666E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711512422108E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8953921620772E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8953921620771E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704028967E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856075211583E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6327643869938E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8470949650411E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2680706755235E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2680706755461E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0716197929286E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0192346598666E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.3848303134037E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.3848303134036E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0717082192142E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2304867405088E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.7073571221351E-04
@@ -4268,8 +4269,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543514203517E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538882723E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7241655236501E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.8793922796385E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.0225215841683E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.8793922796397E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.0225215843036E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4278,7 +4279,7 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501486285427D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501486285394D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417743207D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -4286,27 +4287,27 @@
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388904028634D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388904028601D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677266326D+06
-(PID.TID 0000.0001)  global fc =  0.918388904028634D+07
+(PID.TID 0000.0001)  global fc =  0.918388904028601D+07
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.73784634267033E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102232E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75680295094020E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.72004253669388E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102262E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75680295093998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.72004253669273E-01
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.71227088548905E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.70388041848985E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.69565508448963E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69262228492823E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088548885E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.70388041848922E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69565508449131E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262228492439E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.71227088548905E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.70388041848985E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.69565508448963E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69262228492823E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088548885E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.70388041848922E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69565508449131E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262228492439E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
@@ -4348,32 +4349,32 @@
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.30104260698261E-18  1.83696321991956E-04
+ cg2d: Sum(rhs),rhsMax =  -1.72117094882074E-18  1.83696321991941E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537871882173E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537871882170E-01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928199448871E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716869365749E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500674852E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610669970E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271184883060E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716869365741E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500674803E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610669332E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271184883064E-01
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135526403712E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006108230685E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948336626E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093945894E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006108230650E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948336591E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093945253E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4491391571296E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4213901650299E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.4232914060995E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0607201288096E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2806591451425E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.4232914061078E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0607201288077E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2806591451429E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644806866E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276838944E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457646704E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307437995E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366161E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457646713E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307438000E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366152E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4384,14 +4385,14 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4124591383664E-01
 (PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2051174578904E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0288811373486E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7339517497195E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7089493461287E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.8234328232951E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0288811373465E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7339517497189E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7089493459863E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.8234328232956E-01
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9176186413066E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2780162917685E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5665230940282E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7807579435038E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2780162917479E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5665230940286E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7807579434710E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4417,14 +4418,14 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6266651909072E-03
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9675004378102E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2517097963546E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9867314944239E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6908028322818E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0705289579313E+00
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2517097963553E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9867314944212E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6908028322819E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0705289579314E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.2717672234884E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9043092046148E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3235522587504E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6633245063969E-03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9043092046162E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3235522587500E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6633245063951E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -4432,9 +4433,9 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.9869276838944E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1093644806866E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6859457646704E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4619307437995E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1917372366161E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6859457646713E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4619307438000E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1917372366152E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4443,18 +4444,18 @@
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.9880862116240E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.8212645396146E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.2181652500606E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1061803321284E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0902570843314E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1061803321270E-05
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0902570843317E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.2887484600790E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.3456649824157E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.3805926639165E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.8488985249453E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2422393707882E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.3805926639245E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.8488985249435E-05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2422393707886E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.9869276838944E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1093644806866E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6859457646704E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4619307437995E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1917372366161E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6859457646713E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4619307438000E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1917372366152E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4468,36 +4469,36 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161606952157E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383871293354E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787134832556E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089852746E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551181006983E-05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161606952156E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383871293355E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787134832964E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089852740E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551181005769E-05
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880516821790E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226711472448E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448805759555E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162729551E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802143629E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226711472442E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448805758732E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162729533E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802143167E-05
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028926122318E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878766652545E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153501760430E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878766652544E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153501754979E-05
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5160664053478E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792288044704E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792288044606E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856410E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325209947E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557379819760E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920632770E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185559E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185560E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129465E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440441345E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937450960217E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306043983627E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946803566E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946803565E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.35525271560688E-19  3.43370995140402E-04
+ cg2d: Sum(rhs),rhsMax =   2.84603070277445E-18  3.43370995147148E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4505,24 +4506,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496063720032E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121848319825E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330078190104E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662138950966E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122667912060E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702195395E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330078190156E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662138950986E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122667911754E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702195399E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005571766007E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556257537162E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937495452E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250277815E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556257537210E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937495455E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250277698E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221540597E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296551151225E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607470801E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724898E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556920E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256871217E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029922162E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607471138E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724894E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556939E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256871216E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029922163E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171355217331E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204554913E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177003768E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204554910E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177003769E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4532,15 +4533,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4703497646094E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2278257800177E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0046148454958E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2534461779322E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5259435756236E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3380766183822E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2278257800179E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0046148454973E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2534461779358E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5259435756222E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3380766183825E+00
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5293519661213E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6221770591335E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6785252295025E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4843822011443E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6221770591381E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6785252295038E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4843822011391E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4566,24 +4567,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3929930045893E-03
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6767660506591E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1408786763025E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7814429272374E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3467041792972E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1408786763028E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7814429272369E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3467041793022E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7214525686844E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.5931770570242E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0133044511764E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6092760897678E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2312581831825E-03
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.5931770570312E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0133044511783E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6092760897670E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2312581831941E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.0015029922162E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1889256871217E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.0015029922163E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1889256871216E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.3171355217331E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0886204554913E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3715177003768E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0886204554910E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3715177003769E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4591,19 +4592,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9623062390186E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6115254365767E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.2299476507869E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2157758186398E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1711883943509E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.2299476508036E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2157758186396E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1711883943522E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5647654616689E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.6450064894379E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8153759246678E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3620911423151E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4700963240212E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.0015029922162E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1889256871217E+06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8153759247005E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3620911423147E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4700963240230E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.0015029922163E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1889256871216E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.3171355217331E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0886204554913E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3715177003768E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0886204554910E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3715177003769E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4617,61 +4618,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685037695644E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822503610E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327695700561E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959498686E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625054144E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685037695643E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822503607E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327695701742E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959498615E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625054127E-04
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255788321852E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329195002E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383167091818E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495836618633E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006634207E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329194999E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383167091635E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495836618554E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006634196E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268756297071E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543243011240E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140786431335E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978414917E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079083939402E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543243011239E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140786430354E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978414929E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079083939328E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328845791E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799214818E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336113363660E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362871274457E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905004E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905007E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612417E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682656E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903702051871E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694339E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790262907E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694340E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790262906E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -8.07730618501701E-18  8.65061323491060E-04
+ cg2d: Sum(rhs),rhsMax =   1.08420217248550E-19  8.65061323507219E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281455139E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281455185E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124326332343E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021970381425E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718187311E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168901356681E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021970381475E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718187324E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168901356621E-04
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238428190263E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646479610014E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398904506363E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617743918E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464781283E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398904506368E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617743922E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464780936E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184580149E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510912567E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621755E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424463E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828705E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621928E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424462E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828722E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866219723E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105090455E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366123214E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962193061E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312603950E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105090459E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366123228E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962193059E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312603988E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4681,15 +4682,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8044967982099E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2224813395829E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7618809992857E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0332107011880E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.7957185637048E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2224813395825E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7618809992690E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0332107011894E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.7957185637151E-04
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6206673102942E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3156506148069E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1819085872552E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0358523505268E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6467141308659E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3156506148070E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1819085872479E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0358523505331E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6467141308534E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4715,24 +4716,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4289749817226E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299079429754E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8341573178415E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6552845173467E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9922656332166E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8341573178433E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6552845173466E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9922656332192E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5405228950944E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -7.0038977941325E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2643857784824E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -7.0038977941480E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2643857784879E-01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8846167018313E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3803018479560E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3803018479574E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.0593105090455E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.0593105090459E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2307866219723E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.9066366123214E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6283962193061E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5377312603950E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.9066366123228E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6283962193059E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5377312603988E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4740,19 +4741,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1922706918741E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.3739934933956E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1149415742127E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8173163940751E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2448339473633E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1149415742250E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8173163940750E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2448339473645E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2827775585190E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -9.9038790427450E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.4997677913103E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0341847131729E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.6869949123844E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.0593105090455E+05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.4997677913271E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0341847131728E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.6869949123860E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.0593105090459E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2307866219723E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.9066366123214E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6283962193061E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5377312603950E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.9066366123228E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6283962193059E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5377312603988E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4766,21 +4767,21 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897081493E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381512142520E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686560635463E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743287061E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580634015E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897081506E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381512142515E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686560635593E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743287029E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580634032E-04
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327696097868E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160265952173E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349641155E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852117030298E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467133888688E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005160991748E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201925840583E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324677100171E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335576182287E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484546100148E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160265952168E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349640985E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852117030273E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467133888770E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005160991747E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201925840606E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324677100486E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335576182322E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484546100133E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990351892E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704100870E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114861866459E+00
@@ -4788,39 +4789,39 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171764059947E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275750892E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595522E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882547952E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880772747E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285296286E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882547951E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880772748E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285296287E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -3.16587034365767E-17  1.48334044816748E-03
+ cg2d: Sum(rhs),rhsMax =   7.15573433840433E-18  1.48334044816889E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641272223411E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655500095125E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181323095085E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916359579E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693177571E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655500095126E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181323094836E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916359562E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693178038E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981238656637E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342836961E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781611589525E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976538984E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041832530E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342836962E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781611589489E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976539001E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041832690E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632468381E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272602793E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253153480E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628349386E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105032443E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558694354E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070826643E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703481572E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980616631E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893196783E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253153911E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628349385E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105032445E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558694353E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070826644E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703481579E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980616634E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893196855E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4830,15 +4831,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3306631366382E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0051568922098E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1466842869733E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6757945249379E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5448649368904E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0051568922093E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1466842870210E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6757945249348E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5448649368987E-04
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5469007810072E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0981057825570E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2944778932297E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4494904540993E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2765394973471E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0981057825569E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2944778932204E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4494904541002E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2765394974083E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4864,24 +4865,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9310265812611E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898036906033E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.5592615046159E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5279149357995E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6496294615298E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3331355840000E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.5320305286898E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6021684400208E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1680510643729E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8462983121648E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.5592615046209E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5279149357994E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6496294615285E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3331355840002E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.5320305287128E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6021684400395E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1680510643731E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8462983121652E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2180070826643E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2137558694354E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0464703481572E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1649980616631E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6944893196783E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2180070826644E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2137558694353E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0464703481579E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1649980616634E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6944893196855E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4889,27 +4890,27 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5870853620716E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1111568121848E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.7759752427335E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4162149330914E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3126658992286E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.7759752427637E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4162149330913E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3126658992288E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7079054424709E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3127623494329E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.4145485558875E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7024809498905E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.8954061881469E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2180070826643E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2137558694354E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0464703481572E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1649980616631E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6944893196783E+02
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.4145485559294E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7024809498903E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.8954061881471E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2180070826644E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2137558694353E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0464703481579E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1649980616634E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6944893196855E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.73784634267033E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102232E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75680295094020E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.72004253669388E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102262E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75680295093998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.72004253669273E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4920,21 +4921,21 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474015568385E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829546507554E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975521585322E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041358251E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996434685E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982022933774E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483497606706E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417922096607E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430119474E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735853616483E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451470655497E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839515511624E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077774763583E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614826636147E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101974201167E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474015568379E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829546507549E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975521585540E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041358247E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996434924E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982022933773E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483497606703E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417922096352E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430119475E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735853616530E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451470655493E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839515511626E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077774763256E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614826636144E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101974201242E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517548347E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357649139E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893440285351E+00
@@ -4949,7 +4950,7 @@
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -4.11996825544492E-18  2.12603795188989E-03
+ cg2d: Sum(rhs),rhsMax =   9.97465998686664E-18  2.12603795188483E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4957,24 +4958,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517552897538E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705416864449E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042262651E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436317880E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800242389E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842635458151E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926762044072E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540619617E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630307706E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394656736E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337859E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042262624E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436317849E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800242817E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842635458150E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926762044073E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540619602E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630307684E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394656600E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337858E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329150855E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938814644E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675375570E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112879214E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938815242E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675375565E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112879220E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406303056E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395101562E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819441E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026994638E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835686556E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395101563E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819445E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026994637E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835686534E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4984,15 +4985,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.2906767175756E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.8725864415701E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2907591321776E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4329974369218E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0654125031147E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.8725864415694E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2907591321818E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4329974369171E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0654125031126E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8387472732496E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8454620748074E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752178341008E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0960183454999E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0316853458808E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8454620748073E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752178340998E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0960183454970E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0316853458546E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5018,24 +5019,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4448161609679E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3555552545932E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.2848082883294E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4053420967340E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3226008173670E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.1001117266372E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.2196664781195E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0975407772886E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1474625890475E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3297657716052E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.2848082883336E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4053420967337E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3226008173655E-06
+(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.1001117266373E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.2196664781224E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0975407772898E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1474625890474E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3297657716056E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5082395101562E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5082395101563E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.0867406303056E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2989634819441E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6959026994638E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8362835686556E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2989634819445E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6959026994637E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8362835686534E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -5043,19 +5044,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9807581253621E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3825921723331E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3927967384366E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0132453670357E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3747543628579E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3927967384762E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0132453670354E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3747543628583E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1318979276329E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6319237647723E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.2645290650205E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3680995114303E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.0955879492838E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5082395101562E+06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.2645290650785E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3680995114298E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.0955879492843E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5082395101563E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.0867406303056E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2989634819441E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6959026994638E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8362835686556E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2989634819445E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6959026994637E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8362835686534E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5069,21 +5070,21 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425155767178E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589439067664E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340960843444E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802139836E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285752713108E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425155767366E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589439067661E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340960843390E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802139831E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285752713200E-04
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745259635614E+01
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151327349550E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968625252728E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789020188E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634370471568E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626404185710E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529941972298E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210930280096E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913744525E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971818512E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968625252766E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789020190E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634370471650E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626404185709E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529941972296E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210930279817E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913744527E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971818526E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522233007E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187747064E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671810636985E+00
@@ -5093,12 +5094,12 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107032E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778046107829E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885253164189E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787564968E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787564966E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -3.68628738645072E-18  2.73283074969244E-03
+ cg2d: Sum(rhs),rhsMax =   4.59701721133854E-17  2.73283074969873E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5106,24 +5107,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399429311E+01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139803806685E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049017724E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557161887E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413278150375E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049017704E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557161881E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413278150778E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387091063845E+01
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3685382021798E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273450328E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668862882E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264290092361E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273450305E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668862835E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264290092132E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730846679E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337439364E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392208254E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830781118E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723210650E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392208774E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830781113E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723210658E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863409634E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389033245E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660751043E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936314346E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513476871E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660751042E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936314343E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513476805E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5133,15 +5134,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2588614595935E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.7669334972189E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6763112668072E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2825051154002E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.3996845638727E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.7669334972178E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6763112668102E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2825051153972E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.3996845638703E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3409969387472E+00
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7225299070019E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5349613130890E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8307617524694E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3674917085095E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5349613130868E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8307617524641E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3674917084714E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5167,14 +5168,14 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9699416016528E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660119617301E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.9665576970778E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2935701786004E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0154213361561E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.9665576970822E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2935701786001E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0154213361557E-05
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8419642370774E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5016676256215E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3363167777718E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3820627270878E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8390101435587E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5016676256249E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3363167777730E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3820627270877E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8390101435580E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -5182,29 +5183,29 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.8133389033245E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.5434863409634E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5490660751043E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2226936314346E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9666513476871E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5490660751042E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2226936314343E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9666513476805E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3734855910169E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6511898712448E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.9338322961445E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6082515365589E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4320812897495E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6511898712447E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.9338322961795E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6082515365586E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4320812897501E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5549157316183E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9470548921279E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.0022580442006E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0308185857685E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.2881651514330E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.0022580442511E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0308185857680E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.2881651514338E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.8133389033245E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.5434863409634E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5490660751043E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2226936314346E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9666513476871E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5490660751042E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2226936314343E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9666513476805E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5218,61 +5219,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944538023644E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944538023796E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368256751510E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518039278152E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646487941971E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993208928796E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518039278026E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646487941970E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993208928895E-04
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190311478388E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736983028498E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351318863615E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614200057E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121318761E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055216348275E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809616712303E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505844261074E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736983028501E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351318863740E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614200055E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121318789E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055216348274E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809616712284E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505844261140E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923726462418E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132685764963E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132685764959E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678518482E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723190623E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449499478872E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743774000585E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701806423360E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289834558E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599912256E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599912257E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572883346295E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197963359057E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664206474E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664206470E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.77555756156289E-17  3.23837038282624E-03
+ cg2d: Sum(rhs),rhsMax =   2.10335221462188E-17  3.23837038282247E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517219089569E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678953690223E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247834999630E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028226116E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118514080E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678953690224E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247834999606E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028226131E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118514468E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700512941E+01
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4147058633491E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551574615E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108795923E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122378963E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062759E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551574598E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108795863E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122378688E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062758E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197065021E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380578579E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767736220E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518069889E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380579092E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767736216E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518069895E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560460519767E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039946869875E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905896340912E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825566351E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274072208E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825566349E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274072163E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5282,15 +5283,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0091220260516E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.8071855732161E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0422583353064E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2041854210078E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7457064122464E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.8071855732216E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0422583353079E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2041854210065E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7457064122456E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1876275744945E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6132851196205E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8884616810137E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6404864972240E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7252366973476E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6132851196204E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8884616810119E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6404864972176E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7252366973037E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5316,14 +5317,14 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4742614841407E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2822757440575E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.7553801432967E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1353647526334E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1634237533872E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.7553801433004E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1353647526331E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1634237533869E-05
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.7203070198809E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.7373424284160E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5552667614647E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5993440090867E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2684017906201E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.7373424284195E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5552667614657E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5993440090866E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2684017906200E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -5332,28 +5333,28 @@
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1039946869875E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.2560460519767E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7905896340912E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7379825566351E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0619274072208E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7379825566349E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0619274072163E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7655009357933E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9169793563799E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.6465385781653E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2000209697720E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.4855036310877E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9169793563798E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.6465385781995E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2000209697717E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.4855036310882E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9771431153070E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2580126630876E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.9746819161222E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6886664704133E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.4734852527792E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2580126630875E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.9746819161719E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6886664704129E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.4734852527798E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1039946869875E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.2560460519767E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7905896340912E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7379825566351E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0619274072208E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7379825566349E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0619274072163E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5367,21 +5368,21 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807006857426E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807006856987E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950544278E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429212904999E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288457150E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650052235E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926601876886E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852190465847E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991951721E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823750031E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888235528E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436490681683E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034400142847E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766166847741E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051441233E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493698731537E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429212904840E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288457151E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650052245E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926601876887E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852190465851E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991951737E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823750027E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888235525E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436490681682E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034400142829E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766166847766E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051441230E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493698731462E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894401203E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584521391E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225890455076E+00
@@ -5391,37 +5392,37 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755468695E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367080723706E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510742378978E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528797546E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528797540E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.51534904016637E-17  3.71564340237301E-03
+ cg2d: Sum(rhs),rhsMax =   6.72205346941013E-18  3.71564340234450E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597027185572E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597027185571E+01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972455574338E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298772533E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076530295E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115830722E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298772510E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076530320E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115831041E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935668909E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312407178392E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634710476E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316921924E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926863353116E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067432E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312407178391E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634710472E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316921864E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926863352835E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067431E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380586348E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240565717E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138088748E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884988490E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240566285E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138088744E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884988499E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705832378493E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963105154E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170690048E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056205427E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127905128E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170690049E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056205425E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127905109E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5431,15 +5432,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1731881480925E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8598866324025E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3579618458266E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1822263532823E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0932176943800E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8598866324039E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3579618458267E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1822263532822E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0932176943796E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4285698367528E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3053083101965E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2222270374871E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5116848110572E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0936731491549E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3053083101964E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2222270374866E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5116848110510E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0936731491131E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5465,14 +5466,14 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9807912301336E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7276688771280E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.5925845829687E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9674226609735E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.5925845829726E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9674226609734E-03
 (PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3201854015369E-05
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1909750487665E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9726921970047E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7862018714926E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8145643272658E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7023038391068E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9726921970084E+02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7862018714936E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8145643272657E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7023038391071E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -5480,29 +5481,29 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4343963105154E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.9705832378493E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0202170690048E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2483056205427E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1696127905128E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0202170690049E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2483056205425E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1696127905109E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1559273743638E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1847879183491E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.9888301043664E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7836915631461E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5310000586702E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1847879183490E-03
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.9888301044046E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7836915631459E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5310000586710E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3975589168757E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5720511335409E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8483203348746E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3347223946085E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6483848438835E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5720511335408E-03
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8483203349296E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3347223946082E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6483848438844E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4343963105154E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.9705832378493E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0202170690048E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2483056205427E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1696127905128E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0202170690049E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2483056205425E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1696127905109E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5536,31 +5537,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301269086E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318675401E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618140694400E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498356057E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703432007E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301269185E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318675402E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618140694228E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498356060E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703432017E-03
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936337232144E+02
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736327815E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154479197331E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748630562E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449441276E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154479197352E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748630558E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449441270E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358413850784E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053718714309E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797660747977E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892584101297E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976334030015E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053718714308E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797660747987E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892584101294E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976334029936E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116396947E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472775894E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000453876063E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891644629901E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756982118E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756982119E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063317121E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452420690E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160350961058E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823662134474E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502580454E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502580447E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5589,7 +5590,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18388904028634E+06
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18388904028601E+06
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -5621,13 +5622,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.73784634267103E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.78451867102415E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.75680295094354E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.72004253670174E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411919E+00  1.71227088551064E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.70388041852467E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.69565508452649E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.69262228492449E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.78451867102415E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.75680295094349E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.72004253670258E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088551040E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411906E+00  1.70388041852481E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.69565508452685E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411907E+00  1.69262228492462E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5672,13 +5673,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.73784634266963E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.78451867102115E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.75680295093601E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.72004253668318E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.71227088546763E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.70388041845432E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.69565508445369E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.69262228492649E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.78451867102115E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.75680295093677E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.72004253668278E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.71227088546664E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.70388041845342E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.69565508445302E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.69262228492688E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5692,14 +5693,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388889847581D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388889847580D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.630760677265576D+06
-(PID.TID 0000.0001)  global fc =  0.918388889847581D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889847581E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
+(PID.TID 0000.0001)  global fc =  0.918388889847580D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889847580E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.26981954574585E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.41686034388840E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.41686035320163E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5729,13 +5730,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.73784634267100E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.78451867102413E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.75680295094325E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.72004253670316E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.71227088551012E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.70388041852286E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.69565508452390E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411949E+00  1.69262228492264E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78451867102413E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75680295094280E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.72004253670322E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411964E+00  1.71227088550966E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.70388041852254E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.69565508452347E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.69262228492235E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5780,19 +5781,19 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.73784634266966E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.78451867102070E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.75680295093688E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.72004253668297E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.71227088546819E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.70388041845664E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.69565508445505E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69262228492915E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78451867102070E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.75680295093794E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.72004253668379E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.71227088546889E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.70388041845545E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.69565508445620E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.69262228492951E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501471715117D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501471715097D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417668789D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5800,14 +5801,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388889393906D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388889393886D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265576D+06
-(PID.TID 0000.0001)  global fc =  0.918388889393906D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889393906E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
+(PID.TID 0000.0001)   local fc =  0.630760677265615D+06
+(PID.TID 0000.0001)  global fc =  0.918388889393886D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889393886E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.31621408462524E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.46347214467824E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.46347315981984E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5837,13 +5838,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.73784634267096E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102424E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.75680295094184E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.72004253670083E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.71227088550914E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.70388041852110E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69565508452014E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.69262228492060E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78451867102424E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411955E+00  1.75680295094193E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411944E+00  1.72004253670213E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.71227088550856E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.70388041851916E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.69565508452064E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.69262228492059E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5888,19 +5889,19 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.73784634266969E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.78451867102085E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.75680295093716E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.72004253668390E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411952E+00  1.71227088546908E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.70388041845795E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69565508445820E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69262228492968E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.78451867102085E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411899E+00  1.75680295093651E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411901E+00  1.72004253668364E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.71227088546872E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.70388041845847E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.69565508445839E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.69262228493025E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501470598155D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501470598156D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417707705D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5913,9 +5914,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001)   local fc =  0.630760677265848D+06
 (PID.TID 0000.0001)  global fc =  0.918388888315861D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388888315861E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.43534650802612E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.57573219388723E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.57573214732111E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5945,13 +5946,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.73784634267093E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78451867102423E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.75680295094426E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.72004253670117E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.71227088550773E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.70388041851824E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.69565508451906E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.69262228492060E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.78451867102418E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.75680295094226E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.72004253670027E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411955E+00  1.71227088550874E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.70388041851833E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.69565508451929E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411899E+00  1.69262228491992E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5996,19 +5997,19 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.73784634266973E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.78451867102144E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411905E+00  1.75680295093611E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.72004253668371E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.71227088546942E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.70388041846043E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.69565508446190E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.69262228493063E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.78451867102144E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.75680295093737E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.72004253668397E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.71227088547076E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.70388041845983E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69565508446168E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.69262228493201E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501468075194D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427501468075198D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490887417751557D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6016,14 +6017,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388885836751D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388885836755D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265848D+06
-(PID.TID 0000.0001)  global fc =  0.918388885836751D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388885836751E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028634E+06
+(PID.TID 0000.0001)   local fc =  0.630760677265888D+06
+(PID.TID 0000.0001)  global fc =  0.918388885836755D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388885836755E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.70237884521484E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.83178866282105E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.83178845793009E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6037,259 +6038,259 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1838890402863E+06  9.1838891818479E+06  9.1838888984758E+06
-(PID.TID 0000.0001) grdchk output (g):   1     1.4168603438884E+01  1.2698195457458E+01 -1.1579660955383E-01
+(PID.TID 0000.0001) grdchk output (c):   1  9.1838890402860E+06  9.1838891818479E+06  9.1838888984758E+06
+(PID.TID 0000.0001) grdchk output (g):   1     1.4168603532016E+01  1.2698195457458E+01 -1.1579661688812E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   2  9.1838890402863E+06  9.1838891866335E+06  9.1838888939391E+06
-(PID.TID 0000.0001) grdchk output (g):   2     1.4634721446782E+01  1.3162140846252E+01 -1.1188002147456E-01
+(PID.TID 0000.0001) grdchk output (c):   2  9.1838890402860E+06  9.1838891866335E+06  9.1838888939389E+06
+(PID.TID 0000.0001) grdchk output (g):   2     1.4634731598198E+01  1.3162140846252E+01 -1.1188079273329E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1838890402863E+06  9.1838891983050E+06  9.1838888831586E+06
-(PID.TID 0000.0001) grdchk output (g):   3     1.5757321938872E+01  1.4353465080261E+01 -9.7806129095732E-02
+(PID.TID 0000.0001) grdchk output (c):   3  9.1838890402860E+06  9.1838891983050E+06  9.1838888831586E+06
+(PID.TID 0000.0001) grdchk output (g):   3     1.5757321473211E+01  1.4353465080261E+01 -9.7806096653302E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   4  9.1838890402863E+06  9.1838892247252E+06  9.1838888583675E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.8317886628211E+01  1.7023788452148E+01 -7.6017049888727E-02
+(PID.TID 0000.0001) grdchk output (c):   4  9.1838890402860E+06  9.1838892247252E+06  9.1838888583676E+06
+(PID.TID 0000.0001) grdchk output (g):   4     1.8317884579301E+01  1.7023788452148E+01 -7.6016929533046E-02
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.0157586419985E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.0157604833763E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5111.5817078351974
-(PID.TID 0000.0001)         System time:   10.824318259954453
-(PID.TID 0000.0001)     Wall clock time:   5145.3603131771088
+(PID.TID 0000.0001)           User time:   5523.7646013796329
+(PID.TID 0000.0001)         System time:   11.447837203741074
+(PID.TID 0000.0001)     Wall clock time:   5563.4919168949127
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.820705235004425
-(PID.TID 0000.0001)         System time:  0.71322399377822876
-(PID.TID 0000.0001)     Wall clock time:   15.042571067810059
+(PID.TID 0000.0001)           User time:   11.634086728096008
+(PID.TID 0000.0001)         System time:  0.77282097935676575
+(PID.TID 0000.0001)     Wall clock time:   15.058910131454468
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2027.2730340957642
-(PID.TID 0000.0001)         System time:   4.4183551073074341
-(PID.TID 0000.0001)     Wall clock time:   2047.5890860557556
+(PID.TID 0000.0001)           User time:   2382.9896039962769
+(PID.TID 0000.0001)         System time:   5.1161379814147949
+(PID.TID 0000.0001)     Wall clock time:   2404.2536869049072
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   500.18560791015625
-(PID.TID 0000.0001)         System time:  0.72972249984741211
-(PID.TID 0000.0001)     Wall clock time:   502.41252017021179
+(PID.TID 0000.0001)           User time:   505.22842407226562
+(PID.TID 0000.0001)         System time:  0.85329818725585938
+(PID.TID 0000.0001)     Wall clock time:   508.84038329124451
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1679687500000000
-(PID.TID 0000.0001)         System time:   1.0371208190917969E-003
-(PID.TID 0000.0001)     Wall clock time:   8.1748692989349365
+(PID.TID 0000.0001)           User time:   8.1618041992187500
+(PID.TID 0000.0001)         System time:   1.0340213775634766E-003
+(PID.TID 0000.0001)     Wall clock time:   8.1704804897308350
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0643920898437500
-(PID.TID 0000.0001)         System time:  0.11590719223022461
-(PID.TID 0000.0001)     Wall clock time:   5.4132673740386963
+(PID.TID 0000.0001)           User time:   6.6223754882812500
+(PID.TID 0000.0001)         System time:  0.20071434974670410
+(PID.TID 0000.0001)     Wall clock time:   7.2516119480133057
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.2337341308593750
-(PID.TID 0000.0001)         System time:   8.1948280334472656E-002
-(PID.TID 0000.0001)     Wall clock time:   4.5119521617889404
+(PID.TID 0000.0001)           User time:   5.7611694335937500
+(PID.TID 0000.0001)         System time:  0.11485958099365234
+(PID.TID 0000.0001)     Wall clock time:   6.2537572383880615
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.6479492187500000E-003
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.3269348144531250E-004
+(PID.TID 0000.0001)           User time:   4.2724609375000000E-004
+(PID.TID 0000.0001)         System time:   9.9706649780273438E-004
+(PID.TID 0000.0001)     Wall clock time:   2.2432804107666016E-003
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.62551879882812500
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:  0.62511038780212402
+(PID.TID 0000.0001)           User time:  0.60989379882812500
+(PID.TID 0000.0001)         System time:   1.5974044799804688E-005
+(PID.TID 0000.0001)     Wall clock time:  0.61283016204833984
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25320434570312500
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25474786758422852
+(PID.TID 0000.0001)           User time:  0.25659179687500000
+(PID.TID 0000.0001)         System time:   1.0130405426025391E-003
+(PID.TID 0000.0001)     Wall clock time:  0.25837063789367676
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   88.423187255859375
-(PID.TID 0000.0001)         System time:   1.5058755874633789E-002
-(PID.TID 0000.0001)     Wall clock time:   88.717790842056274
+(PID.TID 0000.0001)           User time:   88.310333251953125
+(PID.TID 0000.0001)         System time:   8.0929994583129883E-002
+(PID.TID 0000.0001)     Wall clock time:   88.534942865371704
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   35.245056152343750
-(PID.TID 0000.0001)         System time:   3.0300617218017578E-003
-(PID.TID 0000.0001)     Wall clock time:   35.273555517196655
+(PID.TID 0000.0001)           User time:   35.366333007812500
+(PID.TID 0000.0001)         System time:   2.8001070022583008E-002
+(PID.TID 0000.0001)     Wall clock time:   35.442675828933716
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   117.89065551757812
-(PID.TID 0000.0001)         System time:   4.0619373321533203E-003
-(PID.TID 0000.0001)     Wall clock time:   117.97315931320190
+(PID.TID 0000.0001)           User time:   117.94125366210938
+(PID.TID 0000.0001)         System time:   1.1058092117309570E-002
+(PID.TID 0000.0001)     Wall clock time:   118.50565958023071
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0870056152343750
-(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
-(PID.TID 0000.0001)     Wall clock time:   2.0876865386962891
+(PID.TID 0000.0001)           User time:   1.8569335937500000
+(PID.TID 0000.0001)         System time:   9.9802017211914062E-004
+(PID.TID 0000.0001)     Wall clock time:   1.8603386878967285
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.687316894531250
-(PID.TID 0000.0001)         System time:   1.5988826751708984E-002
-(PID.TID 0000.0001)     Wall clock time:   16.720104932785034
+(PID.TID 0000.0001)           User time:   17.486938476562500
+(PID.TID 0000.0001)         System time:   1.0073184967041016E-003
+(PID.TID 0000.0001)     Wall clock time:   17.508984804153442
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6148376464843750
-(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
-(PID.TID 0000.0001)     Wall clock time:   2.6158945560455322
+(PID.TID 0000.0001)           User time:   2.6165161132812500
+(PID.TID 0000.0001)         System time:   9.9897384643554688E-004
+(PID.TID 0000.0001)     Wall clock time:   2.6258876323699951
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8687133789062500
-(PID.TID 0000.0001)         System time:   2.0081996917724609E-003
-(PID.TID 0000.0001)     Wall clock time:   4.9775328636169434
+(PID.TID 0000.0001)           User time:   4.8786010742187500
+(PID.TID 0000.0001)         System time:   6.9141387939453125E-006
+(PID.TID 0000.0001)     Wall clock time:   4.8819432258605957
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.72027587890625000
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:  0.72071671485900879
+(PID.TID 0000.0001)           User time:  0.37823486328125000
+(PID.TID 0000.0001)         System time:   9.7990036010742188E-004
+(PID.TID 0000.0001)     Wall clock time:  0.37850952148437500
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.3933410644531250
-(PID.TID 0000.0001)         System time:   9.0038776397705078E-003
-(PID.TID 0000.0001)     Wall clock time:   6.4084742069244385
+(PID.TID 0000.0001)           User time:   7.6134033203125000
+(PID.TID 0000.0001)         System time:   1.0163784027099609E-003
+(PID.TID 0000.0001)     Wall clock time:   7.6202070713043213
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   118.89852905273438
-(PID.TID 0000.0001)         System time:   6.0353279113769531E-003
-(PID.TID 0000.0001)     Wall clock time:   118.98976731300354
+(PID.TID 0000.0001)           User time:   120.06716918945312
+(PID.TID 0000.0001)         System time:   3.0035972595214844E-002
+(PID.TID 0000.0001)     Wall clock time:   120.45455098152161
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.2724609375000000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.0861320495605469E-004
+(PID.TID 0000.0001)           User time:   1.2817382812500000E-003
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.4342231750488281E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1171264648437500
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.1191802024841309
+(PID.TID 0000.0001)           User time:   1.2724304199218750
+(PID.TID 0000.0001)         System time:   2.1457672119140625E-006
+(PID.TID 0000.0001)     Wall clock time:   1.2772655487060547
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8615722656250000E-003
+(PID.TID 0000.0001)           User time:   1.4343261718750000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.4270706176757812E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0718269348144531E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9912414550781250
-(PID.TID 0000.0001)         System time:  0.12691783905029297
-(PID.TID 0000.0001)     Wall clock time:   2.2766737937927246
+(PID.TID 0000.0001)           User time:   1.9257812500000000
+(PID.TID 0000.0001)         System time:  0.12486815452575684
+(PID.TID 0000.0001)     Wall clock time:   2.3272032737731934
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0539245605468750
-(PID.TID 0000.0001)         System time:  0.43056607246398926
-(PID.TID 0000.0001)     Wall clock time:   3.9467799663543701
+(PID.TID 0000.0001)           User time:   2.9008483886718750
+(PID.TID 0000.0001)         System time:  0.39254117012023926
+(PID.TID 0000.0001)     Wall clock time:   4.0798223018646240
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.572570800781250
-(PID.TID 0000.0001)         System time:  0.66355156898498535
-(PID.TID 0000.0001)     Wall clock time:   23.869168519973755
+(PID.TID 0000.0001)           User time:   22.311462402343750
+(PID.TID 0000.0001)         System time:  0.77225637435913086
+(PID.TID 0000.0001)     Wall clock time:   24.088607311248779
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7321472167968750
-(PID.TID 0000.0001)         System time:  0.12990546226501465
-(PID.TID 0000.0001)     Wall clock time:   7.8813838958740234
+(PID.TID 0000.0001)           User time:   8.1458435058593750
+(PID.TID 0000.0001)         System time:  0.17481899261474609
+(PID.TID 0000.0001)     Wall clock time:   8.3743910789489746
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6812744140625000
-(PID.TID 0000.0001)         System time:  0.12189579010009766
-(PID.TID 0000.0001)     Wall clock time:   3.8751480579376221
+(PID.TID 0000.0001)           User time:   3.5949707031250000
+(PID.TID 0000.0001)         System time:  0.12388420104980469
+(PID.TID 0000.0001)     Wall clock time:   3.8036489486694336
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6630859375000000
-(PID.TID 0000.0001)         System time:   8.4928989410400391E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8298480510711670
+(PID.TID 0000.0001)           User time:   3.6118164062500000
+(PID.TID 0000.0001)         System time:   6.8928718566894531E-002
+(PID.TID 0000.0001)     Wall clock time:   3.7610151767730713
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3065.1433105468750
-(PID.TID 0000.0001)         System time:   5.4858994483947754
-(PID.TID 0000.0001)     Wall clock time:   3075.0235419273376
+(PID.TID 0000.0001)           User time:   3121.9340820312500
+(PID.TID 0000.0001)         System time:   5.3660483360290527
+(PID.TID 0000.0001)     Wall clock time:   3136.6145489215851
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2623.0270996093750
-(PID.TID 0000.0001)         System time:   3.8775625228881836
-(PID.TID 0000.0001)     Wall clock time:   2629.7570412158966
+(PID.TID 0000.0001)           User time:   2678.2888183593750
+(PID.TID 0000.0001)         System time:   3.6438078880310059
+(PID.TID 0000.0001)     Wall clock time:   2688.7843997478485
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   431.56762695312500
-(PID.TID 0000.0001)         System time:   1.1536321640014648
-(PID.TID 0000.0001)     Wall clock time:   433.91242384910583
+(PID.TID 0000.0001)           User time:   433.18652343750000
+(PID.TID 0000.0001)         System time:   1.2876443862915039
+(PID.TID 0000.0001)     Wall clock time:   436.44056916236877
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4562988281250000
-(PID.TID 0000.0001)         System time:   2.0980834960937500E-005
-(PID.TID 0000.0001)     Wall clock time:   5.4602704048156738
+(PID.TID 0000.0001)           User time:   5.4755859375000000
+(PID.TID 0000.0001)         System time:   7.9617500305175781E-003
+(PID.TID 0000.0001)     Wall clock time:   5.4893879890441895
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.0507812500000000E-002
-(PID.TID 0000.0001)         System time:   1.4305114746093750E-005
-(PID.TID 0000.0001)     Wall clock time:   1.8797397613525391E-002
+(PID.TID 0000.0001)           User time:   1.8798828125000000E-002
+(PID.TID 0000.0001)         System time:   7.6293945312500000E-006
+(PID.TID 0000.0001)     Wall clock time:   1.8664836883544922E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   392.67993164062500
-(PID.TID 0000.0001)         System time:  0.13312530517578125
-(PID.TID 0000.0001)     Wall clock time:   393.08689403533936
+(PID.TID 0000.0001)           User time:   394.12792968750000
+(PID.TID 0000.0001)         System time:  0.16871690750122070
+(PID.TID 0000.0001)     Wall clock time:   395.00411438941956
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.9294433593750000
-(PID.TID 0000.0001)         System time:  0.32184839248657227
-(PID.TID 0000.0001)     Wall clock time:   6.6858644485473633
+(PID.TID 0000.0001)           User time:   5.8129882812500000
+(PID.TID 0000.0001)         System time:  0.32769966125488281
+(PID.TID 0000.0001)     Wall clock time:   6.6646199226379395
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.4414062500000000E-003
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3939609527587891E-003
+(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3438930511474609E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   26.811767578125000
-(PID.TID 0000.0001)         System time:  0.69660711288452148
-(PID.TID 0000.0001)     Wall clock time:   27.984028816223145
+(PID.TID 0000.0001)           User time:   27.086914062500000
+(PID.TID 0000.0001)         System time:  0.78025817871093750
+(PID.TID 0000.0001)     Wall clock time:   28.589029788970947
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.3447265625000000E-002
-(PID.TID 0000.0001)         System time:   1.0042190551757812E-003
-(PID.TID 0000.0001)     Wall clock time:   3.8821935653686523E-002
+(PID.TID 0000.0001)           User time:   2.6855468750000000E-002
+(PID.TID 0000.0001)         System time:   1.9989013671875000E-003
+(PID.TID 0000.0001)     Wall clock time:   3.5665750503540039E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6329,9 +6330,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         882800
+(PID.TID 0000.0001) //            No. barriers =         904724
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         882800
+(PID.TID 0000.0001) //     Total barrier spins =         904724
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.txt
+++ b/global_oce_llc90/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node016
-(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
+(PID.TID 0000.0001) // Build host:        node104.cm.cluster
+(PID.TID 0000.0001) // Build date:        Sat Jul 24 00:27:03 EDT 2021
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
+(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node104.cm.cluster
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -845,24 +845,25 @@
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) > &SMOOTH_NML
-(PID.TID 0000.0001) > smooth2Dnbt(1)=300
-(PID.TID 0000.0001) > smooth2Dtype(1)=1
-(PID.TID 0000.0001) > smooth2Dsize(1)=2
-(PID.TID 0000.0001) > smooth2Dfilter(1)=0
-(PID.TID 0000.0001) > smooth3Dnbt(1)=300
-(PID.TID 0000.0001) > smooth3DtypeH(1)=1
-(PID.TID 0000.0001) > smooth3DsizeH(1)=3
-(PID.TID 0000.0001) > smooth3DtypeZ(1)=1
-(PID.TID 0000.0001) > smooth3DsizeZ(1)=3
-(PID.TID 0000.0001) > smooth3Dfilter(1)=0
+(PID.TID 0000.0001) > smooth2Dnbt(1)=300,
+(PID.TID 0000.0001) > smooth2Dtype(1)=1,
+(PID.TID 0000.0001) > smooth2Dsize(1)=2,
+(PID.TID 0000.0001) > smooth2Dfilter(1)=0,
+(PID.TID 0000.0001) > smooth3Dnbt(1)=300,
+(PID.TID 0000.0001) >#-
+(PID.TID 0000.0001) > smooth3DtypeH(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeH(1)=3,
+(PID.TID 0000.0001) > smooth3DtypeZ(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeZ(1)=3,
+(PID.TID 0000.0001) > smooth3Dfilter(1)=0,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SMOOTH_READPARMS: finished reading data.smooth
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // pkg/smooth configuration
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.
-(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.
+(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.maskC
+(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.maskC
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of pkg/smooth config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -3733,10 +3734,10 @@
 (PID.TID 0000.0001) whio : create lev 2 rec   9
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.78237496760336E-01
-(PID.TID 0000.0001)      cg2d_init_res =   8.40138354917914E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.78237496760353E-01
+(PID.TID 0000.0001)      cg2d_init_res =   8.40138354918947E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     125
-(PID.TID 0000.0001)      cg2d_last_res =   6.71251578512248E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.71251578321119E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3744,9 +3745,9 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2104142213841E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.4875070933896E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440442E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3137010996784E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.8461865412936E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.8461865412909E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1738224545222E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4368541415283E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8547499633601E-03
@@ -3754,12 +3755,12 @@
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8690961790288E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.6574162425087E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1702307391808E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2210209070722E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2210209070721E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4807061260424E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9988943895242E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9524931542974E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6961952201485E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0998455983065E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9524931542972E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6961952201484E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0998455983051E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4819132840104E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6824461779644E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2659462442116E+01
@@ -3784,13 +3785,13 @@
 (PID.TID 0000.0001) %MON ke_mean                      =   5.4657660776655E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -5.7512352191450E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.0936348708701E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.0936348708700E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543465759560E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760536824546E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240450862978E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2866872624090E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.1817879175702E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2866872624099E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.1817879175846E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3887,12 +3888,12 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.75379551365021E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.71568653333925E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.70652790809471E-01
-(PID.TID 0000.0001)      cg2d_init_res =   3.37342106286624E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.75379551365032E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.71568653334018E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.70652790809491E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.37342106285002E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     108
-(PID.TID 0000.0001)      cg2d_last_res =   6.59366614117299E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.59366614206959E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3902,22 +3903,22 @@
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.0955001231975E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1922425939213E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5960358219728E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.5960358219730E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.2237458663701E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.9165482483796E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9327410995684E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4228317408850E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7716142253438E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.8543299632761E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0756754444552E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.0756754444551E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2476635694276E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.6235008224959E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9044916101952E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6163746037428E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2570710624203E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.9754074982184E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.6163746037429E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2570710624201E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.9754074982159E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4876302211339E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6956544527087E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6956544527085E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2655996931402E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.4065403486480E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905822687441E+00
@@ -3936,7 +3937,7 @@
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0626951300454E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2316132728442E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.8043877041817E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3640342964725E+00
+(PID.TID 0000.0001) %MON ke_max                       =   5.3640342964724E+00
 (PID.TID 0000.0001) %MON ke_mean                      =   6.1748987547396E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -6.9024268539164E-05
@@ -3945,8 +3946,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543504116559E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538335594E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7241198119272E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2774828151973E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.0040936315381E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2774828151967E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.0040936314718E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3970,7 +3971,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =   7.3629828089869E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.8075660796408E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7804083367673E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.2503800159640E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.2503800159641E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9808795909156E-06
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   4.3971588017597E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2527219935006E-08
@@ -4043,12 +4044,12 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.69703285582814E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.68835099835297E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.68580769322861E-01
-(PID.TID 0000.0001)      cg2d_init_res =   2.71818833887211E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411961E+00  1.69703285583042E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.68835099835453E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.68580769322886E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.71818833889079E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     114
-(PID.TID 0000.0001)      cg2d_last_res =   6.40942764891245E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.40942764915215E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4064,17 +4065,17 @@
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8252365637902E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.5493460604223E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7413070878836E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.8509451564675E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.8509451564674E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.7911453849502E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.3751458102368E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.6962938312176E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8666870380484E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.1363757011708E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.0731158055922E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.5239488389036E-08
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8666870380485E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.1363757011699E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.0731158055917E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.5239488389038E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6670643127706E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.3093415597134E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2654225546284E+01
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.3093415597132E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2654225546285E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.6668806171763E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905758224235E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366627207812E+00
@@ -4083,26 +4084,26 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981080282328E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704036819E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856231313683E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6816405089702E-05
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6816405089703E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5347600702112E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2453524769534E-01
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0123139950477E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.5175602085264E-01
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2462917074163E-01
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1187686578864E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2880220167680E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2880220167679E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   6.7031406596623E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.8361086781001E+00
+(PID.TID 0000.0001) %MON ke_max                       =   7.8361086780995E+00
 (PID.TID 0000.0001) %MON ke_mean                      =   6.6645937466152E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6486415611803E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.6486415611804E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   5.2972318978596E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543522436054E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538893210E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   9.7242048112780E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.6749338645698E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.1658639354082E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.6749338645722E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.1658639355472E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4126,20 +4127,20 @@
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00378020371994E+00  1.73700015025699E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371974E+00  1.78237451821771E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371954E+00  1.75379603205384E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371976E+00  1.71568757909502E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371982E+00  1.78237451821771E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371962E+00  1.75379603205445E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371961E+00  1.71568757909542E-01
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.00378020371967E+00  1.70652952668559E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371966E+00  1.69703500007529E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371991E+00  1.68835368135371E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371974E+00  1.68581092213251E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371963E+00  1.70652952668567E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371959E+00  1.69703500007589E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371970E+00  1.68835368135276E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371970E+00  1.68581092213252E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.00378026546642E+00  1.70650732696743E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026546654E+00  1.69702012741719E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026546634E+00  1.68833965208670E-01
- cg2d: Sum(rhs),rhsMax =   3.00378026546621E+00  1.68579734841341E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546648E+00  1.70650732696744E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546666E+00  1.69702012741932E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546643E+00  1.68833965209016E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378026546630E+00  1.68579734841540E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
@@ -4181,32 +4182,32 @@
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.61275073157219E-18  1.84309793280673E-04
+ cg2d: Sum(rhs),rhsMax =   3.79470760369927E-19  1.84309793280673E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.1459157266172E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5768947429147E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0778407570678E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0303724211808E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8329322382120E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   6.0051175616281E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.1459157266173E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5768947429151E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0778407570682E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0303724211776E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8329322381987E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   6.0051175616277E-01
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.7231133109931E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.5426525259823E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8463706384763E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6989254141816E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.5426525259826E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8463706384720E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6989254141585E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4400857037059E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.3997217673701E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   6.0303766892184E-08
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   6.0303766892200E-08
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0756317462372E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2962614968558E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1376260634596E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.0173058327527E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7754842496061E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.6566382327324E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.2588466886380E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.2588466886379E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4215,16 +4216,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4926240172157E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4926240172158E-01
 (PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2093696762948E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0340932335030E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7576682060163E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.9854267399134E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.5964313899566E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0340932335011E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7576682060133E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.9854267398048E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.5964313899561E-01
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.1301260310331E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.4012061901736E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5893070450991E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   9.0547833100011E-05
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.4012061902143E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5893070450970E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   9.0547833099532E-05
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4250,23 +4251,23 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   4.7390577319326E-02
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4079805758563E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.7997309443571E-05
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1283518347187E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.2741597707080E-06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.7997309443545E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1283518347182E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.2741597706962E-06
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2626743143404E-02
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -9.8414145940823E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.9115964108825E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1378753304560E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0069238210469E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.9115964108831E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1378753304558E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0069238210393E-06
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.7986913909438E-03
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5721521903667E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   7.3610191082746E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   7.3610191082749E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.0212236159262E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.8751918542409E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.8751918542410E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0691363055666E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5764551692943E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   3.4869700733562E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3913526118533E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3913526118534E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.5579407284827E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
@@ -4277,7 +4278,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1376260634596E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7754842496061E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.6566382327324E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.2588466886380E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.2588466886379E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4285,19 +4286,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   4.1126834840557E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.8770001593335E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -8.6356451336766E-08
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -8.6356451336775E-08
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.2220314989669E-05
 (PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.1296353353060E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.3997217673701E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.4400857037059E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -6.0303766892184E-08
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -6.0303766892200E-08
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   7.0756317462372E-05
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2962614968558E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.0173058327527E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1376260634596E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7754842496061E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.6566382327324E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.2588466886380E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.2588466886379E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4311,36 +4312,36 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9117486616015E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7454196650692E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3731275410618E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3556688496225E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4883111564997E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2895318693689E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4212412417729E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5274851585108E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2810480685808E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3335518767151E-05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9117486616016E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7454196650693E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3731275410624E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3556688496224E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4883111565235E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2895318693685E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4212412417728E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5274851585061E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2810480685805E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3335518766647E-05
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3433380102214E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2697686979440E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.4912887039538E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6781620686622E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.3552182163229E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.4912887040170E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6781620686559E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.3552182162964E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5615209118999E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4711018659199E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5553183696541E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2251419914253E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1087861514701E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1087861514700E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5477231234611E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7817415615290E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937353013399E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6310813382494E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0397259044080E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0397259044081E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.35813972515597E-18  3.47579959862135E-04
+ cg2d: Sum(rhs),rhsMax =  -1.05709711817337E-18  3.47579959862151E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4348,24 +4349,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0826448515962E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1068039445752E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1349654174105E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.0759649132488E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.0639808318968E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7087891877348E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1349654174112E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.0759649132455E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.0639808319626E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7087891877364E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.0761072798695E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.7531790357449E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.4496886598908E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6293525429575E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.7531790357443E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.4496886598887E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6293525430486E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8766512619839E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.7913596973606E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.5796208114520E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.5796208114512E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4135978531540E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5854685211075E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5854685211077E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.2752931689100E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.3847670882831E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.3847670882830E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.5474837458220E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1306429659152E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.5119787035075E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.5119787035076E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4375,15 +4376,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5423674947313E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.9687356592927E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0034243573893E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3438616264823E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.6212294563615E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.6593483782744E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.9687356592922E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0034243573894E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3438616264778E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.6212294563513E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.6593483782256E+00
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5939888674658E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.7114761468944E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.7745462324557E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.5903484281049E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.7114761468979E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.7745462324501E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.5903484280740E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4409,22 +4410,22 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.7427766138802E-02
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.7628912926801E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -2.1900201969050E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.3797358375161E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   9.0986756562004E-06
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -2.1900201969064E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.3797358375152E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   9.0986756561793E-06
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.5562675365605E-02
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -7.2766320053453E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   3.9517140252784E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.4493901322055E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   9.5752907325362E-06
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   3.9517140252794E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.4493901322048E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   9.5752907324923E-06
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.1186836141373E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.0016008873685E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.4524958129649E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.4524958129651E-04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.0339156351268E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.7341456387174E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.7341456387161E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.0759224675336E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.0214853860816E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.8742214038900E-01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.8742214038901E-01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.7338735429159E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   8.9917303253818E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
@@ -4432,11 +4433,11 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.3847670882831E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.3847670882830E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.2752931689100E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.5474837458220E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1306429659152E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.5119787035075E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.5119787035076E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4444,19 +4445,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   8.2188530522840E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.7519920557392E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0102639385449E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0102639385445E-07
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2432690719471E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.2546489062501E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.2546489062502E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.7913596973606E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.8766512619839E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.5796208114520E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.5796208114512E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.4135978531540E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.5854685211075E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.3847670882831E+05
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.5854685211077E-07
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.3847670882830E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.2752931689100E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.5474837458220E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.1306429659152E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.5119787035075E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.5119787035076E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4470,61 +4471,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0561996595418E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0561996595408E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3540688584464E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5304791573644E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8232640876279E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.8004086179113E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2266329275386E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2641972662361E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1332468918363E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6532379526252E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7841649291039E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5304791573174E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8232640876234E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.8004086178859E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2266329275387E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2641972662360E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1332468918435E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6532379526226E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7841649290781E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.3223619088173E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7501907477882E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.5007039220133E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.6485213659307E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.9449101009037E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.5007039224119E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.6485213659225E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.9449101009030E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2836283860417E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2063681966264E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3329302251454E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3369995061549E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6587095915397E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6587095915407E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3215904243118E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3173268546986E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902741084102E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9460617360449E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5588538851762E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5588538851755E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.71050543121376E-19  8.80668375056054E-04
+ cg2d: Sum(rhs),rhsMax =   2.76471553983804E-18  8.80668375058152E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7976098019584E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2135977548036E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.9714440900136E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1842583242348E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   9.2689170655634E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.0844002577364E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2135977548035E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.9714440900126E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1842583242343E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   9.2689170654860E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.0844002577333E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0606679251681E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.5086888761409E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0442055676531E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.4120772456273E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.5086888761401E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0442055676520E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.4120772455240E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0308972150266E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3174487583539E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.9034129379788E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.9034129379779E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1183573645595E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8676110580278E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.4145321147638E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5817471491673E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.3191293384115E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.3191293384116E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6944373481319E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7573187073554E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7573187073559E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4534,15 +4535,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.9997093368432E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.4684380549056E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7237203949097E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.4684380549055E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7237203949102E-03
 (PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0537456335688E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   5.0146221858090E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   3.0037927364582E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   5.0146221857741E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   3.0037927363948E+00
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.4140012187572E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.4316987638814E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.2569376300921E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.8966286528782E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.4316987638976E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.2569376300877E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.8966286528571E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4568,24 +4569,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.8416616138935E-02
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4327658893664E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.7124645128850E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.9908449545201E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.7060355488205E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.7124645128873E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.9908449545193E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.7060355488175E-05
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.4912774951071E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.1394848576257E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   6.1368404244974E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.9774802028272E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.5956010038105E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.1394848576256E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   6.1368404244985E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.9774802028259E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.5956010038077E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.6153251642495E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.3791028724843E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.1633796775580E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.1633796775583E-04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.0536942433156E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.5940828956783E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.5940828956760E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.2409840041336E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3429519030116E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0248605966867E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0248605966868E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   7.0684859625184E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3395056773892E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3395056773891E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -4593,9 +4594,9 @@
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.5817471491673E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.4145321147638E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   8.3191293384115E+04
+(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   8.3191293384116E+04
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6944373481319E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7573187073554E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7573187073559E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4603,19 +4604,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.2318355803247E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.6243720788377E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -3.4091529013518E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -3.4091529013519E-07
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8633926760940E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.3743216399652E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.3174487583539E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0308972150266E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.9034129379788E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.9034129379779E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1183573645595E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.8676110580278E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.5817471491673E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.4145321147638E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   8.3191293384115E+04
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   8.3191293384116E+04
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6944373481319E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.7573187073554E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.7573187073559E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4629,61 +4630,61 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4751732629202E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4751732629201E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6384567615239E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7700900354839E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2462809259939E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3638388891987E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3354000238444E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4168044263030E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3580184660549E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9941142518252E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3710040233013E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7700900354822E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2462809259943E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3638388891582E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3354000238443E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4168044263028E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3580184660699E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9941142518245E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3710040232608E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.0373840770037E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.5986120845033E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -3.6348536710106E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4290399699383E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2646826093220E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.5986120845034E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -3.6348536708011E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4290399699373E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2646826093215E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7104659779683E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9413302430201E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1105120028603E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4482265450343E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0202671210364E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0202671210367E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0954411272537E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7565347798251E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864538209807E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864538209808E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2606434158198E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0771789013722E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0771789013703E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.07336015076065E-17  1.51546581641259E-03
+ cg2d: Sum(rhs),rhsMax =   1.06251812903579E-17  1.51546581642152E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.0577020339422E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5876807936801E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.4270644922532E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9073327634385E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.4122280962304E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2909803107599E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5876807936802E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.4270644922521E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9073327634388E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.4122280962272E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2909803107600E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.8371015933055E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.8891801269478E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6635187082128E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2813377740891E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.8891801269476E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6635187082134E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2813377740878E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3735851357031E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7547136295613E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.8808548109069E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.8808548108999E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.8224341868546E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.1467725714849E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.1467725714850E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.5548563850827E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2777653024341E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1093103800706E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.2567175716356E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.9995714010001E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.2567175716357E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.9995714010005E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4693,15 +4694,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.7257442119561E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.4309744156462E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.0404074431268E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7119594385032E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.9278419146822E-04
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.4309744156461E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.0404074431148E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7119594385036E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.9278419147169E-04
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5903812224157E+00
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.1168595132654E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.7752572861982E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4880501858542E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.7242819432707E-04
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.7752572862075E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4880501858547E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.7242819432836E-04
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4725,26 +4726,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   9.1824176356980E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.6250517295265E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -5.3313408931166E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.4926079723771E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.0966500564388E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   9.1824176356985E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.6250517295267E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -5.3313408931181E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.4926079723754E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.0966500564410E-05
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   6.7918415948465E-02
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0181606828033E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   8.4742235996720E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.6918195271136E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2634582674848E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   8.4742235996716E-04
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.6918195271134E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2634582674881E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.0694512362815E-02
 (PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8527242050059E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.9086159738230E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.9086159738233E-04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.0906346613472E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.5734749676491E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.5734749676494E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.4951623641191E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.6193350253027E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3703447916824E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3703447916825E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.4353997837165E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.7886433543293E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.7886433543292E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -4753,8 +4754,8 @@
 (PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2777653024341E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.5548563850827E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1093103800706E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.2567175716356E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.9995714010001E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.2567175716357E+05
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.9995714010005E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4762,27 +4763,27 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.6410223459431E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1492923739945E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -5.2436357361206E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4830026746734E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.4917537556849E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -5.2436357361168E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4830026746733E-04
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.4917537556850E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7547136295613E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3735851357031E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.8808548109069E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.8808548108999E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.8224341868546E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.1467725714849E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.1467725714850E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2777653024341E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.5548563850827E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1093103800706E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.2567175716356E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.9995714010001E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.2567175716357E+05
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.9995714010005E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00378020371994E+00  1.73700015025699E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371974E+00  1.78237451821771E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371954E+00  1.75379603205384E-01
- cg2d: Sum(rhs),rhsMax =   3.00378020371976E+00  1.71568757909502E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371982E+00  1.78237451821771E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371962E+00  1.75379603205445E-01
+ cg2d: Sum(rhs),rhsMax =   3.00378020371961E+00  1.71568757909542E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4795,34 +4796,34 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2432870860343E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2844634833995E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7026334660107E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1481047957200E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2567811016850E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7026334660121E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1481047957202E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2567811016782E-04
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.7037751393118E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8509373500392E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0242982973920E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1190722026242E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.3158922628466E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.5012340652953E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -6.6448132444299E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0179185441214E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.9860703309402E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.6298314062947E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8509373500389E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0242982974042E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1190722026240E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.3158922628335E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.5012340652959E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -6.6448132444300E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0179185441045E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.9860703309396E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.6298314062989E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1365102143413E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6759162929704E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8880493660145E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5587619587375E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2739332549599E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2739332549602E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8692505169756E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1957828487074E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9821738687757E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1574885639697E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5945817326229E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5945817326198E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.36609473733174E-17  2.18167383062251E-03
+ cg2d: Sum(rhs),rhsMax =  -5.09575021068187E-17  2.18167383062257E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4830,24 +4831,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   8.7366134616177E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.1443455900466E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3220506297482E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7536756220200E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.9377030247220E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2722161421302E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3220506297485E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7536756220208E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.9377030247252E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2722161421303E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2868110797519E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.2653834876564E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3904079166686E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7654124854872E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.2653834876566E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3904079166692E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7654124854909E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.7151599609709E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1911272802602E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   7.0626241640559E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.5246864410613E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.4193444978206E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   7.0626241640481E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.5246864410612E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.4193444978207E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.6945034381852E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5973136681176E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.3859909459740E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8185654219917E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.2295349037619E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.2295349037621E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4857,15 +4858,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.8760112102570E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.5106179433836E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2680706978912E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4884831756642E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.1243592671393E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.5106179433835E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2680706978900E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4884831756649E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.1243592671441E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.9563193428764E+00
 (PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8823589096814E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.2503318510095E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.1546037107866E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1016905386424E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.2503318510101E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.1546037107867E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1016905386427E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -4889,26 +4890,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3491019451470E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3491019451471E-01
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.0446918283930E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -7.0746238356535E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.4450043098216E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.9642441310602E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -7.0746238356533E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.4450043098199E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.9642441310636E-05
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2643492381711E-01
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.4930898782573E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.0971736288666E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   7.6918727134650E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   3.1183356528911E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.0971736288664E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   7.6918727134646E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   3.1183356528935E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9008052527149E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.2853302085913E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.6985049766863E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.2853302085910E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.6985049766867E-04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.1554346765436E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   9.6006965732799E-06
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   9.6006965732778E-06
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.8404489312082E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.9070770333836E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7327623721723E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1868890827137E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.2530265427026E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.2530265427025E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
@@ -4918,7 +4919,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.6945034381852E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.3859909459740E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8185654219917E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.2295349037619E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.2295349037621E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -4926,19 +4927,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.0495876448868E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.4353225014184E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -7.1854618991611E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -7.1854618991565E-07
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.1012698036356E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.6040784611632E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.6040784611633E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1911272802602E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.7151599609709E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -7.0626241640559E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.5246864410613E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.4193444978206E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -7.0626241640481E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.5246864410612E-04
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.4193444978207E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5973136681176E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.6945034381852E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.3859909459740E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.8185654219917E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.2295349037619E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.2295349037621E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -4952,36 +4953,36 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0380334664304E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2620269948289E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6421129749048E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6351421370065E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3933746541990E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2845422820657E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5206865943205E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0748743185451E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6083141748584E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.5275265029046E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0177503448332E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.1993088416087E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.7491354620636E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.4257401153411E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.7826383195274E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0380334664305E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2620269948290E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6421129749063E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6351421370071E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3933746542041E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2845422820656E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5206865943202E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0748743185529E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6083141748580E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.5275265028993E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0177503448333E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.1993088416089E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.7491354620574E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.4257401153408E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.7826383195305E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5616239404707E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4100651327787E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6655422354161E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6685804581885E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5267599673796E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5267599673800E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6429856671437E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6350141654768E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777398274000E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3888710409113E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1122193656988E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1122193656950E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.75387351811318E-17  2.82609713947500E-03
+ cg2d: Sum(rhs),rhsMax =   2.23345647532014E-17  2.82609713947343E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4989,24 +4990,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.1447898412872E+01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.7823959594880E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7061866717853E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6985448749220E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.4798547335866E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7061866717855E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6985448749226E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.4798547335916E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1611998146931E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.9315029261928E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6626424481915E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.2096690268434E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.2820199144440E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.9315029261943E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6626424481917E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.2096690268435E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.2820199144464E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0558694825367E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6269044368759E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0044747350297E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0044747350291E-06
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.2262075105979E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.6871740764644E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.6871740764645E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.8300591709878E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.9177857932782E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.6628313894493E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.3776276883887E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4477338623452E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4477338623450E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5016,15 +5017,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.0427739179541E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.7020038691980E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6359870947128E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.3609711811883E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4831604288080E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.5556847484580E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.2227367659466E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6440278323699E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.9118710925988E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4692515120443E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.7020038691979E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6359870947112E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.3609711811887E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4831604288112E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.5556847484581E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.2227367659484E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6440278323707E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.9118710925987E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4692515120434E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5048,21 +5049,21 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.2858074860995E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.2858074860992E-01
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3195984052221E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.7488305379373E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   9.6799978016299E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.0066615487695E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.0435769315793E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.7488305379349E-04
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   9.6799978016285E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.0066615487712E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.0435769315791E-01
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.0099630190156E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.3507536634889E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.0122036375152E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.4814968224405E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.3507536634885E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.0122036375151E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.4814968224413E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8312662762439E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.7782714100333E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.5617016986106E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.2587748395846E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1750736913140E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.7782714100330E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.5617016986111E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.2587748395845E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1750736913138E-05
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2805799319818E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.1512516282770E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.1169684730169E+00
@@ -5077,7 +5078,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.8300591709878E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.6628313894493E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.3776276883887E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   7.4477338623452E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   7.4477338623450E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -5085,19 +5086,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4577177570865E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.7206628940516E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -9.6533719958165E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -9.6533719958130E-07
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.7189885909455E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.7136219743436E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.7136219743437E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.6269044368759E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.0558694825367E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0044747350297E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0044747350291E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.2262075105979E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.6871740764644E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.6871740764645E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.9177857932782E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8300591709878E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.6628313894493E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.3776276883887E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   7.4477338623452E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   7.4477338623450E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5111,36 +5112,36 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.8086732723368E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5420286125689E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4650543262320E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1680725286813E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.6912086193067E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0353827009285E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3834189791713E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4120646861847E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1488698631098E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.9098021761860E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.8086732723888E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5420286125690E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4650543262333E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1680725286819E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.6912086193136E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0353827009282E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3834189791711E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4120646861903E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1488698631096E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.9098021761757E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.1012662162274E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.0319098769142E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.6156090729797E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6601822884976E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4248987967739E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.0319098769143E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.6156090729822E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6601822884972E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4248987967754E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9856773639198E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1437252225059E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4429366506704E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7777563412218E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7788857847487E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7777563412219E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7788857847490E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4166072393493E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0801723270609E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572014009561E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6202632702739E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6299671106402E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6299671106363E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.25260651745651E-17  3.42522118314560E-03
+ cg2d: Sum(rhs),rhsMax =   1.30104260698261E-18  3.42522118313852E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5148,19 +5149,19 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4016871132294E+01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.3793603695123E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0670308517639E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.7177641864611E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.0197074527429E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0670308517641E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.7177641864612E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.0197074527474E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.5051609013028E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.0650998614665E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.0630693527409E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.1051441717087E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.8127329035485E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.0650998614652E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.0630693527412E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.1051441717089E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.8127329035505E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3957376764461E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0621964139827E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3722963180532E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3722963180527E-06
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.9257168393705E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.9488050427940E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.9488050427941E-07
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.9506657665906E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1914202818700E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.9390346185319E+02
@@ -5175,15 +5176,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1057338263959E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8089743671607E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.9805540890675E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.3071162971227E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.8581769772503E-03
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8089743671608E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.9805540890659E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.3071162971226E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.8581769772517E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.2189809260795E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3613018748410E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.0417141220617E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3613018748310E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.0417141220622E-02
 (PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.7448059303804E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.8593110593308E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.8593110593299E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5209,22 +5210,22 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.0994674469706E-01
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.6776741761546E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.0111809045645E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1674370380606E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.8146327681422E-05
+(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.0111809045643E-03
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1674370380604E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.8146327681438E-05
 (PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.2189962627341E-01
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.2850893624038E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.6125346691185E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2313598834382E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   5.3990765971843E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.6125346691178E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2313598834381E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   5.3990765971853E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4954945259575E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2426731936596E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2079200944062E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2426731936591E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2079200944066E-04
 (PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   7.2522732877226E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3581007502996E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3581007502997E-05
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.0549419916004E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.2714988944028E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.4464082856939E+00
+(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.2714988944027E+01
+(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.4464082856940E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6541989309916E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.1315206705097E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
@@ -5244,14 +5245,14 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.8655613614961E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.0052410982882E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.2554994552803E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.2554994552799E-06
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.3352680648762E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.8189548124886E-07
+(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.8189548124887E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.0621964139827E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.3957376764461E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.3722963180532E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.3722963180527E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.9257168393705E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.9488050427940E-07
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.9488050427941E-07
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1914202818700E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.9506657665906E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.9390346185319E+05
@@ -5270,36 +5271,36 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.6378469228709E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.6378469229058E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1098471635779E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0631814251585E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7308407751873E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.2081372647199E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.9186744354765E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0631814251570E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7308407751878E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.2081372647205E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.9186744354760E+01
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4003283040805E+01
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0912853539266E-01
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7230382604165E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2376629621558E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2376629621555E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3942763893914E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1746802126295E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3466395998635E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.7354734120577E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4806128039695E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3466395998626E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.7354734120575E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4806128039697E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.4085618123630E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8768537728430E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2201749195106E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8863893724921E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0303562113250E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0303562113254E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1900711844653E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5315513303741E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4365860509956E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8516761247145E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1485740096081E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1485740096042E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.38777878078145E-17  3.92697912649663E-03
+ cg2d: Sum(rhs),rhsMax =   4.77048955893622E-18  3.92697912650105E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5307,24 +5308,24 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.6283012430406E+01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.0087133045335E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.3744942537972E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.7932884456614E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.5462566128312E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.3744942537973E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.7932884456611E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.5462566128343E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.8346989606242E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.5261977737427E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.4531000527073E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.0601541489691E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.3395357313055E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.5261977737393E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.4531000527076E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.0601541489695E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.3395357313066E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.7350576244154E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4965139256334E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0631441124045E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0631441124039E-06
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.6164096032959E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.0202880125332E-06
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.0353237359624E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4445215701599E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4445215701600E+03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.2147933048579E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.4870470556466E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.8690123544422E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.8690123544427E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5334,15 +5335,15 @@
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2794981308728E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.7708791035136E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.2726852254384E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3106490993385E-01
+(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.7708791035137E+00
+(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.2726852254371E-02
+(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3106490993382E-01
 (PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2363438308640E-03
 (PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4723238290970E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -7.3631828603253E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.4300506702726E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6394393276867E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.2593043644948E-03
+(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -7.3631828603106E+00
+(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.4300506702729E-02
+(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6394393276870E-01
+(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.2593043644942E-03
 (PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
@@ -5369,33 +5370,33 @@
 (PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.3296246264526E-01
 (PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -2.0285589283237E-01
 (PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.1385808402104E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3747730421767E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.6970539792847E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.7901268317750E-01
+(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3747730421765E-02
+(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.6970539792851E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.7901268317752E-01
 (PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.4201662027517E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.8565281691426E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.4658789822476E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.3219896641642E-05
+(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.8565281691418E-03
+(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.4658789822475E-02
+(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.3219896641656E-05
 (PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8223603400273E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7284431957257E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.9739067140200E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.2537407503042E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.5499475437001E-05
+(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7284431957253E-02
+(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.9739067140204E-04
+(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.2537407503041E-03
+(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.5499475437000E-05
 (PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.6068436276226E+01
 (PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0337375874268E+02
 (PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.8099342041846E+00
 (PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8694063193673E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.5311314422428E-02
+(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.5311314422429E-02
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4445215701599E+06
+(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4445215701600E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.0353237359624E+06
 (PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.2147933048579E+05
 (PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.4870470556466E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.8690123544422E+02
+(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.8690123544427E+02
 (PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
@@ -5403,19 +5404,19 @@
 (PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.2725190201466E-03
 (PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2893380003346E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.0981091354794E-06
+(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.0981091354791E-06
 (PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9460156486765E-04
 (PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.9182120554959E-07
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.4965139256334E-03
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.7350576244154E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0631441124045E-06
+(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0631441124039E-06
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.6164096032959E-04
 (PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.0202880125332E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4445215701599E+06
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4445215701600E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.0353237359624E+06
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.2147933048579E+05
 (PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.4870470556466E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.8690123544422E+02
+(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.8690123544427E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
@@ -5449,31 +5450,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9930191378122E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9930191378103E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3992997238554E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6850185585680E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2534889798707E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4146503297223E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0974561368860E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6850185585653E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2534889798711E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4146503297227E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0974561368859E+02
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1490405641979E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3151606009567E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2205418146382E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4469794571268E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3151606009566E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2205418146383E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4469794571266E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3465575413422E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.6017286219914E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4297605825441E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2052529111163E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.9928256123641E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4297605825433E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2052529111164E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.9928256123635E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8301821699540E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.6094158880793E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.9972563626566E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9946125163716E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2811436513420E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.9972563626565E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9946125163717E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2811436513423E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9633266087554E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9834690484516E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6158823668121E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0831251998477E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6675933323492E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6675933323453E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5534,13 +5535,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78237496760336E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411910E+00  1.75379551365030E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.71568653333853E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.70652790809525E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.69703285583006E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.68835099835393E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.68580769322799E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.75379551365050E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.71568653333979E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.70652790809389E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.69703285582915E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.68835099835447E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411961E+00  1.68580769322857E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5585,19 +5586,19 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78237496760335E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.75379551365048E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.71568653333876E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.70652790809531E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.69703285582886E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.68835099835466E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.68580769322781E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.75379551364948E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.71568653333817E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.70652790809448E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.69703285582920E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.68835099835581E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.68580769322741E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427619379456650D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427619379456647D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490911667429045D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5605,14 +5606,14 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918531046885695D+07
+(PID.TID 0000.0001)  --> fc               = 0.918531046885693D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.631096589646047D+06
-(PID.TID 0000.0001)  global fc =  0.918531046885695D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046885695E+06
+(PID.TID 0000.0001)  global fc =  0.918531046885693D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046885693E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  9.69490930438042E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  9.42394137382507E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  9.42405313253403E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5642,19 +5643,19 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78237496760336E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.75379551365034E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.71568653333880E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.70652790809568E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.69703285582896E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.68835099835437E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411904E+00  1.68580769322981E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75379551365022E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.71568653333954E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.70652790809531E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411906E+00  1.69703285582776E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411906E+00  1.68835099835356E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411958E+00  1.68580769322816E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427619379651529D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.427619379651526D+07 1
 (PID.TID 0000.0001)  --> f_gencost = 0.490911667429045D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5662,11 +5663,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918531047080574D+07
+(PID.TID 0000.0001)  --> fc               = 0.918531047080571D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.631096589646047D+06
-(PID.TID 0000.0001)  global fc =  0.918531047080574D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18531047080574E+06
+(PID.TID 0000.0001)  global fc =  0.918531047080571D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18531047080571E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5693,13 +5694,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.78237496760335E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.75379551365025E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.71568653334004E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.70652790809497E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.69703285583025E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.68835099835502E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.68580769322813E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.75379551365025E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411913E+00  1.71568653333965E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.70652790809431E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.69703285582831E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411895E+00  1.68835099835387E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411944E+00  1.68580769322840E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5720,7 +5721,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046877543E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.02185688912868E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.01515557616949E-01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.01514440029860E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5750,13 +5751,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.78237496760336E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75379551365007E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.71568653333882E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.70652790809606E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411898E+00  1.69703285582973E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.68835099835461E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.68580769322869E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.75379551365044E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.71568653333957E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411904E+00  1.70652790809421E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.69703285582788E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.68835099835449E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.68580769322764E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5801,13 +5802,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.78237496760335E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75379551365062E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.71568653333974E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.70652790809491E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.69703285582779E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.68835099835386E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.68580769322759E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.75379551365007E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.71568653333945E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.70652790809480E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.69703285582871E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411903E+00  1.68835099835282E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.68580769322771E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5828,7 +5829,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046870745E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.09075747430325E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.08562875539064E-01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.08562782406807E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5858,13 +5859,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.78237496760336E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411919E+00  1.75379551364970E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411905E+00  1.71568653333996E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.70652790809512E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.69703285583040E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.68835099835515E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.68580769322912E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.78237496760354E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.75379551364976E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.71568653333973E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.70652790809547E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69703285582920E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.68835099835395E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.68580769322818E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5878,11 +5879,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918531047098381D+07
+(PID.TID 0000.0001)  --> fc               = 0.918531047098382D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
 (PID.TID 0000.0001)   local fc =  0.631096589646047D+06
-(PID.TID 0000.0001)  global fc =  0.918531047098381D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18531047098381E+06
+(PID.TID 0000.0001)  global fc =  0.918531047098382D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18531047098382E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5909,13 +5910,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.73700750724292E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78237496760335E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411913E+00  1.75379551365055E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.71568653333950E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.70652790809464E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.69703285582956E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.68835099835453E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.68580769322766E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.78237496760353E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.75379551365019E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.71568653333981E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.70652790809537E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.69703285582842E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.68835099835327E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411960E+00  1.68580769322718E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5936,7 +5937,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18531046860141E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18531046980472E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.20151698589325E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.19120161980391E-01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.19120441377163E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -5951,252 +5952,252 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   1  9.1853104698047E+06  9.1853104707417E+06  9.1853104688569E+06
-(PID.TID 0000.0001) grdchk output (g):   1     9.4239413738251E-02  9.6949093043804E-02  2.7949506493363E-02
+(PID.TID 0000.0001) grdchk output (g):   1     9.4240531325340E-02  9.6949093043804E-02  2.7937978927148E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   2  9.1853104698047E+06  9.1853104708057E+06  9.1853104687754E+06
-(PID.TID 0000.0001) grdchk output (g):   2     1.0151555761695E-01  1.0218568891287E-01  6.5579760047498E-03
+(PID.TID 0000.0001) grdchk output (g):   2     1.0151444002986E-01  1.0218568891287E-01  6.5689128306540E-03
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   3  9.1853104698047E+06  9.1853104708787E+06  9.1853104687075E+06
-(PID.TID 0000.0001) grdchk output (g):   3     1.0856287553906E-01  1.0907574743032E-01  4.7019791598290E-03
+(PID.TID 0000.0001) grdchk output (g):   3     1.0856278240681E-01  1.0907574743032E-01  4.7028329908561E-03
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   4  9.1853104698047E+06  9.1853104709838E+06  9.1853104686014E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.1912016198039E-01  1.2015169858932E-01  8.5852852772408E-03
+(PID.TID 0000.0001) grdchk output (g):   4     1.1912044137716E-01  1.2015169858932E-01  8.5829599104281E-03
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.5165731879903E-02
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.5161341639796E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4945.0948987007141
-(PID.TID 0000.0001)         System time:   12.372582137584686
-(PID.TID 0000.0001)     Wall clock time:   4995.3486869335175
+(PID.TID 0000.0001)           User time:   5351.6975942850113
+(PID.TID 0000.0001)         System time:   8.5260327756404877
+(PID.TID 0000.0001)     Wall clock time:   5409.7569811344147
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.745999336242676
-(PID.TID 0000.0001)         System time:  0.75707700848579407
-(PID.TID 0000.0001)     Wall clock time:   14.001218080520630
+(PID.TID 0000.0001)           User time:   11.618197977542877
+(PID.TID 0000.0001)         System time:  0.73539304733276367
+(PID.TID 0000.0001)     Wall clock time:   18.996614933013916
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1961.2864618301392
-(PID.TID 0000.0001)         System time:   5.7622342109680176
-(PID.TID 0000.0001)     Wall clock time:   1992.6940820217133
+(PID.TID 0000.0001)           User time:   2310.4545917510986
+(PID.TID 0000.0001)         System time:   3.3261749744415283
+(PID.TID 0000.0001)     Wall clock time:   2339.5019850730896
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   386.83706665039062
-(PID.TID 0000.0001)         System time:  0.78070592880249023
-(PID.TID 0000.0001)     Wall clock time:   392.23709225654602
+(PID.TID 0000.0001)           User time:   391.03820800781250
+(PID.TID 0000.0001)         System time:  0.52853381633758545
+(PID.TID 0000.0001)     Wall clock time:   395.44285964965820
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1643981933593750
-(PID.TID 0000.0001)         System time:   2.6464462280273438E-005
-(PID.TID 0000.0001)     Wall clock time:   8.1712260246276855
+(PID.TID 0000.0001)           User time:   8.1604919433593750
+(PID.TID 0000.0001)         System time:   1.4424324035644531E-005
+(PID.TID 0000.0001)     Wall clock time:   8.1747930049896240
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.5802307128906250
-(PID.TID 0000.0001)         System time:  0.10396933555603027
-(PID.TID 0000.0001)     Wall clock time:   6.7239351272583008
+(PID.TID 0000.0001)           User time:   5.4479980468750000
+(PID.TID 0000.0001)         System time:   5.6818723678588867E-002
+(PID.TID 0000.0001)     Wall clock time:   7.4586560726165771
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.7502746582031250
-(PID.TID 0000.0001)         System time:   5.0013065338134766E-002
-(PID.TID 0000.0001)     Wall clock time:   5.8019824028015137
+(PID.TID 0000.0001)           User time:   4.5788574218750000
+(PID.TID 0000.0001)         System time:   2.8923511505126953E-002
+(PID.TID 0000.0001)     Wall clock time:   6.5197761058807373
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.9672851562500000E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.0932846069335938E-004
+(PID.TID 0000.0001)           User time:   2.6550292968750000E-003
+(PID.TID 0000.0001)         System time:   9.9897384643554688E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0622901916503906E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.62063598632812500
-(PID.TID 0000.0001)         System time:   1.0187625885009766E-003
-(PID.TID 0000.0001)     Wall clock time:  0.62208986282348633
+(PID.TID 0000.0001)           User time:  0.60864257812500000
+(PID.TID 0000.0001)         System time:   1.0728836059570312E-005
+(PID.TID 0000.0001)     Wall clock time:  0.60887026786804199
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25405883789062500
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25731134414672852
+(PID.TID 0000.0001)           User time:  0.25454711914062500
+(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
+(PID.TID 0000.0001)     Wall clock time:  0.25722837448120117
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.724822998046875
-(PID.TID 0000.0001)         System time:   4.4958114624023438E-002
-(PID.TID 0000.0001)     Wall clock time:   13.776080131530762
+(PID.TID 0000.0001)           User time:   13.809783935546875
+(PID.TID 0000.0001)         System time:   8.9949369430541992E-003
+(PID.TID 0000.0001)     Wall clock time:   13.834371805191040
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   116.77218627929688
-(PID.TID 0000.0001)         System time:   4.3990135192871094E-002
-(PID.TID 0000.0001)     Wall clock time:   117.16535949707031
+(PID.TID 0000.0001)           User time:   116.74505615234375
+(PID.TID 0000.0001)         System time:   3.9958953857421875E-003
+(PID.TID 0000.0001)     Wall clock time:   116.91865682601929
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8263854980468750
-(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
-(PID.TID 0000.0001)     Wall clock time:   1.8281579017639160
+(PID.TID 0000.0001)           User time:   2.2863464355468750
+(PID.TID 0000.0001)         System time:   9.9754333496093750E-004
+(PID.TID 0000.0001)     Wall clock time:   2.2894222736358643
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.069671630859375
-(PID.TID 0000.0001)         System time:   1.8993377685546875E-002
-(PID.TID 0000.0001)     Wall clock time:   16.094737291336060
+(PID.TID 0000.0001)           User time:   16.159210205078125
+(PID.TID 0000.0001)         System time:   2.9981136322021484E-003
+(PID.TID 0000.0001)     Wall clock time:   16.179602146148682
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6146545410156250
-(PID.TID 0000.0001)         System time:   1.0037422180175781E-003
-(PID.TID 0000.0001)     Wall clock time:   2.6172778606414795
+(PID.TID 0000.0001)           User time:   2.6193542480468750
+(PID.TID 0000.0001)         System time:   9.8729133605957031E-004
+(PID.TID 0000.0001)     Wall clock time:   2.6248073577880859
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8610534667968750
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   4.8636279106140137
+(PID.TID 0000.0001)           User time:   4.9893493652343750
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   4.9929099082946777
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35488891601562500
-(PID.TID 0000.0001)         System time:   4.2915344238281250E-006
-(PID.TID 0000.0001)     Wall clock time:  0.35491299629211426
+(PID.TID 0000.0001)           User time:  0.25991821289062500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.26265597343444824
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.8042907714843750
-(PID.TID 0000.0001)         System time:   1.2951135635375977E-002
-(PID.TID 0000.0001)     Wall clock time:   6.8223547935485840
+(PID.TID 0000.0001)           User time:   7.2197875976562500
+(PID.TID 0000.0001)         System time:   3.9751529693603516E-003
+(PID.TID 0000.0001)     Wall clock time:   7.2309224605560303
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   84.279052734375000
-(PID.TID 0000.0001)         System time:   2.3995637893676758E-002
-(PID.TID 0000.0001)     Wall clock time:   84.365673542022705
+(PID.TID 0000.0001)           User time:   84.127593994140625
+(PID.TID 0000.0001)         System time:   1.0011196136474609E-003
+(PID.TID 0000.0001)     Wall clock time:   84.231177091598511
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0681152343750000E-003
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.1767311096191406E-004
+(PID.TID 0000.0001)           User time:   1.2512207031250000E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.3936920166015625E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0666503906250000
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.0684475898742676
+(PID.TID 0000.0001)           User time:   1.1271362304687500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1278192996978760
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6479492187500000E-003
+(PID.TID 0000.0001)           User time:   4.5776367187500000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.2124938964843750E-004
+(PID.TID 0000.0001)     Wall clock time:   8.9526176452636719E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9259033203125000
-(PID.TID 0000.0001)         System time:  0.14692902565002441
-(PID.TID 0000.0001)     Wall clock time:   2.4052197933197021
+(PID.TID 0000.0001)           User time:   2.0145568847656250
+(PID.TID 0000.0001)         System time:  0.10594892501831055
+(PID.TID 0000.0001)     Wall clock time:   2.5100038051605225
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6810302734375000
-(PID.TID 0000.0001)         System time:  0.38082790374755859
-(PID.TID 0000.0001)     Wall clock time:   3.8175435066223145
+(PID.TID 0000.0001)           User time:   2.6250610351562500
+(PID.TID 0000.0001)         System time:  0.33881783485412598
+(PID.TID 0000.0001)     Wall clock time:   3.7344808578491211
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.260650634765625
-(PID.TID 0000.0001)         System time:  0.95163130760192871
-(PID.TID 0000.0001)     Wall clock time:   24.734815835952759
+(PID.TID 0000.0001)           User time:   22.469940185546875
+(PID.TID 0000.0001)         System time:  0.63365173339843750
+(PID.TID 0000.0001)     Wall clock time:   28.381501197814941
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.6747436523437500
-(PID.TID 0000.0001)         System time:  0.20191764831542969
-(PID.TID 0000.0001)     Wall clock time:   8.1376705169677734
+(PID.TID 0000.0001)           User time:   8.1640319824218750
+(PID.TID 0000.0001)         System time:  0.14392209053039551
+(PID.TID 0000.0001)     Wall clock time:   8.3338489532470703
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6733398437500000
-(PID.TID 0000.0001)         System time:  0.12093257904052734
-(PID.TID 0000.0001)     Wall clock time:   4.1185531616210938
+(PID.TID 0000.0001)           User time:   3.6506347656250000
+(PID.TID 0000.0001)         System time:  0.10493707656860352
+(PID.TID 0000.0001)     Wall clock time:   4.7168910503387451
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6583251953125000
-(PID.TID 0000.0001)         System time:   8.0995082855224609E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8370978832244873
+(PID.TID 0000.0001)           User time:   3.6447753906250000
+(PID.TID 0000.0001)         System time:   8.2979202270507812E-002
+(PID.TID 0000.0001)     Wall clock time:   3.8014991283416748
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2965.7307128906250
-(PID.TID 0000.0001)         System time:   5.6513342857360840
-(PID.TID 0000.0001)     Wall clock time:   2980.6976151466370
+(PID.TID 0000.0001)           User time:   3022.3291015625000
+(PID.TID 0000.0001)         System time:   4.2765235900878906
+(PID.TID 0000.0001)     Wall clock time:   3042.7398819923401
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2621.5328369140625
-(PID.TID 0000.0001)         System time:   4.1308150291442871
-(PID.TID 0000.0001)     Wall clock time:   2630.4715878963470
+(PID.TID 0000.0001)           User time:   2677.3806152343750
+(PID.TID 0000.0001)         System time:   3.2333774566650391
+(PID.TID 0000.0001)     Wall clock time:   2690.8929340839386
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   343.15673828125000
-(PID.TID 0000.0001)         System time:   1.4145469665527344
-(PID.TID 0000.0001)     Wall clock time:   349.02947521209717
+(PID.TID 0000.0001)           User time:   344.67163085937500
+(PID.TID 0000.0001)         System time:   1.0241599082946777
+(PID.TID 0000.0001)     Wall clock time:   351.20337080955505
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4567871093750000
-(PID.TID 0000.0001)         System time:   4.9943923950195312E-003
-(PID.TID 0000.0001)     Wall clock time:   5.4652261734008789
+(PID.TID 0000.0001)           User time:   5.4589843750000000
+(PID.TID 0000.0001)         System time:   9.8800659179687500E-004
+(PID.TID 0000.0001)     Wall clock time:   5.4697675704956055
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
 (PID.TID 0000.0001)           User time:   1.7822265625000000E-002
-(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.8765687942504883E-002
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   1.8740653991699219E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   304.11865234375000
-(PID.TID 0000.0001)         System time:  0.10696983337402344
-(PID.TID 0000.0001)     Wall clock time:   307.28824234008789
+(PID.TID 0000.0001)           User time:   305.37841796875000
+(PID.TID 0000.0001)         System time:   5.9753894805908203E-002
+(PID.TID 0000.0001)     Wall clock time:   307.40846824645996
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.9353027343750000
-(PID.TID 0000.0001)         System time:  0.33490228652954102
-(PID.TID 0000.0001)     Wall clock time:   6.5914144515991211
+(PID.TID 0000.0001)           User time:   5.8703613281250000
+(PID.TID 0000.0001)         System time:  0.30576372146606445
+(PID.TID 0000.0001)     Wall clock time:   6.7206749916076660
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
-(PID.TID 0000.0001)         System time:   4.2915344238281250E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3622512817382812E-003
+(PID.TID 0000.0001)           User time:   1.7089843750000000E-003
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   2.3658275604248047E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   26.623779296875000
-(PID.TID 0000.0001)         System time:  0.96367597579956055
-(PID.TID 0000.0001)     Wall clock time:   28.651564836502075
+(PID.TID 0000.0001)           User time:   27.250000000000000
+(PID.TID 0000.0001)         System time:  0.65564775466918945
+(PID.TID 0000.0001)     Wall clock time:   30.883779764175415
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.36450195312500000
-(PID.TID 0000.0001)         System time:   1.9955635070800781E-003
-(PID.TID 0000.0001)     Wall clock time:  0.37312412261962891
+(PID.TID 0000.0001)           User time:   5.3466796875000000E-002
+(PID.TID 0000.0001)         System time:   1.9998550415039062E-003
+(PID.TID 0000.0001)     Wall clock time:   6.0159921646118164E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6236,9 +6237,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         875380
+(PID.TID 0000.0001) //            No. barriers =         897304
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         875380
+(PID.TID 0000.0001) //     Total barrier spins =         897304
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #502 (improve_remove_mean): update 3 llc90 output_adm (all except
+    ecco_v4) since FWD results & FWD Grad change at machine truncation level.
+
 checkpoint68a (2021/07/16) synchronised with main MITgcm code.
   - define ALLOW_DIFFKR_CONTROL in experiment global_oce_cs32 & llc90:
     with generic-control and ALLOW_3D_DIFFKR, diffKr was available as a control


### PR DESCRIPTION
Update 3 llc90 output_adm*.txt files (primary, core2 and ecmwf) after changes in 
remove_mean.F (PR https://github.com/MITgcm/MITgcm/pull/502 ) affect results
at truncation level (in forward part + forward-Grad).

Note: all FWD and AD tests in global_oce_llc90 use "balanceEmPmR" but only
          these 3 AD tests call REMOVE_MEAN_RS (since the others use pkg/seaice).
