### PR TITLE
Rename GM_K3D to GM_BATES(_K3D):

### DIFF
--- a/global_oce_cs32/code/GMREDI_OPTIONS.h
+++ b/global_oce_cs32/code/GMREDI_OPTIONS.h
@@ -26,8 +26,8 @@ C (which depends on tapering scheme)
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
-#undef GM_K3D
-#undef GM_K3D_PASSIVE
+#undef GM_BATES_K3D
+#undef GM_BATES_PASSIVE
 
 C This allows the leading diagonal (top two rows) to be non-unity
 C (a feature required when tapering adiabatically).

--- a/global_oce_cs32/input/data.diagnostics
+++ b/global_oce_cs32/input/data.diagnostics
@@ -1,22 +1,28 @@
 # Diagnostic Package Choices
-#-----------------
-# for each output-stream:
-#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-#               > 0 : write time-average output every multiple of frequency (iter)
+#--------------------
+#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+#--for each output-stream:
+#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+#               > 0 : write time-average output every frequency seconds
+#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+#    averagingFreq  : frequency (in s) for periodic averaging interval
+#    averagingPhase : phase     (in s) for periodic averaging interval
+#    repeatCycle    : number of averaging intervals in 1 cycle
 #  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-#                 when this entry is missing, select all common levels of this list
-#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file 
-#                 for the list of all available diag. in this particular config)
-#--------------------------------------------------------------------
-#
- &diagnostics_list
-#
+#                when this entry is missing, select all common levels of this list
+#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#  missing_value(n) : missing value for real-type fields in output file "n"
+#  fileFlags(n)     : specific code (8c string) for output file "n"
+#--------------------
+ &DIAGNOSTICS_LIST
    dumpatlast = .TRUE.,
    diagMdsDir = 'diags',
 #---
   frequency(1) = 2635200.0,
-   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 #stuff that is not quite state variables (and may not be quite
 #synchroneous) but are added here to reduce number of files
                  'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -149,19 +155,24 @@
 #  filename(17) = 'state_2d_set2',
 #---
  &
-#
-#
+
+#--------------------
 # Parameter for Diagnostics of per level statistics:
-#-----------------
-# for each output-stream:
-#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+#--------------------
+#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+#  diagSt_regMaskFile : file containing the region-mask to read-in
+#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+#  val_regMask(i)   : region "i" identifier value in the region mask
+#--for each output-stream:
+#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 #  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 #               > 0 : write time-average output every stat_freq seconds
 #  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 #  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-#                 file for the list of all available diag. in this particular config)
-#-----------------
+#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#--------------------
  &DIAG_STATIS_PARMS
 # diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 # nSetRegMskFile=1,
@@ -170,17 +181,17 @@
 # val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 #                10.,11.,12.,13.,14.,15.,16.,17.
 ##---
-# stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-#                   'UVEL    ','VVEL    ','WVEL    ',
-#                   'THETA   ','SALT    ',
+# stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+#                      'UVEL    ','VVEL    ','WVEL    ',
+#                      'THETA   ','SALT    ',
 #    stat_fname(1)= 'dynStDiag',
 #     stat_freq(1)= 3153600.,
 # stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 #                   10,11,12,13,14,15,16,17
 ##---
-# stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-#                   'oceQnet ','oceSflux','oceFWflx',
+# stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+#                      'oceQnet ','oceSflux','oceFWflx',
 #    stat_fname(2)= 'surfStDiag',
 #     stat_freq(2)= 3153600.,
 # stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/global_oce_llc90/code/GMREDI_OPTIONS.h
+++ b/global_oce_llc90/code/GMREDI_OPTIONS.h
@@ -26,8 +26,8 @@ C (which depends on tapering scheme)
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
-#undef GM_K3D
-#undef GM_K3D_PASSIVE
+#undef GM_BATES_K3D
+#undef GM_BATES_PASSIVE
 
 C This allows the leading diagonal (top two rows) to be non-unity
 C (a feature required when tapering adiabatically).

--- a/global_oce_llc90/input/data.diagnostics
+++ b/global_oce_llc90/input/data.diagnostics
@@ -1,22 +1,28 @@
 # Diagnostic Package Choices
-#-----------------
-# for each output-stream:
-#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-#               > 0 : write time-average output every multiple of frequency (iter)
+#--------------------
+#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+#--for each output-stream:
+#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+#               > 0 : write time-average output every frequency seconds
+#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+#    averagingFreq  : frequency (in s) for periodic averaging interval
+#    averagingPhase : phase     (in s) for periodic averaging interval
+#    repeatCycle    : number of averaging intervals in 1 cycle
 #  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-#                 when this entry is missing, select all common levels of this list
