### PR TITLE
Remove #ifdef ALLOW_ECCO in ECCO.h

### DIFF
--- a/global_oce_cs32/code/ECCO_OPTIONS.h
+++ b/global_oce_cs32/code/ECCO_OPTIONS.h
@@ -15,7 +15,6 @@ CEOP
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
 
-#ifdef ALLOW_ECCO
 #ifdef ECCO_CPPOPTIONS_H
 
 C-- When multi-package option-file ECCO_CPPOPTIONS.h is used (directly included
@@ -47,6 +46,5 @@ C re-activate deprecated codes (just in case ... but not recommended)
 #undef ECCO_CTRL_DEPRECATED
 
 #endif /* ndef ECCO_CPPOPTIONS_H */
-#endif /* ALLOW_ECCO */
 #endif /* ECCO_OPTIONS_H */
 

--- a/global_oce_llc90/code/ECCO_OPTIONS.h
+++ b/global_oce_llc90/code/ECCO_OPTIONS.h
@@ -15,7 +15,6 @@ CEOP
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
 
-#ifdef ALLOW_ECCO
 #ifdef ECCO_CPPOPTIONS_H
 
 C-- When multi-package option-file ECCO_CPPOPTIONS.h is used (directly included
@@ -47,6 +46,5 @@ C re-activate deprecated codes (just in case ... but not recommended)
 #undef ECCO_CTRL_DEPRECATED
 
 #endif /* ndef ECCO_CPPOPTIONS_H */
-#endif /* ALLOW_ECCO */
 #endif /* ECCO_OPTIONS_H */
 


### PR DESCRIPTION
Remove unnecessary #ifdef ALLOW_ECCO in ECCO.h. See MITgcm pull request #508 https://github.com/MITgcm/MITgcm/pull/508.
