### PR TITLE
Add sterGloH output to cs32 experiment

### DIFF
--- a/global_oce_cs32/input/data.ecco
+++ b/global_oce_cs32/input/data.ecco
@@ -2,7 +2,10 @@
 # ECCO cost functions
 # *******************
  &ECCO_COST_NML
+ ecco_output_sterGloH=.TRUE.,
+ ecco_keepTSeriesOutp_open=.TRUE.,
  &
+
 # ***************************
 # ECCO generic cost functions
 # ***************************
@@ -41,4 +44,3 @@
  mult_gencost(2) = 1.,
 #
  &
-#

--- a/update_history
+++ b/update_history
@@ -1,6 +1,7 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #507: Turn on "sterGloH" output in global_oce_cs32 "data.ecco".
   - post PR #502 (improve_remove_mean): update 3 llc90 output_adm (all except
     ecco_v4) since FWD results & FWD Grad change at machine truncation level.
 


### PR DESCRIPTION
This is a very minor update, just adding (new) output to both FWD & ADM global_oce_cs32 test exp so that this new feature (https://github.com/MITgcm/MITgcm/pull/507) is used in at least one test.