-#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file 
-#                 for the list of all available diag. in this particular config)
-#--------------------------------------------------------------------
-#
- &diagnostics_list
-#
+#                when this entry is missing, select all common levels of this list
+#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#  missing_value(n) : missing value for real-type fields in output file "n"
+#  fileFlags(n)     : specific code (8c string) for output file "n"
+#--------------------
+ &DIAGNOSTICS_LIST
    dumpatlast = .TRUE.,
    diagMdsDir = 'diags',
 #---
   frequency(1) = 2635200.0,
-   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 #stuff that is not quite state variables (and may not be quite
 #synchroneous) but are added here to reduce number of files
                  'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -149,19 +155,24 @@
 #  filename(17) = 'state_2d_set2',
 #---
  &
-#
-#
+
+#--------------------
 # Parameter for Diagnostics of per level statistics:
-#-----------------
-# for each output-stream:
-#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+#--------------------
+#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+#  diagSt_regMaskFile : file containing the region-mask to read-in
+#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+#  val_regMask(i)   : region "i" identifier value in the region mask
+#--for each output-stream:
+#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 #  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 #               > 0 : write time-average output every stat_freq seconds
 #  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 #  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-#                 file for the list of all available diag. in this particular config)
-#-----------------
+#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+#                (see "available_diagnostics.log" file for the full list of diags)
+#--------------------
  &DIAG_STATIS_PARMS
 # diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 # nSetRegMskFile=1,
@@ -170,17 +181,17 @@
 # val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 #                10.,11.,12.,13.,14.,15.,16.,17.
 ##---
-# stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-#                   'UVEL    ','VVEL    ','WVEL    ',
-#                   'THETA   ','SALT    ',
+# stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+#                      'UVEL    ','VVEL    ','WVEL    ',
+#                      'THETA   ','SALT    ',
 #    stat_fname(1)= 'dynStDiag',
 #     stat_freq(1)= 3153600.,
 # stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 #                   10,11,12,13,14,15,16,17
 ##---
-# stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-#                   'oceQnet ','oceSflux','oceFWflx',
+# stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+#                      'oceQnet ','oceSflux','oceFWflx',
 #    stat_fname(2)= 'surfStDiag',
 #     stat_freq(2)= 3153600.,
 # stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/global_ocean.gm_k3d/code/GMREDI_OPTIONS.h
+++ b/global_ocean.gm_k3d/code/GMREDI_OPTIONS.h
@@ -26,8 +26,8 @@ C (which depends on tapering scheme)
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
-#define GM_K3D
-#undef GM_K3D_PASSIVE
+#define GM_BATES_K3D
+#undef GM_BATES_PASSIVE
 
 C This allows the leading diagonal (top two rows) to be non-unity
 C (a feature required when tapering adiabatically).
@@ -43,6 +43,9 @@ C  instead of the Skew-Flux form (=default)
 
 C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 #define GM_BOLUS_BVP
+
+C Allow QG Leith variable viscosity to be added to GMRedi coefficient
+#undef ALLOW_GM_LEITH_QG
 
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */

--- a/global_ocean.gm_k3d/input/data.gmredi
+++ b/global_ocean.gm_k3d/input/data.gmredi
@@ -1,15 +1,15 @@
 # GM+Redi package parameters:
 
-# GM_background_K: 	G & Mc.W  diffusion coefficient
-# GM_maxSlope    :	max slope of isopycnals
-# GM_Scrit       :	transition for scaling diffusion coefficient
-# GM_Sd          :	half width scaling for diffusion coefficient
-# GM_taper_scheme:	slope clipping or one of the tapering schemes
-# GM_Kmin_horiz  :	horizontal diffusion minimum value
+# GM_background_K:: G & Mc.W  diffusion coefficient
+# GM_maxSlope    :: max slope of isopycnals
+# GM_Scrit       :: transition for scaling diffusion coefficient
+# GM_Sd          :: half width scaling for diffusion coefficient
+# GM_taper_scheme:: slope clipping or one of the tapering schemes
+# GM_Kmin_horiz  :: horizontal diffusion minimum value
 
 #-Option parameters (needs to "define" options in GMREDI_OPTIONS.h")
-# GM_isopycK     :	isopycnal diffusion coefficient (default=GM_background_K)
-# GM_AdvForm     :	turn on GM Advective form       (default=Skew flux form)
+# GM_isopycK     :: isopycnal diffusion coefficient (default=GM_background_K)
+# GM_AdvForm     :: turn on GM Advective form       (default=Skew flux form)
 
  &GM_PARM01
   GM_AdvForm         = .TRUE.,
@@ -17,31 +17,31 @@
   GM_background_K    = 0.0,
   GM_isopycK         = 0.0,
   GM_taper_scheme    = 'gkw91',
-  GM_maxSlope        = 1.e-2,
+  GM_maxSlope        = 1.E-2,
   GM_Kmin_horiz      = 50.,
