### PR TITLE
Post pr560 output update

### DIFF
--- a/global_oce_cs32/results/output_adm.txt
+++ b/global_oce_cs32/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68f
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri May  7 10:13:10 EDT 2021
+(PID.TID 0000.0001) // Build date:        Tue Mar 15 13:47:34 EDT 2022
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -628,58 +628,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -833,6 +833,9 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dFullAdjoint = /* use full hand written cg2d adjoint (no approximation) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
@@ -1036,8 +1039,8 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // pkg/smooth configuration
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) smooth 2D parameters:  1    30    0.    0.
-(PID.TID 0000.0001) smooth 3D parameters:  1    30    0.    0.    0.
+(PID.TID 0000.0001) smooth 2D parameters:  1    30    0.    0.maskC
+(PID.TID 0000.0001) smooth 3D parameters:  1    30    0.    0.    0.maskC
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of pkg/smooth config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -1051,7 +1054,10 @@
 (PID.TID 0000.0001) ># ECCO cost functions
 (PID.TID 0000.0001) ># *******************
 (PID.TID 0000.0001) > &ECCO_COST_NML
+(PID.TID 0000.0001) > ecco_output_sterGloH=.TRUE.,
+(PID.TID 0000.0001) > ecco_keepTSeriesOutp_open=.TRUE.,
 (PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># ***************************
 (PID.TID 0000.0001) ># ECCO generic cost functions
 (PID.TID 0000.0001) ># ***************************
@@ -1090,7 +1096,6 @@
 (PID.TID 0000.0001) > mult_gencost(2) = 1.,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: finished reading #1: ecco_cost_nml
 (PID.TID 0000.0001) ECCO_READPARMS: finished reading #2: ecco_gencost_nml
@@ -1330,6 +1335,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 7.200000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 3.153600000000000E+07
@@ -1582,6 +1590,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = sststep
 (PID.TID 0000.0001) -------------
@@ -1595,6 +1604,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -2881,17 +2891,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -2899,10 +2912,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3149,8 +3162,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3165,6 +3178,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -5356,7 +5372,7 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974313852075D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624875249D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650397462471D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644067409975D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448722019373161D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -5364,10 +5380,10 @@
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895297944020D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894664938770D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142475055178853D+04
-(PID.TID 0000.0001)  global fc =  0.331895297944020D+05
+(PID.TID 0000.0001)   local fc =  0.142473231505990D+04
+(PID.TID 0000.0001)  global fc =  0.331894664938770D+05
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
@@ -5387,164 +5403,78 @@
  cg2d: Sum(rhs),rhsMax =   5.85339734146226E+00  2.96284271209768E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.47451495458029E-17  2.59260668204037E-03
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -9.97465998686664E-18  2.28694924569916E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.59263162023582E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.99493199737333E-17  2.28707906627996E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7042374251496E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2119133090194E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.7286876219092E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8171248129705E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3150815866912E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1205832073029E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2256645661127E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4682785931570E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0732521631237E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5364054535095E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196776262627E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875271853879E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1257572885020E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.3544565302023E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7881957079704E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.1626509520787E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.1174737345498E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   7.8713266269185E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1858703282223E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.0678106725603E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7044832355171E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2118582829951E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6547383902750E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8170085027526E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3149953857108E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1210024444293E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2256888427286E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4586815785172E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0733228841403E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5364509294721E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196594861287E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875432885064E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1269091962144E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.3544552257591E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7882058126039E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.1607532697540E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.1192571990263E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   7.6913584704888E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1858728633943E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.0677904981727E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.6946736141657E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.3345664867200E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6228172252363E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584309330E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.3311872089491E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.3007712585751E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2577479290909E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.5719792740106E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.0118645471067E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.2538226555869E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.3294376795794E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.4087104042163E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -7.9828160558829E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   7.0222493457938E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4147278736920E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   1.0080710802461E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -1.3089987139600E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =  -4.5723444685724E-08
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   6.3659549392397E-07
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.1986569511769E-08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.1568909174648E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.0248092394377E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   2.1581343336572E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.0521090493646E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.2996419541864E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7670905156800E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -4.1093334109322E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.8962846277833E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.4852919461777E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.6562892559234E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.7799418840966E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.5000922342957E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.1049084377862E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.4943470239489E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2300203343579E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2679328266223E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.4669683701748E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.2839554608538E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.2062982394987E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8361538642794E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   7.2053910263764E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -7.0675440490525E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7663256213583E+01
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1862116054439E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.0686525590860E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5113893718719E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3881304034442E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.3096428622743E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0778326451654E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.1377200633831E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.0875271853879E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9196776262627E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   5.9732302659424E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.1831140837535E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.7127065825105E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2813634541980E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.2570622360756E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -2.1072423796342E+01
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.8729225921749E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.5867686206527E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_time_tsnumber             =                     6
 (PID.TID 0000.0001) %MON ad_time_secondsf             =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   1.9136041641235E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.2046289443970E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -4.7801920623822E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.7437245341451E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8722714164592E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1341182084311E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1396756700831E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.8927018523545E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0506075878555E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0665350981938E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3080552897237E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5158246322462E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.1483680462085E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.9874505241360E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0034036357934E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6089850801307E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5276081571095E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4568354463012E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3553425464535E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0422408136273E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2008716674611E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4402512672479E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.6031993542578E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6763518924716E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1692144215633E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1328085200407E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.2476140352144E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.7168157003000E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9610172479383E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3808036445417E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   1.9138391494751E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.2043855667114E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -4.7562494213580E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.7437240559581E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8721446814901E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1341095486001E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1397492516459E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.9905251869927E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0506244446408E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0665182148744E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3080432403011E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5158944695913E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.1486765565651E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.9874464065158E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0034180913884E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6097048463388E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5277591619389E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4549716367740E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3554009614010E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0423373263728E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2009895241713E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4401547219330E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.5683437849469E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6738998528160E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691860307461E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1326273453603E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.3166963428279E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.1576138320642E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9308456274746E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3574196626010E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5553,199 +5483,113 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     6
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2253857849773E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7308378174473E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7878196880268E-05
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5342942413284E-03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5301076188974E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0581237511235E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0332794890516E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3278588991294E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1517616020703E-03
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0871191023561E-05
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378295586651E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1436254455606E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.0219619995027E-06
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0906271388125E-03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3910383164964E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1558758253181E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3506530315151E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -6.4577551597618E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.4146163991417E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.0175106259832E-01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8181489156679E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5244221604671E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3493824434459E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015427363980E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879385409458E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2255912180524E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7310208954596E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7873810211848E-05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5343092270984E-03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5301417400765E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0581370366637E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0333957200843E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3273873378754E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1518130122099E-03
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0872034202754E-05
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378409220195E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1435016011649E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.8112238579074E-06
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0912014805983E-03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3910922257339E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1559034700064E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3506250698662E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -6.4546389535943E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.4146182121453E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.0174916650970E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8182554998653E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5243150893519E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3481968559688E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015433841762E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879311334983E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.17995238316738E-18  3.49934970105552E-03
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.25514051876985E-17  2.04009046652893E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   7.58941520739853E-19  3.49905873621620E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.21430643318376E-17  2.04009942678851E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
  cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
  cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
  cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.93889390390723E-18  2.83603652392051E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -4.85722573273506E-17  2.83628801421088E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3101801259183E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8263621263518E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0212151755591E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9722009943326E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2827338188074E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7298927920136E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9068311090507E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6382637644528E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0019827358433E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7395804557796E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0394345719167E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2932775759382E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6108819652866E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459180698244E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8614874145103E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5723374577767E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5761510053863E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.9911011083166E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5424976681291E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.4433780471732E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3102640000804E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8265295500100E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0237748824936E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9721802467114E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2826806470714E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7300262876995E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9069112282952E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6348741748740E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0019419791610E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7393012113036E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0393761935041E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2933731732452E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6167205416842E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459245331703E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615169105904E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5716268955521E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5832842454975E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.9176078900338E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5424800418975E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.4427367137472E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   7.5236624874256E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.6463644354210E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.1264528808496E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.4118155948284E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.0332263471203E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.7326004554033E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5323297899198E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.1785282917849E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.5860531982840E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.1994468338146E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3649463960068E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4855931729822E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.3376170629186E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5528616350171E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.1329486764011E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   2.1290842081962E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -5.7245169067443E-06
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   4.9525263379392E-08
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   6.6586303616265E-07
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   1.6341031931099E-08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   8.5127904282191E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.1985429469905E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   6.0032881659038E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   8.8477319726328E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.9470281106601E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.9558318895732E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0323613587113E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.0428609421341E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   8.0888521884122E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.9309085440237E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.0081822320763E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -6.3382740306536E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.4670865469439E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.6421391425346E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.2799121476821E-04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0115042687650E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3886256102212E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   7.4174628436492E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.9062800152346E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8882191784564E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.9314236150111E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.5403425637727E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1141415891887E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.5433223076222E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.4313581470611E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3732123746512E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2180612538734E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.2025294076235E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9083171998782E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.3797648185690E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.2932775759382E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.0394345719167E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.5385497790899E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.6189842951266E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.7873883878089E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.6202531167736E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.9692088130213E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -1.0030786159124E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.9066512274657E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.1734121828239E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_time_tsnumber             =                     3
 (PID.TID 0000.0001) %MON ad_time_secondsf             =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   2.0462471008301E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.0767431259155E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   1.9246047352709E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.6093149342319E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.6374460834453E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.4112080465147E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.3838091739858E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4967195457508E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.8726116406241E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.9845591594114E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4604074014395E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4797065995985E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.9876801251131E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6357394013078E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.9330079648082E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.8201115190336E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8116331215956E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.0115873595623E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.2720952924657E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.3928764808781E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.3380525567395E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.2399285741789E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.3945591995389E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.1160766199097E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.0367655865500E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.6647887733214E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.9254623638710E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.0388334329248E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.5880895268354E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0265709267515E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   2.0466220855713E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.0763593673706E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   1.9630677226673E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.6093156437125E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.6374326598003E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.4113189451581E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.3839569255260E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4928785442398E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.8725953858454E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.9845427503203E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4607189925323E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4799779328470E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.9898170122889E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6358660125636E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.9331315367514E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.8195346437399E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8116911371072E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.0113237964823E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.2723113156833E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.3931390205821E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.3380419572589E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.2399992228549E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.0193545434904E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.1175542005660E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.0367835365638E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.6664667202304E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.9149849764797E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2069120399685E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.5994701570782E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0275952986677E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5754,158 +5598,72 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     3
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1740571535125E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2161412010073E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4515862504626E-04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5199416405814E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9193969869688E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299887390782E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7473232141681E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1535815233256E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5798586412304E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2193436150449E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4297517729715E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3620086118978E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.4730089547544E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4491018070847E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5500929401755E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4086999459622E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7138933509604E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -5.7118628660053E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.0005838173599E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.2012719500522E-01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.2362863084963E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3468628725405E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.0777679493126E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.5386075230068E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.3366635552046E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1742071259913E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2162651394104E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4514952241469E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5199607959207E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9194176121027E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299856020008E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7473260446963E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1535235210124E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5798735267702E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2193963854717E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4304244524037E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3618258869498E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.5022997361647E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4493754748493E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5504654862445E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4087948500214E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7138034109404E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -5.7005491783713E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.0005950968021E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.2012477079381E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.2363227949789E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3468270074775E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.0733875571305E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.5386116103963E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.3366537375404E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.75640751942652E-17  1.94342368675061E-03
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   7.48099499014998E-18  1.58412648734265E-03
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.30104260698261E-18  2.31197703703447E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -1.50704101975485E-17  1.94295766760882E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   4.98732999343332E-18  1.58381888351740E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -3.46944695195361E-18  2.31109058484344E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7854907650343E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3593798356716E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9946259290888E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7801460856860E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1545359388769E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5235986070066E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0450547779028E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8893203615448E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6411923442741E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5371341591614E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956895803745E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4091308948291E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.6081886646773E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7477999386743E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419808810625E-05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5374192852953E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5386443041251E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.9597311761153E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8362029510534E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5438155316060E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7856995508937E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3596153351940E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9996883909553E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7801389565012E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1546289728027E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5235851609192E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0450941004869E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8826105591752E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6410827857225E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5366547897089E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956064643829E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4091388786480E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.6141293280267E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7478179311550E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419842383760E-05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5363078612157E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5398375291447E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.8377771188866E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8360841130859E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5427552699047E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.0052936384856E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.0513318962825E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3140005491751E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8458700461333E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.6972406212083E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.7437493743617E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5917439895689E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   2.0334921270305E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.3230816572385E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.4571099497600E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8536308029025E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.7803669262983E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -2.5126412371241E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0863856107057E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.4470653941238E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2418305570607E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.8761239112234E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =   5.6973778517272E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.2058591887654E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.6152238703263E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   8.1282773927222E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -4.2181549763028E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -6.7348730573240E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2667665460814E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.8534386052205E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.9794362675887E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -7.8403060618549E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.3820397878295E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.1173179004010E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6913855890912E-04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.2303164046281E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9344367516751E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4127176199600E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.4104584754864E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7048370860393E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5844471635580E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.5078972858726E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =  -2.0062518573437E+01
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.8351920871613E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.5335239993460E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4076784519630E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -3.3104314669592E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.2973075435537E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1823111378958E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.1110830027001E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3244027533740E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -4.5956895803745E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.0068386753406E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   8.3424966302278E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.1242862532324E-05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.8498693297198E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8315974787183E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =  -1.3526085386808E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   8.4404589373559E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.4907407108766E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5920,31 +5678,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9804680348074E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.1266023981405E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3033448927737E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2821267694218E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.4659142166707E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3452713430160E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.4013571898089E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.3654369000928E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3890260664704E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.6337378326569E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9807034093562E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.1270333022907E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.2963838542005E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2821304189064E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.4658711843025E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3452838954058E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.4018915177098E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.3701546314855E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3893779168920E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.6338967877690E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0955080420031E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.4242604569479E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5284799098629E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4371375577351E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700842237147E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174214509438E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4711305561207E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6221911902664E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3393233631783E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6754516385784E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0955157173850E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.4242530737105E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.4525377147399E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4369505464535E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700869890080E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0169434786589E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4797947980258E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.5854306757326E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3392324216324E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6755277330329E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5953,31 +5711,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     0
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8132191297611E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1834666623637E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0929057897657E-04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2608529202088E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1070351106290E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890935349381E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5622148527256E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9716220093132E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1005504968013E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9936605066522E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1711786189105E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3353849744159E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6468625453491E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3711473517757E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2630055483285E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9823477397125E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7087608714628E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -7.4160671285878E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   8.9981377688008E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.1722230786254E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8072393758011E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3460042713133E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.6948834307503E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2631377887967E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.2507621749226E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8134713670095E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1836720517881E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0929765992065E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2609087185825E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1070856335372E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890852038234E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5622210090942E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9713238034987E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1005762338646E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9937935295157E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1713203850489E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3352704302588E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6478040243645E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3711869572396E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2631458822373E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9825487868929E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7084760777433E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -7.3923826785352E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   8.9981545849668E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.1722186131805E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8073154428099E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3458975563003E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.6860118074680E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2631438735970E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.2507452061718E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5989,7 +5747,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  3.31895297944020E+04
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  3.31894664938770E+04
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -6023,7 +5781,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974314233500D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624872024D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650396089885D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644066489935D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448722092846220D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6031,11 +5789,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895305188985D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894672228990D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142475115091432D+04
-(PID.TID 0000.0001)  global fc =  0.331895305188985D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31895305188985E+04
+(PID.TID 0000.0001)   local fc =  0.142473291578341D+04
+(PID.TID 0000.0001)  global fc =  0.331894672228990D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894672228990E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6061,7 +5819,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974313470536D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624878488D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650399269928D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644068188824D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448721953015326D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6069,17 +5827,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895291454067D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894658345956D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142474999778740D+04
-(PID.TID 0000.0001)  global fc =  0.331895291454067D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31895291454067E+04
+(PID.TID 0000.0001)   local fc =  0.142473175566186D+04
+(PID.TID 0000.0001)  global fc =  0.331894658345956D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894658345956E+04
 grad-res -------------------------------
- grad-res     0    1    1    1    1    1    1    1   3.31895297944E+04  3.31895305189E+04  3.31895291454E+04
- grad-res     0    1    1    1    0    1    1    1   5.09790554643E-02  6.86745897838E-02 -3.47113812885E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31895297944020E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09790554642677E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.86745897837682E-02
+ grad-res     0    1    1    1    1    1    1    1   3.31894664939E+04  3.31894672229E+04  3.31894658346E+04
+ grad-res     0    1    1    1    0    1    1    1   5.09815104306E-02  6.94151665812E-02 -3.61575323973E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09815104305744E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.94151665811660E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2         594           2
@@ -6111,7 +5869,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974314354079D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624875213D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650395337306D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644065660966D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448722083640594D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6119,11 +5877,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895304208411D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894671240777D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142475125817979D+04
-(PID.TID 0000.0001)  global fc =  0.331895304208411D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31895304208411E+04
+(PID.TID 0000.0001)   local fc =  0.142473302055009D+04
+(PID.TID 0000.0001)  global fc =  0.331894671240777D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894671240777E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6149,7 +5907,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974313349852D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624875285D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650400003887D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644069502959D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448721950110760D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6157,17 +5915,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895291221735D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894658171642D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142474983625346D+04
-(PID.TID 0000.0001)  global fc =  0.331895291221735D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31895291221735E+04
+(PID.TID 0000.0001)   local fc =  0.142473159962094D+04
+(PID.TID 0000.0001)  global fc =  0.331894658171642D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894658171642E+04
 grad-res -------------------------------
- grad-res     0    2    2    1    1    1    1    1   3.31895297944E+04  3.31895304208E+04  3.31895291222E+04
- grad-res     0    2    2    2    0    1    1    1   4.96661998332E-02  6.49333815090E-02 -3.07395808964E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31895297944020E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.96661998331547E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.49333815090358E-02
+ grad-res     0    2    2    1    1    1    1    1   3.31894664939E+04  3.31894671241E+04  3.31894658172E+04
+ grad-res     0    2    2    2    0    1    1    1   4.96699325740E-02  6.53456765576E-02 -3.15598253737E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.96699325740337E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.53456765576266E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3         594           3
@@ -6199,7 +5957,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974314378885D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624876853D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650394373489D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644064600946D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448722054806655D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6207,11 +5965,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895301232756D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894668255502D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142475114577916D+04
-(PID.TID 0000.0001)  global fc =  0.331895301232756D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31895301232756E+04
+(PID.TID 0000.0001)   local fc =  0.142473290834129D+04
+(PID.TID 0000.0001)  global fc =  0.331894668255502D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894668255502E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6237,7 +5995,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974313325207D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624873647D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650401142285D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644070269005D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448721984700163D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6245,17 +6003,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895294790412D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894661703084D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142474998639050D+04
-(PID.TID 0000.0001)  global fc =  0.331895294790412D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31895294790412E+04
+(PID.TID 0000.0001)   local fc =  0.142473174626259D+04
+(PID.TID 0000.0001)  global fc =  0.331894661703084D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894661703084E+04
 grad-res -------------------------------
- grad-res     0    3    3    1    1    1    1    1   3.31895297944E+04  3.31895301233E+04  3.31895294790E+04
- grad-res     0    3    3    3    0    1    1    1   2.86020413041E-02  3.22117186442E-02 -1.26203486729E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31895297944020E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.86020413041115E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.22117186442483E-02
+ grad-res     0    3    3    1    1    1    1    1   3.31894664939E+04  3.31894668256E+04  3.31894661703E+04
+ grad-res     0    3    3    3    0    1    1    1   2.86069530994E-02  3.27620866301E-02 -1.45249076904E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.86069530993700E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27620866301004E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4         594           4
@@ -6287,7 +6045,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974314321325D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624877234D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650392444322D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644063623697D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448722023213277D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6295,11 +6053,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895297875126D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894664993063D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142475089527951D+04
-(PID.TID 0000.0001)  global fc =  0.331895297875126D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31895297875126E+04
+(PID.TID 0000.0001)   local fc =  0.142473266403134D+04
+(PID.TID 0000.0001)  global fc =  0.331894664993063D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894664993063E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6325,7 +6083,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  --> f_profiles = 0.134974313382708D+04 1 1
 (PID.TID 0000.0001)  --> f_profiles = 0.229260624873260D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442650402134672D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.442644071851342D+04 1
 (PID.TID 0000.0001)  --> f_gencost = 0.448722009451622D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
@@ -6333,17 +6091,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331895297370160D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894664341827D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142475015572560D+04
-(PID.TID 0000.0001)  global fc =  0.331895297370160D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31895297370160E+04
+(PID.TID 0000.0001)   local fc =  0.142473191782152D+04
+(PID.TID 0000.0001)  global fc =  0.331894664341827D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894664341827E+04
 grad-res -------------------------------
- grad-res     0    4    4    1    1    1    1    1   3.31895297944E+04  3.31895297875E+04  3.31895297370E+04
- grad-res     0    4    4    4    0    1    1    1   4.67482302338E-03  2.52482968790E-03  4.59909032861E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31895297944020E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.67482302337885E-03
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.52482968789991E-03
+ grad-res     0    4    4    1    1    1    1    1   3.31894664939E+04  3.31894664993E+04  3.31894664342E+04
+ grad-res     0    4    4    4    0    1    1    1   4.68086265028E-03  3.25618239003E-03  3.04362756758E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.68086265027523E-03
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.25618239003234E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6357,271 +6115,271 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   1  3.3189529794402E+04  3.3189530518898E+04  3.3189529145407E+04
-(PID.TID 0000.0001) grdchk output (g):   1     6.8674589783768E-02  5.0979055464268E-02 -3.4711381288544E-01
+(PID.TID 0000.0001) grdchk output (c):   1  3.3189466493877E+04  3.3189467222899E+04  3.3189465834596E+04
+(PID.TID 0000.0001) grdchk output (g):   1     6.9415166581166E-02  5.0981510430574E-02 -3.6157532397347E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   2  3.3189529794402E+04  3.3189530420841E+04  3.3189529122173E+04
-(PID.TID 0000.0001) grdchk output (g):   2     6.4933381509036E-02  4.9666199833155E-02 -3.0739580896402E-01
+(PID.TID 0000.0001) grdchk output (c):   2  3.3189466493877E+04  3.3189467124078E+04  3.3189465817164E+04
+(PID.TID 0000.0001) grdchk output (g):   2     6.5345676557627E-02  4.9669932574034E-02 -3.1559825373686E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   3  3.3189529794402E+04  3.3189530123276E+04  3.3189529479041E+04
-(PID.TID 0000.0001) grdchk output (g):   3     3.2211718644248E-02  2.8602041304111E-02 -1.2620348672869E-01
+(PID.TID 0000.0001) grdchk output (c):   3  3.3189466493877E+04  3.3189466825550E+04  3.3189466170308E+04
+(PID.TID 0000.0001) grdchk output (g):   3     3.2762086630100E-02  2.8606953099370E-02 -1.4524907690438E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   4  3.3189529794402E+04  3.3189529787513E+04  3.3189529737016E+04
-(PID.TID 0000.0001) grdchk output (g):   4     2.5248296878999E-03  4.6748230233788E-03  4.5990903286109E-01
+(PID.TID 0000.0001) grdchk output (c):   4  3.3189466493877E+04  3.3189466499306E+04  3.3189466434183E+04
+(PID.TID 0000.0001) grdchk output (g):   4     3.2561823900323E-03  4.6808626502752E-03  3.0436275675791E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.3257473635042E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9328866101126E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   261.57172036916018
-(PID.TID 0000.0001)         System time:   3.7431039810180664
-(PID.TID 0000.0001)     Wall clock time:   283.41399979591370
+(PID.TID 0000.0001)           User time:   174.55678601562977
+(PID.TID 0000.0001)         System time:   2.5830048844218254
+(PID.TID 0000.0001)     Wall clock time:   178.22393393516541
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   1.6839419826865196
-(PID.TID 0000.0001)         System time:  0.37137998640537262
-(PID.TID 0000.0001)     Wall clock time:   2.3726098537445068
+(PID.TID 0000.0001)           User time:  0.94894698262214661
+(PID.TID 0000.0001)         System time:  0.24376498907804489
+(PID.TID 0000.0001)     Wall clock time:   1.3828959465026855
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   122.01326441764832
-(PID.TID 0000.0001)         System time:   2.3394979238510132
-(PID.TID 0000.0001)     Wall clock time:   133.24424099922180
+(PID.TID 0000.0001)           User time:   83.311727702617645
+(PID.TID 0000.0001)         System time:   1.8113310635089874
+(PID.TID 0000.0001)     Wall clock time:   85.824037075042725
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   144.92237949371338
-(PID.TID 0000.0001)         System time:  0.48906904458999634
-(PID.TID 0000.0001)     Wall clock time:   153.55122780799866
+(PID.TID 0000.0001)           User time:   99.223167896270752
+(PID.TID 0000.0001)         System time:  0.37552225589752197
+(PID.TID 0000.0001)     Wall clock time:   100.12991309165955
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4456906318664551
-(PID.TID 0000.0001)         System time:   4.3926835060119629E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5616633892059326
+(PID.TID 0000.0001)           User time:   1.9138526916503906
+(PID.TID 0000.0001)         System time:   5.3608417510986328E-004
+(PID.TID 0000.0001)     Wall clock time:   1.9153716564178467
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2396762371063232
-(PID.TID 0000.0001)         System time:   6.7929148674011230E-002
-(PID.TID 0000.0001)     Wall clock time:   3.5185043811798096
+(PID.TID 0000.0001)           User time:  0.96229171752929688
+(PID.TID 0000.0001)         System time:   4.6961843967437744E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1297271251678467
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.1263146400451660
-(PID.TID 0000.0001)         System time:   6.7339181900024414E-002
-(PID.TID 0000.0001)     Wall clock time:   3.4046058654785156
+(PID.TID 0000.0001)           User time:  0.88628745079040527
+(PID.TID 0000.0001)         System time:   4.6710014343261719E-002
+(PID.TID 0000.0001)     Wall clock time:   1.0535964965820312
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   7.2574615478515625E-004
-(PID.TID 0000.0001)         System time:   1.1146068572998047E-005
-(PID.TID 0000.0001)     Wall clock time:   8.5186958312988281E-004
+(PID.TID 0000.0001)           User time:   7.6031684875488281E-004
+(PID.TID 0000.0001)         System time:   9.0599060058593750E-006
+(PID.TID 0000.0001)     Wall clock time:   7.5268745422363281E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35948109626770020
-(PID.TID 0000.0001)         System time:   4.3118000030517578E-003
-(PID.TID 0000.0001)     Wall clock time:  0.41223597526550293
+(PID.TID 0000.0001)           User time:  0.16671729087829590
+(PID.TID 0000.0001)         System time:   2.9695034027099609E-004
+(PID.TID 0000.0001)     Wall clock time:  0.16712141036987305
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.5258245468139648E-002
-(PID.TID 0000.0001)         System time:   1.8292665481567383E-004
-(PID.TID 0000.0001)     Wall clock time:   8.5813999176025391E-002
+(PID.TID 0000.0001)           User time:   6.1922788619995117E-002
+(PID.TID 0000.0001)         System time:   2.3317337036132812E-004
+(PID.TID 0000.0001)     Wall clock time:   6.2314271926879883E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   32.634188175201416
-(PID.TID 0000.0001)         System time:  0.12008345127105713
-(PID.TID 0000.0001)     Wall clock time:   35.026981592178345
+(PID.TID 0000.0001)           User time:   22.515388488769531
+(PID.TID 0000.0001)         System time:   5.2355706691741943E-002
+(PID.TID 0000.0001)     Wall clock time:   22.609428882598877
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   4.3645236492156982
-(PID.TID 0000.0001)         System time:   1.8995285034179688E-002
-(PID.TID 0000.0001)     Wall clock time:   4.6577699184417725
+(PID.TID 0000.0001)           User time:   2.0323276519775391
+(PID.TID 0000.0001)         System time:   4.2564272880554199E-003
+(PID.TID 0000.0001)     Wall clock time:   2.0372138023376465
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   3.1158931255340576
-(PID.TID 0000.0001)         System time:   1.4984250068664551E-002
-(PID.TID 0000.0001)     Wall clock time:   3.3508486747741699
+(PID.TID 0000.0001)           User time:   1.5270893573760986
+(PID.TID 0000.0001)         System time:   4.0290355682373047E-003
+(PID.TID 0000.0001)     Wall clock time:   1.5316410064697266
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   8.2642426490783691
-(PID.TID 0000.0001)         System time:   8.2607865333557129E-003
-(PID.TID 0000.0001)     Wall clock time:   8.8893122673034668
+(PID.TID 0000.0001)           User time:   6.7513849735260010
+(PID.TID 0000.0001)         System time:   1.6428112983703613E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8024644851684570
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   26.455229282379150
-(PID.TID 0000.0001)         System time:   3.6488771438598633E-003
-(PID.TID 0000.0001)     Wall clock time:   28.181684017181396
+(PID.TID 0000.0001)           User time:   22.042269229888916
+(PID.TID 0000.0001)         System time:   7.9120993614196777E-003
+(PID.TID 0000.0001)     Wall clock time:   22.089069366455078
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2971901893615723
-(PID.TID 0000.0001)         System time:   4.2312741279602051E-003
-(PID.TID 0000.0001)     Wall clock time:   8.5519115924835205
+(PID.TID 0000.0001)           User time:   2.3157866001129150
+(PID.TID 0000.0001)         System time:   4.6759843826293945E-004
+(PID.TID 0000.0001)     Wall clock time:   2.3171830177307129
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3075618743896484
-(PID.TID 0000.0001)         System time:   4.0781497955322266E-003
-(PID.TID 0000.0001)     Wall clock time:   3.3761281967163086
+(PID.TID 0000.0001)           User time:   1.2438883781433105
+(PID.TID 0000.0001)         System time:   1.1682510375976562E-004
+(PID.TID 0000.0001)     Wall clock time:   1.2445726394653320
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.69877338409423828
-(PID.TID 0000.0001)         System time:   7.3194503784179688E-005
-(PID.TID 0000.0001)     Wall clock time:  0.76126813888549805
+(PID.TID 0000.0001)           User time:  0.51593875885009766
+(PID.TID 0000.0001)         System time:   3.9716362953186035E-003
+(PID.TID 0000.0001)     Wall clock time:  0.52020168304443359
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4231801033020020
-(PID.TID 0000.0001)         System time:   4.0915012359619141E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5585913658142090
+(PID.TID 0000.0001)           User time:  0.93417286872863770
+(PID.TID 0000.0001)         System time:   1.7881393432617188E-005
+(PID.TID 0000.0001)     Wall clock time:  0.93725109100341797
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.22207927703857422
-(PID.TID 0000.0001)         System time:   8.2314014434814453E-005
-(PID.TID 0000.0001)     Wall clock time:  0.22696924209594727
+(PID.TID 0000.0001)           User time:   7.6619148254394531E-002
+(PID.TID 0000.0001)         System time:   2.5212764739990234E-005
+(PID.TID 0000.0001)     Wall clock time:   7.6673269271850586E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.597478866577148
-(PID.TID 0000.0001)         System time:  0.11859393119812012
-(PID.TID 0000.0001)     Wall clock time:   13.167008161544800
+(PID.TID 0000.0001)           User time:   4.1334791183471680
+(PID.TID 0000.0001)         System time:  0.11519706249237061
+(PID.TID 0000.0001)     Wall clock time:   4.2663819789886475
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   28.757848739624023
-(PID.TID 0000.0001)         System time:   3.1269133090972900E-002
-(PID.TID 0000.0001)     Wall clock time:   30.248376846313477
+(PID.TID 0000.0001)           User time:   23.508372306823730
+(PID.TID 0000.0001)         System time:   1.1636674404144287E-002
+(PID.TID 0000.0001)     Wall clock time:   23.558078765869141
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.4556808471679688E-004
-(PID.TID 0000.0001)         System time:   7.7486038208007812E-006
-(PID.TID 0000.0001)     Wall clock time:   8.8834762573242188E-004
+(PID.TID 0000.0001)           User time:   7.2121620178222656E-004
+(PID.TID 0000.0001)         System time:   1.4960765838623047E-005
+(PID.TID 0000.0001)     Wall clock time:   7.0810317993164062E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.52240753173828125
-(PID.TID 0000.0001)         System time:   7.0333480834960938E-006
-(PID.TID 0000.0001)     Wall clock time:  0.54837679862976074
+(PID.TID 0000.0001)           User time:  0.30049419403076172
+(PID.TID 0000.0001)         System time:   3.2901763916015625E-005
+(PID.TID 0000.0001)     Wall clock time:  0.30106925964355469
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7281723022460938E-004
-(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
-(PID.TID 0000.0001)     Wall clock time:   7.6031684875488281E-004
+(PID.TID 0000.0001)           User time:   6.4849853515625000E-004
+(PID.TID 0000.0001)         System time:   1.1861324310302734E-005
+(PID.TID 0000.0001)     Wall clock time:   6.4563751220703125E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.59683084487915039
-(PID.TID 0000.0001)         System time:   1.5109717845916748E-002
-(PID.TID 0000.0001)     Wall clock time:  0.65968489646911621
+(PID.TID 0000.0001)           User time:  0.37810039520263672
+(PID.TID 0000.0001)         System time:   2.0011961460113525E-002
+(PID.TID 0000.0001)     Wall clock time:  0.40956854820251465
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32646799087524414
-(PID.TID 0000.0001)         System time:   8.7515890598297119E-002
-(PID.TID 0000.0001)     Wall clock time:  0.45331954956054688
+(PID.TID 0000.0001)           User time:  0.15532779693603516
+(PID.TID 0000.0001)         System time:  0.10785597562789917
+(PID.TID 0000.0001)     Wall clock time:  0.26313352584838867
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.6433887481689453
-(PID.TID 0000.0001)         System time:   7.2693943977355957E-002
-(PID.TID 0000.0001)     Wall clock time:   3.9871866703033447
+(PID.TID 0000.0001)           User time:   2.2100772857666016
+(PID.TID 0000.0001)         System time:   5.9949994087219238E-002
+(PID.TID 0000.0001)     Wall clock time:   2.3064212799072266
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.47706794738769531
-(PID.TID 0000.0001)         System time:  0.14012753963470459
-(PID.TID 0000.0001)     Wall clock time:  0.83186435699462891
+(PID.TID 0000.0001)           User time:  0.49365520477294922
+(PID.TID 0000.0001)         System time:   6.0001909732818604E-002
+(PID.TID 0000.0001)     Wall clock time:  0.55388855934143066
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.37516021728515625
-(PID.TID 0000.0001)         System time:   2.8243780136108398E-002
-(PID.TID 0000.0001)     Wall clock time:  0.42074584960937500
+(PID.TID 0000.0001)           User time:  0.14381408691406250
+(PID.TID 0000.0001)         System time:   3.9890050888061523E-002
+(PID.TID 0000.0001)     Wall clock time:  0.18666410446166992
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.22261047363281250
-(PID.TID 0000.0001)         System time:   1.5960216522216797E-002
-(PID.TID 0000.0001)     Wall clock time:  0.23881411552429199
+(PID.TID 0000.0001)           User time:  0.17381286621093750
+(PID.TID 0000.0001)         System time:   8.0449581146240234E-003
+(PID.TID 0000.0001)     Wall clock time:  0.18190193176269531
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   137.27663421630859
-(PID.TID 0000.0001)         System time:  0.98799085617065430
-(PID.TID 0000.0001)     Wall clock time:   147.13747715950012
+(PID.TID 0000.0001)           User time:   89.978340148925781
+(PID.TID 0000.0001)         System time:  0.47994995117187500
+(PID.TID 0000.0001)     Wall clock time:   90.648307085037231
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   12.169746398925781
-(PID.TID 0000.0001)         System time:  0.40932917594909668
-(PID.TID 0000.0001)     Wall clock time:   13.741947174072266
+(PID.TID 0000.0001)           User time:   6.0911788940429688
+(PID.TID 0000.0001)         System time:  0.17961978912353516
+(PID.TID 0000.0001)     Wall clock time:   6.2722082138061523
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   125.09156799316406
-(PID.TID 0000.0001)         System time:  0.56356287002563477
-(PID.TID 0000.0001)     Wall clock time:   133.34758186340332
+(PID.TID 0000.0001)           User time:   83.865112304687500
+(PID.TID 0000.0001)         System time:  0.30023193359375000
+(PID.TID 0000.0001)     Wall clock time:   84.351010322570801
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   6.7923431396484375
-(PID.TID 0000.0001)         System time:   2.7940034866333008E-002
-(PID.TID 0000.0001)     Wall clock time:   7.2899816036224365
+(PID.TID 0000.0001)           User time:   2.2147979736328125
+(PID.TID 0000.0001)         System time:   1.5872001647949219E-002
+(PID.TID 0000.0001)     Wall clock time:   2.2594349384307861
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.69148254394531250
-(PID.TID 0000.0001)         System time:   1.1882305145263672E-002
-(PID.TID 0000.0001)     Wall clock time:  0.78047895431518555
+(PID.TID 0000.0001)           User time:  0.56592559814453125
+(PID.TID 0000.0001)         System time:   3.1868457794189453E-002
+(PID.TID 0000.0001)     Wall clock time:  0.59794902801513672
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   112.29781341552734
-(PID.TID 0000.0001)         System time:  0.26619291305541992
-(PID.TID 0000.0001)     Wall clock time:   119.29996013641357
+(PID.TID 0000.0001)           User time:   77.691154479980469
+(PID.TID 0000.0001)         System time:  0.13638019561767578
+(PID.TID 0000.0001)     Wall clock time:   77.979200601577759
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.50663757324218750
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:  0.51583218574523926
+(PID.TID 0000.0001)           User time:  0.23314666748046875
+(PID.TID 0000.0001)         System time:   1.2159347534179688E-005
+(PID.TID 0000.0001)     Wall clock time:  0.23728299140930176
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.4871826171875000E-003
-(PID.TID 0000.0001)         System time:   7.1525573730468750E-006
-(PID.TID 0000.0001)     Wall clock time:   2.5203227996826172E-003
+(PID.TID 0000.0001)           User time:   1.5945434570312500E-003
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   1.6019344329833984E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.5582885742187500
-(PID.TID 0000.0001)         System time:  0.16389250755310059
-(PID.TID 0000.0001)     Wall clock time:   4.0615916252136230
+(PID.TID 0000.0001)           User time:   2.4043350219726562
+(PID.TID 0000.0001)         System time:   6.3962936401367188E-002
+(PID.TID 0000.0001)     Wall clock time:   2.4692320823669434
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   5.1055908203125000E-002
-(PID.TID 0000.0001)         System time:   1.9690990447998047E-003
-(PID.TID 0000.0001)     Wall clock time:   5.3037166595458984E-002
+(PID.TID 0000.0001)           User time:   1.5907287597656250E-002
+(PID.TID 0000.0001)         System time:   1.2397766113281250E-004
+(PID.TID 0000.0001)     Wall clock time:   1.6055822372436523E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6661,9 +6419,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         234788
+(PID.TID 0000.0001) //            No. barriers =         232022
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         234788
+(PID.TID 0000.0001) //     Total barrier spins =         232022
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,8 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #560 (extra_diags): update cs32 (primary) output_adm.txt
+
 checkpoint68g (2022/02/19) synchronised with main MITgcm code.
   - following main code PR #576, rename GM_K3D to GM_BATES(_K3D).
 


### PR DESCRIPTION
Update global_oce_cs32 (primary) reference AD output after PR 560 changes
    
    Density used to estimate Greatbatch correction has been shifted by one time-step
    (now using rhoInSitu) which affects "m_eta" associated cost-function that is
    used in this set-up (gencost_barfile(1) = 'etastep', in data.ecco).
    Update AD output from reference machine (villon, gfortran & -devel, using 8 MPI procs)