-  GM_Scrit           = 4.e-3,
-  GM_Sd              = 1.e-3,
-  GM_K3D_gamma       = 0.35,
-  GM_K3D_b1          = 4,
-  GM_K3D_EadyMaxDepth= 1000.0,
-  GM_K3D_EadyMinDepth= 50.0,
-  GM_K3D_smallK      = 0.1D+3,
-  GM_K3D_maxC        =-0.15,
-  GM_maxK3D          = 2.0D+3,
-  GM_K3D_Lambda      = 4.0,
-  GM_useK3D          = .TRUE.,
-  GM_K3D_use_constK  = .FALSE.,
-  GM_K3D_ThickSheet  = .FALSE.,
-  GM_K3D_smooth      = .TRUE.,
-  GM_K3D_constK      = 1000.0,
-  GM_K3D_Rmax        = 75.0D+03,
-  GM_K3D_Rmin        = 30.0D+03,
-  GM_K3D_minCori     = 1.52D-5,
-  GM_K3D_minN2       = 1.0D-7,
-  GM_K3D_surfMinDepth= 0.0,
-  GM_K3D_vecFreq     = 2592000,
+  GM_Scrit           = 4.E-3,
+  GM_Sd              = 1.E-3,
   GM_InMomAsStress   = .FALSE.,
-  GM_K3D_surfK       = .TRUE.,
-  GM_K3D_constRedi   = .FALSE.,
+  GM_useBatesK3d     = .TRUE.,
+  GM_Bates_gamma       = 0.35,
+  GM_Bates_b1          = 4.,
+  GM_Bates_EadyMaxDepth= 1000.0,
+  GM_Bates_EadyMinDepth= 50.0,
+  GM_Bates_smallK      = 0.1E+3,
+  GM_Bates_maxC        =-0.15,
+  GM_Bates_maxK        = 2.0E+3,
+  GM_Bates_Lambda      = 4.0,
+  GM_Bates_use_constK  = .FALSE.,
+  GM_Bates_ThickSheet  = .FALSE.,
+  GM_Bates_smooth      = .TRUE.,
+  GM_Bates_constK      = 1000.0,
+  GM_Bates_Rmax        = 75.0E+03,
+  GM_Bates_Rmin        = 30.0E+03,
+  GM_Bates_minCori     = 1.52E-5,
+  GM_Bates_minN2       = 1.0E-7,
+  GM_Bates_surfMinDepth= 0.0,
+  GM_Bates_vecFreq     = 2592000.,
+  GM_Bates_surfK       = .TRUE.,
+  GM_Bates_constRedi   = .FALSE.,
  &
 

--- a/global_ocean.gm_res/code/GMREDI_OPTIONS.h
+++ b/global_ocean.gm_res/code/GMREDI_OPTIONS.h
@@ -26,8 +26,8 @@ C (which depends on tapering scheme)
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
-#define GM_K3D
-#undef GM_K3D_PASSIVE
+#define GM_BATES_K3D
+#undef GM_BATES_PASSIVE
 
 C This allows the leading diagonal (top two rows) to be non-unity
 C (a feature required when tapering adiabatically).
@@ -43,6 +43,9 @@ C  instead of the Skew-Flux form (=default)
 
 C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 #define GM_BOLUS_BVP
+
+C Allow QG Leith variable viscosity to be added to GMRedi coefficient
+#undef ALLOW_GM_LEITH_QG
 
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */

--- a/global_ocean.gm_res/input/data.gmredi
+++ b/global_ocean.gm_res/input/data.gmredi
@@ -1,15 +1,15 @@
 # GM+Redi package parameters:
 
-# GM_background_K: 	G & Mc.W  diffusion coefficient
-# GM_maxSlope    :	max slope of isopycnals
-# GM_Scrit       :	transition for scaling diffusion coefficient
-# GM_Sd          :	half width scaling for diffusion coefficient
-# GM_taper_scheme:	slope clipping or one of the tapering schemes
-# GM_Kmin_horiz  :	horizontal diffusion minimum value
+# GM_background_K:: G & Mc.W  diffusion coefficient
+# GM_maxSlope    :: max slope of isopycnals
+# GM_Scrit       :: transition for scaling diffusion coefficient
+# GM_Sd          :: half width scaling for diffusion coefficient
+# GM_taper_scheme:: slope clipping or one of the tapering schemes
+# GM_Kmin_horiz  :: horizontal diffusion minimum value
 
 #-Option parameters (needs to "define" options in GMREDI_OPTIONS.h")
-# GM_isopycK     :	isopycnal diffusion coefficient (default=GM_background_K)
-# GM_AdvForm     :	turn on GM Advective form       (default=Skew flux form)
+# GM_isopycK     :: isopycnal diffusion coefficient (default=GM_background_K)
+# GM_AdvForm     :: turn on GM Advective form       (default=Skew flux form)
 
  &GM_PARM01
   GM_AdvForm         = .TRUE.,
@@ -17,31 +17,31 @@
   GM_background_K    = 0.0,
   GM_isopycK         = 0.0,
   GM_taper_scheme    = 'gkw91',
-  GM_maxSlope        = 1.e-2,
+  GM_maxSlope        = 1.E-2,
   GM_Kmin_horiz      = 50.,
-  GM_Scrit           = 4.e-3,
-  GM_Sd              = 1.e-3,
-  GM_K3D_gamma       = 0.35,
-  GM_K3D_b1          = 4,
-  GM_K3D_EadyMaxDepth= 1000.0,
-  GM_K3D_EadyMinDepth= 50.0,
-  GM_K3D_smallK      = 0.1D+3,
-  GM_K3D_maxC        =-0.15,
-  GM_maxK3D          = 2.0D+3,
-  GM_K3D_Lambda      = 4.0,
-  GM_useK3D          = .TRUE.,
-  GM_K3D_use_constK  = .FALSE.,
-  GM_K3D_ThickSheet  = .FALSE.,
-  GM_K3D_smooth      = .TRUE.,
-  GM_K3D_constK      = 1000.0,
-  GM_K3D_Rmax        = 75.0D+03,
-  GM_K3D_Rmin        = 30.0D+03,
-  GM_K3D_minCori     = 1.52D-5,
-  GM_K3D_minN2       = 1.0D-7,
-  GM_K3D_surfMinDepth= 0.0,
-  GM_K3D_vecFreq     = 2592000,
+  GM_Scrit           = 4.E-3,
+  GM_Sd              = 1.E-3,
   GM_InMomAsStress   = .TRUE.,
-  GM_K3D_surfK       = .TRUE.,
-  GM_K3D_constRedi   = .FALSE.,
+  GM_useBatesK3d     = .TRUE.,
+  GM_Bates_gamma       = 0.35,
+  GM_Bates_b1          = 4.,
+  GM_Bates_EadyMaxDepth= 1000.0,
+  GM_Bates_EadyMinDepth= 50.0,
+  GM_Bates_smallK      = 0.1E+3,
+  GM_Bates_maxC        =-0.15,
+  GM_Bates_maxK        = 2.0E+3,
+  GM_Bates_Lambda      = 4.0,
+  GM_Bates_use_constK  = .FALSE.,
+  GM_Bates_ThickSheet  = .FALSE.,
+  GM_Bates_smooth      = .TRUE.,
+  GM_Bates_constK      = 1000.0,
+  GM_Bates_Rmax        = 75.0E+03,
+  GM_Bates_Rmin        = 30.0E+03,
+  GM_Bates_minCori     = 1.52E-5,
+  GM_Bates_minN2       = 1.0E-7,
+  GM_Bates_surfMinDepth= 0.0,
+  GM_Bates_vecFreq     = 2592000.,
+  GM_Bates_surfK       = .TRUE.,
+  GM_Bates_constRedi   = .FALSE.,
  &
 

--- a/update_history
+++ b/update_history
@@ -1,6 +1,8 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - following main code PR #576, rename GM_K3D to GM_BATES(_K3D).
+
 checkpoint68f (2022/01/14) synchronised with main MITgcm code.
 checkpoint68e (2021/12/10) synchronised with main MITgcm code.
 checkpoint68d (2021/11/05) synchronised with main MITgcm code.


### PR DESCRIPTION
Following code changes in https://github.com/MITgcm/MITgcm/pull/576
rename CPP-option:
 GM_K3D     --> GM_BATES_K3D
 GM_K3D_PASSIVE --> GM_BATES_PASSIVE
diagnostic name:
 'GM_K3D  ' --> 'GM_BaK  '
 'GM_K3D_T' --> 'GM_BaK_T'
on/off switch:
 GM_useK3D  --> GM_useBatesK3d
Parameters:
 GM_K3D_*   --> GM_Bates_*
 GM_maxK3D  --> GM_Bates_maxK

These changes can be done using "sed" command:
``#- dianostics name:``
``s/'GM_K3D  '/'GM_BaK  '/g``
``s/'GM_K3D_T'/'GM_BaK_T'/g``
``#- CPP options:``
``s/\<GM_K3D\>/GM_BATES_K3D/g``
``s/GM_K3D_PASSIVE/GM_BATES_PASSIVE/g``
``#- 3-D array:``
``#s/\<K3D\>/GM_BatesK3d/g``
``#- on/off switch:``
``s/GM_useK3D/GM_useBatesK3d/g``
``#- params:``
``s/GM_maxK3D/GM_Bates_maxK/g``
``s/GM_K3D_/GM_Bates_/g``
``#------------------------------------------``
