### PR TITLE
Post pr611 ad output update

### DIFF
--- a/global_oce_llc90/results/output_adm.core2.txt
+++ b/global_oce_llc90/results/output_adm.core2.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68i
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node104.cm.cluster
-(PID.TID 0000.0001) // Build date:        Sat Jul 24 00:27:03 EDT 2021
+(PID.TID 0000.0001) // Build host:        node143
+(PID.TID 0000.0001) // Build date:        Sun May  8 00:44:45 EDT 2022
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node104.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node143
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -194,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -662,6 +662,9 @@
 (PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dFullAdjoint = /* use full hand written cg2d adjoint (no approximation) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -843,6 +846,9 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># =======================
+(PID.TID 0000.0001) ># pkg SMOOTH parameters :
+(PID.TID 0000.0001) ># =======================
 (PID.TID 0000.0001) > &SMOOTH_NML
 (PID.TID 0000.0001) > smooth2Dnbt(1)=300,
 (PID.TID 0000.0001) > smooth2Dtype(1)=1,
@@ -1144,6 +1150,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 1.440000000000000E+04
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1396,6 +1405,7 @@
 (PID.TID 0000.0001)  error file = some_T_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = saltatlas
@@ -1405,6 +1415,7 @@
 (PID.TID 0000.0001)  error file = some_S_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -2218,17 +2229,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -2236,10 +2250,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -2431,8 +2445,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -2449,7 +2463,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -2486,8 +2500,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -2502,6 +2516,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -4122,128 +4139,42 @@
  cg2d: Sum(rhs),rhsMax =  -1.95399252334028E-14  4.51184359657809E-02
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.97993951420693E-20  1.81186037021313E-06
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.80367905541173E-19  1.23068566104391E-05
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.96935160236625E-20  1.81185773994806E-06
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -7.96210970419042E-20  1.23068586544962E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   4.4571683586574E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -4.0186052717060E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.1540487620562E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9078633884453E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7694594030457E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.2085842632029E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.3752631121034E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.3857908368593E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   6.1608297157204E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7916543227416E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.2687831845393E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.7809532006091E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.2726244088977E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4691455247990E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.4461703126962E-08
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1740797016350E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.3164062465617E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1061352560603E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9655041103660E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.2643527757197E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   4.4571683460734E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -4.0186052761510E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.1540488255331E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9078633595973E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7694594025920E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.2085842477283E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.3752631169286E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.3857907782963E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   6.1608297103172E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7916543245704E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.2687831845411E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.7809532006416E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.2726244088966E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4691455247945E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.4461703126854E-08
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1740797015283E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.3164062538378E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1061352557676E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9655041106266E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.2643527754460E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4753319901255E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8175348763914E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.0814473624582E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.1510813096960E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   3.4620476871836E-09
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5634269679665E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5753676363565E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.0532180582892E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.9805567730096E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   6.0464969961708E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.8943492126884E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3003412912396E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.3726217552727E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.1361468931768E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   6.2368938257609E-05
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.6579409017662E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -3.8494692280799E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.8125589991346E-07
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.4897267232905E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   8.4699933476012E-07
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   5.0938287535020E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.7400160153450E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -1.3620094424907E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1989209600184E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   8.7761197429835E-07
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1635525616149E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2062814299230E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.3226276717845E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.6011301269943E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   2.0977909704075E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.1454848447969E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.3637531487921E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.4810049415879E-03
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6085257236130E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.9707313108573E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.3164062465617E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1740797016350E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1061352560603E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9655041103660E+03
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.2643527757197E+01
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.0874502105207E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.5094487105955E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   9.9422401425679E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.0634822656282E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0553311691362E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.7809532006091E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.2687831845393E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.2726244088977E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.4691455247990E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.4461703126962E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.3164062465617E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1740797016350E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1061352560603E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9655041103660E+03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.2643527757197E+01
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4255,163 +4186,77 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.8249138386130E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.5665824775746E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.5813599491459E-04
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2001156865405E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.7429094803190E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.1352585605422E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5693330193283E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.9690478564843E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.1983359684059E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.3635197224360E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.4406350647829E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6147328447246E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.0774920079800E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.0384297738190E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.2135314246503E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.1986378239452E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.4908277499962E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5104279261470E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8446396354585E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.3428222959637E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.8995007291426E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.2725005955509E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.3847122538803E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4221299017206E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0819365065796E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.8249138250581E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.5665826263287E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.5813607101720E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2001157752331E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.7429098838949E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.1352576964111E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5694030885787E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.9690479077912E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.1983359591824E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.3635196887178E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.4406339074230E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6147273182778E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.0774875217587E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.0384292090459E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.2135316700268E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.1986378235576E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.4908277500037E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.5104279262171E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8446396364621E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.3428222963364E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.8995007567897E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.2725005617328E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.3847122542216E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.4221299019254E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0819365081339E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -3.02729575348687E-18  3.35616017148734E-05
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.20228566286118E-19  6.11359000645135E-05
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.89396567006062E-18  3.35616002912240E-05
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -4.83147593113853E-18  6.11358920486299E-05
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =  -2.49800180540660E-15  4.10108399308005E-02
  cg2d: Sum(rhs),rhsMax =   8.13932254928318E-15  4.56571171210609E-02
  cg2d: Sum(rhs),rhsMax =   4.16333634234434E-15  4.87116106300475E-02
  cg2d: Sum(rhs),rhsMax =   5.81756864903582E-14  4.97483791442106E-02
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.34458719799990E-18  9.30047782264631E-05
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -5.20078229614140E-18  9.30047609930503E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2968520425815E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3026968300815E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.3529122708652E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.1809944414110E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.7545877498985E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.3648772662890E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2506065199873E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.9215034472236E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.2014084911962E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.6382169409038E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.5670848722458E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -7.2377541696784E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.9532722711877E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.3717306867731E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.4549437963973E-08
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.9353426736058E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.5428003612819E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7235698831929E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   9.9088366079390E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.1579604660209E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2968520489389E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3026968134189E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.3529124536644E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.1809944375106E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.7545877599297E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.3648772605168E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2506065317869E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -6.9215035757057E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.2014084838166E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.6382169374926E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.5670848722399E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -7.2377541425044E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.9532722711980E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.3717306867702E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.4549437963824E-08
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.9353426740137E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.5428004027385E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7235698838410E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   9.9088366085913E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.1579604669208E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.3778222964156E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.5865031678554E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   4.6261085318764E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.8730479423473E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.9424224637819E-09
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.4162955458749E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.5376181486675E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   1.9177748311900E-04
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2641880883227E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2194745174504E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.1478404641807E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -8.9299614628048E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -6.8483237892299E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2792498236802E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.1846962694637E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   6.4288096993120E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -9.8321997858223E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -6.1369484376053E-06
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   4.1984103000219E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.7293879002085E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2354117946729E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0880555277913E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -3.7545685524965E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.4161814413093E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.3993963436667E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.3982762471406E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.0727939397178E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   6.6132091641608E-08
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.6776488198521E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.1961073215845E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.0054896816330E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.4828998332013E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3692142454921E-02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.0331777931957E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.4295596801843E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.5428003612819E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.9353426736058E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7235698831929E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   9.9088366079390E+03
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.1579604660209E+01
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   5.5511119068674E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1286778747961E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3262777644121E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.0197161385449E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.5418099172009E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   7.2377541696784E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.5670848722458E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.9532722711877E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3717306867731E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.4549437963973E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.5428003612819E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.9353426736058E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7235698831929E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   9.9088366079390E+03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.1579604660209E+01
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4423,158 +4268,72 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   9.8684724638398E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.5719136759881E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2894635856365E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3046265209375E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.6586792888977E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.2020065022480E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4525244942818E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.7810194304361E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.3611651244599E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5473179714194E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.4481346902186E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2115989654778E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.5123088779555E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2418504823442E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.3722101782079E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.3386038462999E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.0459457937453E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.5316367236351E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.7187172191311E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3557626917883E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.8893419449307E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.8543531257136E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.7813099602465E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.7865830173724E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2996390520225E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   9.8683937073297E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.5719137000853E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -1.2894641085110E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3046265279063E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.6586792403795E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.2020063630988E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4525241897777E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   1.7810192844728E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.3611651149993E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.5473179438154E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.4481346149017E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2115989422568E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.5123083687113E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2418504649629E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.3722102019680E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.3386038416596E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.0459457934909E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.5316367237677E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.7187172191214E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3557626916033E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.8893419363253E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.8543531249891E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.7813099609321E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.7865830166768E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.2996390540725E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.79659236876851E-18  1.27414982274332E-04
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -3.41862497511836E-18  1.62830216162888E-04
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.37219337455197E-17  1.98180025122224E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   5.16690097825123E-18  1.27414955251921E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   3.01882542401433E-18  1.62830176209548E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -7.82658443262974E-19  1.98179982526499E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.8714602162422E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.0201515592666E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.6134242542414E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.8778462981686E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9058031097945E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.0965922523405E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.2977258844038E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.2934112161131E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.8524462604111E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.6196848227175E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.5044462861154E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.1058019209738E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3123833957084E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.2174822425960E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.5481850714715E-08
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.1320835171870E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -4.3670395950260E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.1284943137608E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.4257550460704E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1602879394227E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.8714602371652E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.0201515646159E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.6134241056679E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.8778462226844E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9058029890579E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.0965922962144E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.2977258738150E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -1.2934111946561E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.8524462016813E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.6196847248104E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.5044462861201E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.1058019204582E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3123833957886E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.2174822425913E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.5481850714559E-08
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.1320835174800E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -4.3670396098310E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.1284943027856E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.4257550464304E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1602879396511E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.1147387870487E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -5.7105948418540E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   6.2418159025707E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.6374555417537E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.2625956841277E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.2705668199551E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -8.3048617357170E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =   6.7318748963269E-05
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4817992159402E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   3.8207457849559E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   8.1272545249216E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.4447340385797E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =  -1.2799386680617E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.4768021491284E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   3.7377752705760E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.2023120787073E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.5863286232020E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.4505358607864E-05
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.1594457186372E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.3255083268320E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.7603951700615E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.3683490377210E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -5.9603382789540E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.8025319702747E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0807262513781E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.6105869013262E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.8945207670473E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -3.0780436520416E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6514856286126E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.2748322056521E-07
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.5711949919574E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.1155258321159E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.4577827539794E-02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.1911132153954E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.9845270909134E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   4.3670395950260E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.1320835171870E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.1284943137608E+02
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.4257550460704E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1602879394227E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.0334500491522E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.8057832729991E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.4447804862923E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.6484197401207E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.0939230309710E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.1058019209738E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5044462861154E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.3123833957084E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.2174822425960E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.5481850714715E-08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.3670395950260E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.1320835171870E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   4.1284943137608E+02
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.4257550460704E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1602879394227E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -4589,31 +4348,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.0229491497922E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.2682717204360E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.7491459258773E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.5173884276569E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.7648169578866E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.5190521237511E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8465168149022E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.7598925099904E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6731943371235E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6505755592517E-04
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.0229491894863E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.2682717566169E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.7491460382027E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.5173884388422E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.7648169144829E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.5190520870739E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.8465167685680E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   2.7598932160729E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6731943447113E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.6505755562471E-04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.4038083237266E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.4537263516015E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -8.5203014471578E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.6694218416760E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1642437992636E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   8.6251812063491E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5631803010437E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2214259277537E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   5.6572600988621E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9896294613994E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.4038083177268E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.4537263500408E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -8.5203014472913E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.6694218412163E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1642437981966E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   8.6251812314258E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5631802968817E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2214259278444E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   5.6572600942577E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.9896294405303E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4959,231 +4718,231 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5302.3805320560932
-(PID.TID 0000.0001)         System time:   7.5806401371955872
-(PID.TID 0000.0001)     Wall clock time:   5336.7704648971558
+(PID.TID 0000.0001)           User time:   3921.8517138659954
+(PID.TID 0000.0001)         System time:   9.8710643649101257
+(PID.TID 0000.0001)     Wall clock time:   3951.0284008979797
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.864517003297806
-(PID.TID 0000.0001)         System time:  0.65788000822067261
-(PID.TID 0000.0001)     Wall clock time:   14.472150087356567
+(PID.TID 0000.0001)           User time:   9.6023608148097992
+(PID.TID 0000.0001)         System time:  0.78391396999359131
+(PID.TID 0000.0001)     Wall clock time:   11.994705915451050
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2297.0269470214844
-(PID.TID 0000.0001)         System time:   3.2292671203613281
-(PID.TID 0000.0001)     Wall clock time:   2315.2598340511322
+(PID.TID 0000.0001)           User time:   1639.9154481887817
+(PID.TID 0000.0001)         System time:   3.9233487844467163
+(PID.TID 0000.0001)     Wall clock time:   1656.2442090511322
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   393.25616455078125
-(PID.TID 0000.0001)         System time:  0.57544791698455811
-(PID.TID 0000.0001)     Wall clock time:   396.65479445457458
+(PID.TID 0000.0001)           User time:   307.31472778320312
+(PID.TID 0000.0001)         System time:  0.67969989776611328
+(PID.TID 0000.0001)     Wall clock time:   309.16874742507935
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1546325683593750
-(PID.TID 0000.0001)         System time:   2.0384788513183594E-005
-(PID.TID 0000.0001)     Wall clock time:   8.1660764217376709
+(PID.TID 0000.0001)           User time:   6.1375427246093750
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   6.1406610012054443
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7435302734375000
-(PID.TID 0000.0001)         System time:   5.2900791168212891E-002
-(PID.TID 0000.0001)     Wall clock time:   5.4256272315979004
+(PID.TID 0000.0001)           User time:   6.5414123535156250
+(PID.TID 0000.0001)         System time:   5.5940628051757812E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8580591678619385
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.0481567382812500
-(PID.TID 0000.0001)         System time:   3.0965685844421387E-002
-(PID.TID 0000.0001)     Wall clock time:   4.4543797969818115
+(PID.TID 0000.0001)           User time:   6.0045471191406250
+(PID.TID 0000.0001)         System time:   2.8937339782714844E-002
+(PID.TID 0000.0001)     Wall clock time:   6.2553172111511230
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.2277832031250000E-003
-(PID.TID 0000.0001)         System time:   9.9396705627441406E-004
-(PID.TID 0000.0001)     Wall clock time:   9.7298622131347656E-004
+(PID.TID 0000.0001)           User time:   1.5258789062500000E-004
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   8.8453292846679688E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60928344726562500
-(PID.TID 0000.0001)         System time:   1.5735626220703125E-005
-(PID.TID 0000.0001)     Wall clock time:  0.61239385604858398
+(PID.TID 0000.0001)           User time:  0.46350097656250000
+(PID.TID 0000.0001)         System time:   6.9141387939453125E-006
+(PID.TID 0000.0001)     Wall clock time:  0.46431159973144531
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25427246093750000
-(PID.TID 0000.0001)         System time:   7.6293945312500000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25741982460021973
+(PID.TID 0000.0001)           User time:  0.21276855468750000
+(PID.TID 0000.0001)         System time:   1.3589859008789062E-005
+(PID.TID 0000.0001)     Wall clock time:  0.21390438079833984
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.722473144531250
-(PID.TID 0000.0001)         System time:   6.9959163665771484E-003
-(PID.TID 0000.0001)     Wall clock time:   13.743909358978271
+(PID.TID 0000.0001)           User time:   11.522369384765625
+(PID.TID 0000.0001)         System time:   1.2995719909667969E-002
+(PID.TID 0000.0001)     Wall clock time:   11.548506498336792
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   116.52664184570312
-(PID.TID 0000.0001)         System time:   4.0315389633178711E-003
-(PID.TID 0000.0001)     Wall clock time:   116.79773449897766
+(PID.TID 0000.0001)           User time:   89.406280517578125
+(PID.TID 0000.0001)         System time:   2.0043849945068359E-003
+(PID.TID 0000.0001)     Wall clock time:   89.481272935867310
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.5117187500000000
-(PID.TID 0000.0001)         System time:   7.0333480834960938E-006
-(PID.TID 0000.0001)     Wall clock time:   3.5177741050720215
+(PID.TID 0000.0001)           User time:   1.8663024902343750
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   1.8668582439422607
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   19.171386718750000
-(PID.TID 0000.0001)         System time:   3.9919614791870117E-003
-(PID.TID 0000.0001)     Wall clock time:   19.198579788208008
+(PID.TID 0000.0001)           User time:   14.691040039062500
+(PID.TID 0000.0001)         System time:   9.9794864654541016E-003
+(PID.TID 0000.0001)     Wall clock time:   14.707982301712036
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6205749511718750
-(PID.TID 0000.0001)         System time:   1.0251998901367188E-005
-(PID.TID 0000.0001)     Wall clock time:   2.6240954399108887
+(PID.TID 0000.0001)           User time:   2.1006469726562500
+(PID.TID 0000.0001)         System time:   1.0013580322265625E-005
+(PID.TID 0000.0001)     Wall clock time:   2.1015076637268066
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9444580078125000
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   4.9500520229339600
+(PID.TID 0000.0001)           User time:   3.8640747070312500
+(PID.TID 0000.0001)         System time:   1.0063648223876953E-003
+(PID.TID 0000.0001)     Wall clock time:   3.8685390949249268
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31677246093750000
-(PID.TID 0000.0001)         System time:   9.9992752075195312E-004
-(PID.TID 0000.0001)     Wall clock time:  0.31554675102233887
+(PID.TID 0000.0001)           User time:  0.79296875000000000
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:  0.79409003257751465
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.3288574218750000
-(PID.TID 0000.0001)         System time:   1.0068416595458984E-003
-(PID.TID 0000.0001)     Wall clock time:   7.3390567302703857
+(PID.TID 0000.0001)           User time:   7.1335754394531250
+(PID.TID 0000.0001)         System time:   1.7978906631469727E-002
+(PID.TID 0000.0001)     Wall clock time:   7.1557860374450684
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   83.738006591796875
-(PID.TID 0000.0001)         System time:   2.0098686218261719E-003
-(PID.TID 0000.0001)     Wall clock time:   83.945553779602051
+(PID.TID 0000.0001)           User time:   64.991882324218750
+(PID.TID 0000.0001)         System time:   2.0139217376708984E-003
+(PID.TID 0000.0001)     Wall clock time:   65.039625644683838
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7138671875000000E-004
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.2005729675292969E-004
+(PID.TID 0000.0001)           User time:   2.1362304687500000E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.9359283447265625E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.70944213867187500
+(PID.TID 0000.0001)           User time:  0.52584838867187500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.70997309684753418
+(PID.TID 0000.0001)     Wall clock time:  0.52535367012023926
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7138671875000000E-004
+(PID.TID 0000.0001)           User time:   7.0190429687500000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9764595031738281E-004
+(PID.TID 0000.0001)     Wall clock time:   8.5067749023437500E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0288085937500000
-(PID.TID 0000.0001)         System time:  0.12384593486785889
-(PID.TID 0000.0001)     Wall clock time:   2.4690527915954590
+(PID.TID 0000.0001)           User time:   1.7690429687500000
+(PID.TID 0000.0001)         System time:  0.14592719078063965
+(PID.TID 0000.0001)     Wall clock time:   2.1855649948120117
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5979309082031250
-(PID.TID 0000.0001)         System time:  0.37156498432159424
-(PID.TID 0000.0001)     Wall clock time:   3.6559841632843018
+(PID.TID 0000.0001)           User time:   2.3121948242187500
+(PID.TID 0000.0001)         System time:  0.43177986145019531
+(PID.TID 0000.0001)     Wall clock time:   3.1768958568572998
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.447631835937500
-(PID.TID 0000.0001)         System time:  0.61831474304199219
-(PID.TID 0000.0001)     Wall clock time:   24.171561956405640
+(PID.TID 0000.0001)           User time:   19.203796386718750
+(PID.TID 0000.0001)         System time:  0.67900776863098145
+(PID.TID 0000.0001)     Wall clock time:   20.668752670288086
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   8.1665649414062500
-(PID.TID 0000.0001)         System time:  0.14186978340148926
-(PID.TID 0000.0001)     Wall clock time:   8.3386709690093994
+(PID.TID 0000.0001)           User time:   6.8823242187500000
+(PID.TID 0000.0001)         System time:  0.16798663139343262
+(PID.TID 0000.0001)     Wall clock time:   7.0759069919586182
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6640625000000000
-(PID.TID 0000.0001)         System time:   8.8906764984130859E-002
-(PID.TID 0000.0001)     Wall clock time:   3.9102711677551270
+(PID.TID 0000.0001)           User time:   3.0576171875000000
+(PID.TID 0000.0001)         System time:  0.12199306488037109
+(PID.TID 0000.0001)     Wall clock time:   3.2725441455841064
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6794433593750000
-(PID.TID 0000.0001)         System time:   7.2937011718750000E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8310668468475342
+(PID.TID 0000.0001)           User time:   3.0622558593750000
+(PID.TID 0000.0001)         System time:   8.3992958068847656E-002
+(PID.TID 0000.0001)     Wall clock time:   3.2361438274383545
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2987.1455078125000
-(PID.TID 0000.0001)         System time:   3.5316252708435059
-(PID.TID 0000.0001)     Wall clock time:   2999.2970230579376
+(PID.TID 0000.0001)           User time:   2266.2139892578125
+(PID.TID 0000.0001)         System time:   4.9577975273132324
+(PID.TID 0000.0001)     Wall clock time:   2276.2806949615479
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2641.3352050781250
-(PID.TID 0000.0001)         System time:   2.5106329917907715
-(PID.TID 0000.0001)     Wall clock time:   2650.1996867656708
+(PID.TID 0000.0001)           User time:   1995.7756347656250
+(PID.TID 0000.0001)         System time:   3.6887946128845215
+(PID.TID 0000.0001)     Wall clock time:   2002.9720191955566
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   345.52856445312500
-(PID.TID 0000.0001)         System time:   1.0070018768310547
-(PID.TID 0000.0001)     Wall clock time:   348.76088094711304
+(PID.TID 0000.0001)           User time:   270.20849609375000
+(PID.TID 0000.0001)         System time:   1.1600542068481445
+(PID.TID 0000.0001)     Wall clock time:   272.92626166343689
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4575195312500000
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   5.4629163742065430
+(PID.TID 0000.0001)           User time:   4.0084228515625000
+(PID.TID 0000.0001)         System time:   1.0027885437011719E-003
+(PID.TID 0000.0001)     Wall clock time:   4.0172531604766846
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7578125000000000E-002
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.8658876419067383E-002
+(PID.TID 0000.0001)           User time:   1.7089843750000000E-002
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   1.6929626464843750E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   306.14453125000000
-(PID.TID 0000.0001)         System time:   5.3981781005859375E-002
-(PID.TID 0000.0001)     Wall clock time:   306.77607846260071
+(PID.TID 0000.0001)           User time:   237.54797363281250
+(PID.TID 0000.0001)         System time:   6.9999694824218750E-002
+(PID.TID 0000.0001)     Wall clock time:   237.82835698127747
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8991699218750000
-(PID.TID 0000.0001)         System time:  0.29467535018920898
-(PID.TID 0000.0001)     Wall clock time:   6.7274930477142334
+(PID.TID 0000.0001)           User time:   5.3659667968750000
+(PID.TID 0000.0001)         System time:  0.35100603103637695
+(PID.TID 0000.0001)     Wall clock time:   6.2996382713317871
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.1738281250000000E-003
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3689270019531250E-003
+(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   2.1753311157226562E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   27.239257812500000
-(PID.TID 0000.0001)         System time:  0.65833234786987305
-(PID.TID 0000.0001)     Wall clock time:   28.955294847488403
+(PID.TID 0000.0001)           User time:   23.202148437500000
+(PID.TID 0000.0001)         System time:  0.73503637313842773
+(PID.TID 0000.0001)     Wall clock time:   24.689206123352051
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.12744140625000000
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:  0.17822480201721191
+(PID.TID 0000.0001)           User time:   2.7832031250000000E-002
+(PID.TID 0000.0001)         System time:   2.0027160644531250E-003
+(PID.TID 0000.0001)     Wall clock time:   3.5661935806274414E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -5223,9 +4982,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         901434
+(PID.TID 0000.0001) //            No. barriers =         900772
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         901434
+(PID.TID 0000.0001) //     Total barrier spins =         900772
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecco_v4.txt
+++ b/global_oce_llc90/results/output_adm.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68i
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node016
-(PID.TID 0000.0001) // Build date:        Wed May  5 17:54:00 EDT 2021
+(PID.TID 0000.0001) // Build host:        node143
+(PID.TID 0000.0001) // Build date:        Sun May  8 00:44:45 EDT 2022
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node016
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node143
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -194,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -627,58 +627,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -838,6 +838,9 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dFullAdjoint = /* use full hand written cg2d adjoint (no approximation) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
@@ -1021,25 +1024,29 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># =======================
+(PID.TID 0000.0001) ># pkg SMOOTH parameters :
+(PID.TID 0000.0001) ># =======================
 (PID.TID 0000.0001) > &SMOOTH_NML
-(PID.TID 0000.0001) > smooth2Dnbt(1)=300
-(PID.TID 0000.0001) > smooth2Dtype(1)=1
-(PID.TID 0000.0001) > smooth2Dsize(1)=2
-(PID.TID 0000.0001) > smooth2Dfilter(1)=0
-(PID.TID 0000.0001) > smooth3Dnbt(1)=300
-(PID.TID 0000.0001) > smooth3DtypeH(1)=1
-(PID.TID 0000.0001) > smooth3DsizeH(1)=3
-(PID.TID 0000.0001) > smooth3DtypeZ(1)=1
-(PID.TID 0000.0001) > smooth3DsizeZ(1)=3
-(PID.TID 0000.0001) > smooth3Dfilter(1)=0
+(PID.TID 0000.0001) > smooth2Dnbt(1)=300,
+(PID.TID 0000.0001) > smooth2Dtype(1)=1,
+(PID.TID 0000.0001) > smooth2Dsize(1)=2,
+(PID.TID 0000.0001) > smooth2Dfilter(1)=0,
+(PID.TID 0000.0001) > smooth3Dnbt(1)=300,
+(PID.TID 0000.0001) >#-
+(PID.TID 0000.0001) > smooth3DtypeH(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeH(1)=3,
+(PID.TID 0000.0001) > smooth3DtypeZ(1)=1,
+(PID.TID 0000.0001) > smooth3DsizeZ(1)=3,
+(PID.TID 0000.0001) > smooth3Dfilter(1)=0,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SMOOTH_READPARMS: finished reading data.smooth
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // pkg/smooth configuration
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.
-(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.
+(PID.TID 0000.0001) smooth 2D parameters:  1   300    0.    0.maskC
+(PID.TID 0000.0001) smooth 3D parameters:  1   300    0.    0.    0.maskC
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of pkg/smooth config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -1496,6 +1503,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 1.080000000000000E+04
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1752,6 +1762,7 @@
 (PID.TID 0000.0001)  preprocess = clim
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 8) = saltclim
@@ -1762,6 +1773,7 @@
 (PID.TID 0000.0001)  preprocess = clim
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(11) = sshv4-mdt
@@ -1772,6 +1784,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag = -1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(15) = sshv4-lsc
@@ -1781,6 +1794,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag = -1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(16) = sshv4-gmsl
@@ -1789,6 +1803,7 @@
 (PID.TID 0000.0001)  error file =
 (PID.TID 0000.0001)  gencost_flag = -1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(17) = sss_repeat
@@ -1798,6 +1813,7 @@
 (PID.TID 0000.0001)  error file = sigma_surf_0p5.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  0
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  3
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
@@ -3058,17 +3074,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -3076,10 +3095,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3271,8 +3290,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3289,7 +3308,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3326,8 +3345,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3342,6 +3361,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -5217,116 +5239,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.71050543121376E-18  1.83998182747982E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -4.83825219471656E-18  1.83998478083479E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.8758899369461E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.6687258099322E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0738515875897E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0034051363709E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7911886422220E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2851323347224E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.2899846458991E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4325526564714E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8185245114819E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6464240404793E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.8758899076575E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.6687258257338E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0738515480811E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0034051364115E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7911886735964E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2851323939449E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.2899845997103E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4325524309879E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8185245089395E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6464240843005E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4801456261814E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4079817633290E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.8226351576354E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0664897132867E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2870936147529E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1079833601456E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.8431569788541E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6682919101314E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4392367811590E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1823452132892E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1079833603842E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.8431569785755E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6682919101472E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4392367813318E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1823452133833E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.9283368167650E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.3242899150089E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.4329942081556E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.3732614063064E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.4516737638032E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4531181932778E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0740345742281E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0311218656433E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7346589953662E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7106493136070E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.9875791185885E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9336593364647E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.3093939516737E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5677189093854E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7880723996945E-05
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6126396016881E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9676558494346E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.3677977672729E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9752704117103E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6880315603269E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0663747102484E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.1881558296345E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9098481616668E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3204884507762E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6539349149534E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.8431569788541E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1079833601456E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6682919101314E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4392367811590E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1823452132892E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.9759258042614E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.8428120675245E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.3691916840430E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1118454268430E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0951498317903E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.2757423104292E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.3757412573960E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.7679561029063E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.8544950218881E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2484808063103E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.8431569788541E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1079833601456E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6682919101314E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4392367811590E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1823452132892E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5338,31 +5284,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9135930596408E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.6551970829961E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3895548809321E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544229111382E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4448086269833E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2879846510821E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4246597837622E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5577525868682E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2799629156548E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.2897168701688E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.1637905010133E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.6643200153683E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   7.3241495356222E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4515807843473E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2286869688428E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580719837999E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705323600726E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557545958153E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247710503101E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1000350673150E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475534218075E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752403227068E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5936296997748E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306503522320E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0380578674820E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9135930618102E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.6551970368458E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3895552762193E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544229312070E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4448086337136E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2879826184424E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4246599193513E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5577521598175E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2799629512132E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.2897170568780E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.1637903952238E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.6643211526486E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   7.3241361251457E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4515807854006E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2286868883083E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580719838208E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705323600902E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557545958149E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247710503070E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1000350673448E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475534218066E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752403227138E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5936296997725E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306503522510E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0380578674678E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5399,116 +5345,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.97866896478605E-18  3.43198734061423E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -8.99887803162969E-18  3.43198354435765E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9995028854331E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1176522333010E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1377715007240E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9719156506581E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9228170512808E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4388953106296E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9384174643432E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6629102784185E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3362660182616E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4641771469180E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.9189952674226E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8072001481306E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.8429890693585E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4053262908028E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5588195400337E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1865934339719E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -5.7561083877836E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.2813928390479E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0840648398440E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3528772208326E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9995028882219E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1176522478164E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1377714544541E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9719156134790E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9228170609195E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4388953270509E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9384174747745E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6629103245047E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3362659320166E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4641769823869E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.9189952672961E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8072001486419E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.8429890691424E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4053262908036E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5588195400391E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1865934352013E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -5.7561083883119E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.2813928390379E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0840648398682E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3528772207589E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.7042498688252E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.2583960552396E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.6274967356742E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.2517409436911E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.8358707330491E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4983255957851E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.1725264302623E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0098741384199E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2573906551208E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5311786322997E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3773949691577E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5327290878263E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6295665766392E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6821767165086E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4874920424319E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3691284724346E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6769991280096E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1633999955376E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7791270322055E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3381184017690E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7208213159439E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3639019426031E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0229978976175E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6020684821232E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2026105427586E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   5.7561083877836E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1865934339719E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.2813928390479E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0840648398440E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3528772208326E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9419234171854E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6582871504927E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.5551493232197E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2168656333782E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1805693780096E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5429841436867E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.7114254093999E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   7.6076993972776E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3631665020787E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4820549538327E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   5.7561083877836E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1865934339719E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.2813928390479E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0840648398440E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3528772208326E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5520,31 +5390,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0667656109274E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3542603781008E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5750442943458E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8196315148899E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7875723133133E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255694116981E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2647771242968E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1391401975753E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6491561781347E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7707143276532E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.1022640078354E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -9.9682470814772E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.8201405529672E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4698082046678E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   7.6286861433825E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826306858980E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046795622960E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336343615909E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362557213243E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6406366628015E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211604918392E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164899184870E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902020131784E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9451818924714E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5556511146799E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0667652357989E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3542603778305E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5750449081478E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8196315246697E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7875723463417E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255691930690E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2647771047350E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1391400871205E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6491562409717E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7707143479657E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.1022638346504E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -9.9682472557413E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.8201414943904E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4698082333183E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   7.6286861393463E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826306858859E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046795623368E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336343615860E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362557213211E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6406366627435E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211604918370E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164899185001E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902020131535E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9451818925280E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5556511147621E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5581,116 +5451,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   8.40256683676266E-18  8.65048531509537E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -8.23993651088983E-18  8.65047188136703E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.6279083248426E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2237190967463E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0107788777493E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1604310068420E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9416583620302E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9189793717794E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0084405005862E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2474846284866E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0182171253877E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0469870820264E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0316555898603E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3197624098651E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.6684796466827E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0987064433763E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8188223226663E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2279701454202E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.7213238184832E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.8532385169142E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6216682738011E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5133726350699E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.6279083309074E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2237191421759E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0107787113928E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1604310066317E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9416584245012E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9189795372183E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0084405413430E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2474844452424E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0182171168287E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0469869358830E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0316555898360E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3197624099246E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.6684796466377E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0987064433777E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8188223226714E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2279701429822E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.7213238178917E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.8532385168634E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6216682737862E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5133726346400E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4335966940075E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8788364957191E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.2653259258585E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8492611868251E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.1700670051735E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8660503833875E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2677776380290E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7712569301726E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0342282665224E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.8072899298828E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6300632829017E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3105539347820E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1892072175880E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0434719546211E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6526693723497E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4260707228637E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299403720935E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8660940078146E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6519235855505E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9727963797760E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5396233221289E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.6079777333666E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2773239566631E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8726639869267E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3750212175373E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   8.7213238184832E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2279701454202E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.8532385169142E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6216682738011E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5133726350699E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1898259257292E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.4457269203445E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1647857166616E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8189004908415E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2584400678367E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2801695375692E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0007059221645E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.6184252572823E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0357452500750E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.7042576529863E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   8.7213238184832E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2279701454202E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.8532385169142E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6216682738011E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5133726350699E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5702,31 +5496,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4777670008827E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6379963814218E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7758013576422E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2388282729193E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3373516450593E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327164350506E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4171259132144E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3669397309840E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9848876949320E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3440475820800E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.7470318870572E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6633751594756E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.5009381491078E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.1286095000319E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3555815509055E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084958526493E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379699085804E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1115200817193E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4469809850095E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171616611024E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946318020123E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557085891735E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864639509249E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2591519378424E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721071046217E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4777667339951E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6379963644605E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7758014982246E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2388283067232E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3373516986264E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327176872168E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4171258591282E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3669394240789E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9848878315495E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3440476132433E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.7470324981638E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6633749718893E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.5009387413580E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.1286094501845E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3555815376248E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084958527220E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379699084896E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1115200817101E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4469809850042E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171616610675E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946318020047E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557085914917E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864639508826E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2591519379558E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721071045964E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5763,116 +5557,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -7.80625564189563E-18  1.48391655861559E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  1.48391651194492E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4797678974140E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5828915613610E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5330685316710E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8655548672628E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3543817914778E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.3070758890077E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7729335862215E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3828597235329E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6179167814681E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2159854774284E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3672268095354E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7578669897267E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6579729703412E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7881285077753E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0700771561458E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2107420058163E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.1734356274896E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0397899305024E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1564325750820E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6673068727494E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4797678376713E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5828917133581E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5330684282438E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8655548578669E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3543817778597E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.3070761858382E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7729336665856E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3828593714677E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6179167747900E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2159854555591E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3672268095262E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7578669897885E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6579729703391E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7881285077768E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0700771561278E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2107420050301E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.1734356275533E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0397899304915E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1564325750408E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6673068724897E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8831195676479E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.4946396874480E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   8.1645487131557E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.4333949540593E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   5.4666639983233E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3659944976062E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0756656129737E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1624626179823E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6776052272880E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5621138970655E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5667418153337E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0623118062154E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2990546760450E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4506904208674E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2901259132320E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9278830449193E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898435444952E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.6014648993513E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5234785785145E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6290764725961E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3320791532239E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.9683216645617E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6228732309785E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1513647445910E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8387734693235E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.1734356274896E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2107420058163E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0397899305024E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1564325750820E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6673068727494E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5844814146830E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1204297641203E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.8466998055916E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4182636893775E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3304466554771E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7051309800349E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3262100052493E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.5782337812310E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7044846525421E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.9179748414614E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.1734356274896E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2107420058163E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0397899305024E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1564325750820E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6673068727494E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
@@ -5889,31 +5607,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2469354087709E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2827672314149E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7078645293542E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1467055019812E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2121766218041E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6981947415104E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8501439738455E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0358563944396E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174223872684E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2709865632243E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.5883803668365E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.8625067421442E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.3886582070263E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.4340888957800E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.1162587750100E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332480671457E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703351750621E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893861396555E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5568871250668E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692310569296E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679408844988E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952061633547E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9823399124595E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572618291171E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5877246890138E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2469351312436E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2827671951645E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7078651517372E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1467055086878E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2121766725460E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6981950411676E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8501434450969E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0358558823424E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174224072855E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2709866074407E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.5883824733814E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.8625076598237E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.3886589922372E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.4340889854878E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.1162588300354E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332480671114E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703351749248E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893861396400E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5568871250654E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692310568705E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679408844964E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952061665152E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9823399123919E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572618291352E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5877246888917E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5950,116 +5668,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -8.89045781438114E-18  2.12700156386073E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -3.03576608295941E-17  2.12700108595391E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8600140943421E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0950997398100E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3456554186319E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6891297881857E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8470429159115E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2093532620038E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2255014968746E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859405838521E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3201761144393E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6647799832291E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6982575706626E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1949357757113E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.5859782808232E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4747508567802E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.3122109521037E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.1075160385497E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.4805373146061E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2912231244552E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6854309912259E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8094767327777E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8600141650385E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0951001200105E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3456554003285E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6891297925196E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8470429506853E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2093533196941E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2255017928476E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859405430021E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3201761091927E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6647800025494E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6982575706644E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1949357770148E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.5859782808893E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4747508567817E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.3122109520600E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.1075160921686E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.4805373148873E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2912231244261E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6854309912788E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8094767350868E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.3195777501770E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.1061337237348E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.0888509770302E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.0066648431584E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.7249716469408E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.3156635253562E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.9626217883980E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2939112627101E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4355264215678E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0677597505367E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8696397461624E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.7983720860548E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752421676536E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0973908565850E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0340397688450E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4415695500091E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3556007363895E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.3366007472245E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4000624961638E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3150836075995E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.0989870122305E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.1475728542463E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.1006438844960E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1453352328803E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3198492638159E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.4805373146061E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.1075160385497E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2912231244552E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6854309912259E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8094767327778E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9781199624435E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3931505712049E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.4879427670648E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0157291516211E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3963744595650E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1290877024399E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6473098435427E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.4783989323985E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3705083310768E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.1228446235406E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.4805373146061E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.1075160385497E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2912231244552E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6854309912259E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8094767327778E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -6071,31 +5713,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0415637361552E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2587745507645E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6445719276007E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6328915667709E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3261127709471E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745027702195E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5167261964454E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0862956193087E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6057007444720E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4609070615323E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.8144905637407E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3089173043266E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.6809554475260E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3351696278040E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0254493633048E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567483818839E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017181540489E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6672169755761E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6659746682313E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202292878963E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410546849798E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349671545443E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777756090213E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885584216966E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1029198270915E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0415629068531E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2587744983745E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6445725994890E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6328915747092E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3261128261828E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745029579459E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5167260162216E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0862951217712E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6057007649771E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4609071263937E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.8144904570473E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3089181203324E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.6809556004813E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3351696079157E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0254494148981E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567483817391E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017181539807E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6672169755442E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6659746682608E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202292878354E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410546850279E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349671575172E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777756090078E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885584217162E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1029198267800E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6132,116 +5774,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -2.79724160501260E-17  2.73193028507770E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -3.07913416985883E-17  2.73193076598066E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0254693517014E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6475876268829E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7489072544012E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6057944782375E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3476559269881E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1433198042228E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3983881100957E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5460354760838E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1113165580782E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1332084251991E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0174887574244E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6308728293783E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3962373380901E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1583406159201E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5450427071305E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.6025636545436E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.7646974313196E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5401201974998E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2098958057846E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9408959289305E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0254693813273E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6475882265736E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7489072059280E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6057944884131E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3476559476950E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1433197978053E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3983877665873E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5460354143219E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1113165337201E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1332083720943E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0174887574318E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6308728303104E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3962373383300E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1583406159213E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5450427070765E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.6025636870657E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.7646974307352E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5401201974653E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2098958058177E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9408959284970E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7438981293599E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.7173574746337E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3273612879853E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.5674569159937E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.9352045954397E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2767468005799E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.8573819609290E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6818471692760E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2854439494387E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4024872869128E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3846641300051E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7442291655488E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5333608152384E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8324104018058E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3707274332473E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9664372514837E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660911753061E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.0266587578439E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2875882210522E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0140267016203E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8407625530913E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.4164896586704E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3399752832635E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3795626771864E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8267447427287E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.7646974313196E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.6025636545436E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5401201974998E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2098958057846E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9408959289305E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3707065439655E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6582605287081E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.0521957962119E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6111496503640E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4565247133964E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5519466444970E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9569640947017E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.2643502179474E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0335903974425E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.3186914259166E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.7646974313196E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.6025636545436E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5401201974998E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2098958057846E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9408959289305E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -6253,31 +5819,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7943506924813E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5366733568503E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4567527158862E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1647452082352E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5956858087584E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190134564256E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3751277819551E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4180962979348E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1451313419764E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8168504071997E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0205314912310E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.9658933016879E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.0469243138794E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7840899889130E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0201487748772E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788639750645E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320716935130E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449660099298E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743073136511E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7702490120993E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139344090621E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749415509853E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572525557696E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6198390900189E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6182356444269E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7943495662000E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5366733207773E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4567536098640E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1647452218326E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5956858570082E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190137568384E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3751268597287E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4180958870289E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1451313619578E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8168505099254E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0205317565148E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.9658936884314E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.0469248688268E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7840899563507E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0201487477414E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788639742147E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320716937157E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449660098879E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743073137429E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7702490120048E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139344091629E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749415578249E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572525557534E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6198390900503E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6182356442081E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6314,116 +5880,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.49619899803000E-17  3.23777135165434E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -4.90059381963448E-17  3.23776925565403E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2507345381697E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.1084287222895E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1327366439986E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5947252578721E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8432475922299E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4724407312723E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4414086134162E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.8987699078360E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9779499273613E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6127899630873E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3321984982391E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0655626361390E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.4218849807799E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8370920473367E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7692026766278E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.1683477299418E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.0765888387199E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7809190809761E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7240878982131E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0293016237734E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2507345615079E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.1084294945918E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1327365729784E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5947252437327E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8432475587106E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4724407338280E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4414078514585E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.8987699031115E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9779499208262E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6127899255360E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3321984981648E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0655626368953E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.4218849810301E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8370920473372E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7692026765444E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.1683477192082E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.0765888387645E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7809190809222E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7240878982006E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0293016242194E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1565635780975E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.2614531735139E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6136908841944E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.1030042906018E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   9.0404243686312E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0101319186962E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.9992771397770E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0501375853708E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2070937724444E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7482912799120E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1920864816418E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6382739401770E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8848206521569E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6417644648835E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7283513337642E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4700406747830E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2823643751000E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.8215042253110E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1289980625213E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1622042207730E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.6944745974094E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.6500396856167E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5591839332732E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5969349848657E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2553506720180E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.0765888387199E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.1683477299418E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7809190809761E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7240878982131E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0293016237734E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7621988027388E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9205314374157E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.7718437040968E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2034708089762E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.5127567717328E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9735957570548E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2622325432919E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   5.2592284313566E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6919792859166E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.5061265963290E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.0765888387199E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.1683477299418E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7809190809761E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7240878982131E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0293016237734E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -6435,31 +5925,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807630490666E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090809427146E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0355508108109E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7262274936797E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1952240537119E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926435291812E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3864969354766E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0908725722583E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7179522391696E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2249499301408E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.4587774885268E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.8540262592182E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2587995442944E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2932642793558E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.1235016730716E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994855308564E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613578314888E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2226213423125E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8819659636798E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0192668984356E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865369717264E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150565491997E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4366613156865E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8511194737161E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1340807092819E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807636340517E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090809471090E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0355516806878E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7262275105983E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1952240594564E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926451207677E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3864965582450E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0908724885034E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7179522535356E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2249499369936E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.4587771632586E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.8540246601735E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2587996094387E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2932642578866E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.1235016218500E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994855294406E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613578318395E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2226213422454E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8819659638804E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0192668983799E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865369718717E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150565563763E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4366613156609E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8511194737704E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1340807091315E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6496,116 +5986,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.12757025938492E-17  3.72673471234007E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -2.73218947466347E-17  3.72672899397703E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4545958681058E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.3369310670651E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4643102906605E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6396674780877E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3271216113108E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7866586909897E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2469960835762E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2301160971679E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9071578952467E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0997066468141E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6583926569315E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4987111711512E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.3444568936127E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.5041939342121E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9872243378374E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.7860817870414E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4242589731628E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0093233282469E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2331028810641E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1338335923600E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4545959011220E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.3369319127401E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4643102346658E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6396674579405E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3271215220249E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7866585955473E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2469959860029E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2301160689270E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9071578757037E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0997066078693E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6583926568027E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4987111721187E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.3444568941994E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.5041939342083E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9872243377150E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.7860817744155E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4242589727449E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0093233281541E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2331028809906E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1338335946813E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.5573126015235E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.9006295755961E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.1417484298967E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5995239732386E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0122563112758E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1712977020685E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.0696866045695E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3666033740404E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1847842200861E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0967458120037E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4335199820468E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3172472907549E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2156776885053E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5124465678026E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0975185724295E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9762168707699E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6904108825147E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.6624519357389E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9612343971917E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3195850526538E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1607758413598E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.8908601771760E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7888985732665E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8125676073953E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.6926688341971E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4242589731628E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.7860817870414E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0093233282469E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2331028810641E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1338335923600E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1523762547593E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1900080426187E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.1031775500117E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7880199880287E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5643499656384E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3937498360167E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5786408772236E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   7.1241231868042E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3390681161857E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6876076077023E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4242589731628E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.7860817870414E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0093233282469E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2331028810641E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1338335923600E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
@@ -6652,31 +6066,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9937273313224E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982179268149E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6438639231062E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473986543199E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3980350325314E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936322362497E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1469868352105E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3128261631226E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140779491590E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4308824554782E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0565947628821E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5025326360709E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3778443659886E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1859472226760E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8584518595009E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185076543007E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895466644077E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0001120198805E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9890506801006E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2674787361101E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588118224445E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552270981094E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6159714472906E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0824151555926E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516877202095E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9937259928514E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982179269647E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6438649532530E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473986642839E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3980350433527E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936321848914E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1469867976705E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3128260899965E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140779665323E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4308824541794E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0565950779218E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5025335846713E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3778445660979E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1859472086342E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8584518277555E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185076523597E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895466651015E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0001120197961E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9890506804135E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2674787362160E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588118227172E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552271031954E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6159714472599E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0824151556443E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516877199612E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6879,7 +6293,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150642730589D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150642730589E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217221736908E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217460155487E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.65408971533179E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
@@ -7019,7 +6433,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150700736972D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150700736972E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.85234189033508E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.85234367847443E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       = -7.39056272432208E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
@@ -7159,7 +6573,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150725407700D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150725407700E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19272053241730E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19272172451019E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.00992285273969E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
@@ -7299,7 +6713,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  global fc =  0.918150698368234D+07
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150698368234E+06
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455932617188E-01
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455992221832E-01
 (PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.47791613824666E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
@@ -7315,270 +6729,270 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   1  9.1815070591342E+06  9.1815073581238E+06  9.1815064273059E+06
-(PID.TID 0000.0001) grdchk output (g):   1     4.6540897153318E+01  7.3921722173691E-01 -6.1959703568543E+01
+(PID.TID 0000.0001) grdchk output (g):   1     4.6540897153318E+01  7.3921746015549E-01 -6.1959683262255E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   2  9.1815070591342E+06  9.1815068595585E+06  9.1815070073697E+06
-(PID.TID 0000.0001) grdchk output (g):   2    -7.3905627243221E+00  6.8523418903351E-01  1.1785455312360E+01
+(PID.TID 0000.0001) grdchk output (g):   2    -7.3905627243221E+00  6.8523436784744E-01  1.1785452497863E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   3  9.1815070591342E+06  9.1815068520924E+06  9.1815072540770E+06
-(PID.TID 0000.0001) grdchk output (g):   3    -2.0099228527397E+01  6.1927205324173E-01  3.3456217622259E+01
+(PID.TID 0000.0001) grdchk output (g):   3    -2.0099228527397E+01  6.1927217245102E-01  3.3456211374469E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
 (PID.TID 0000.0001) grdchk output (c):   4  9.1815070591342E+06  9.1815072792656E+06  9.1815069836823E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.4779161382467E+01  5.4545593261719E-01 -2.6095060294887E+01
+(PID.TID 0000.0001) grdchk output (g):   4     1.4779161382467E+01  5.4545599222183E-01 -2.6095057334077E+01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8007145685394E+01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8007135308190E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5165.1794047355652
-(PID.TID 0000.0001)         System time:   11.897560656070709
-(PID.TID 0000.0001)     Wall clock time:   5212.7467699050903
+(PID.TID 0000.0001)           User time:   4114.6382327377796
+(PID.TID 0000.0001)         System time:   11.644455373287201
+(PID.TID 0000.0001)     Wall clock time:   4146.5505251884460
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.813695073127747
-(PID.TID 0000.0001)         System time:  0.77099692821502686
-(PID.TID 0000.0001)     Wall clock time:   15.315376043319702
+(PID.TID 0000.0001)           User time:   11.024121433496475
+(PID.TID 0000.0001)         System time:  0.75727805495262146
+(PID.TID 0000.0001)     Wall clock time:   13.739370107650757
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2044.1891679763794
-(PID.TID 0000.0001)         System time:   5.0608608722686768
-(PID.TID 0000.0001)     Wall clock time:   2072.1896901130676
+(PID.TID 0000.0001)           User time:   1708.5532817840576
+(PID.TID 0000.0001)         System time:   4.5195938348770142
+(PID.TID 0000.0001)     Wall clock time:   1725.0967710018158
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   543.32949829101562
-(PID.TID 0000.0001)         System time:  0.77621769905090332
-(PID.TID 0000.0001)     Wall clock time:   547.69349408149719
+(PID.TID 0000.0001)           User time:   423.34573364257812
+(PID.TID 0000.0001)         System time:  0.73385119438171387
+(PID.TID 0000.0001)     Wall clock time:   426.22882413864136
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1670227050781250
-(PID.TID 0000.0001)         System time:   7.1525573730468750E-006
-(PID.TID 0000.0001)     Wall clock time:   8.1779236793518066
+(PID.TID 0000.0001)           User time:   6.1393432617187500
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   6.1398909091949463
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.4613342285156250
-(PID.TID 0000.0001)         System time:  0.12379193305969238
-(PID.TID 0000.0001)     Wall clock time:   6.0460829734802246
+(PID.TID 0000.0001)           User time:   6.1010437011718750
+(PID.TID 0000.0001)         System time:   9.9002599716186523E-002
+(PID.TID 0000.0001)     Wall clock time:   6.3533687591552734
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.6246032714843750
-(PID.TID 0000.0001)         System time:   9.0894222259521484E-002
-(PID.TID 0000.0001)     Wall clock time:   5.1373019218444824
+(PID.TID 0000.0001)           User time:   5.4201049804687500
+(PID.TID 0000.0001)         System time:   6.2055826187133789E-002
+(PID.TID 0000.0001)     Wall clock time:   5.5862576961517334
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7395019531250000E-003
-(PID.TID 0000.0001)         System time:   3.0994415283203125E-006
-(PID.TID 0000.0001)     Wall clock time:   9.1481208801269531E-004
+(PID.TID 0000.0001)           User time:   5.4931640625000000E-004
+(PID.TID 0000.0001)         System time:   9.9396705627441406E-004
+(PID.TID 0000.0001)     Wall clock time:   8.8763236999511719E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.61761474609375000
-(PID.TID 0000.0001)         System time:   1.0118484497070312E-003
-(PID.TID 0000.0001)     Wall clock time:  0.62047076225280762
+(PID.TID 0000.0001)           User time:  0.47528076171875000
+(PID.TID 0000.0001)         System time:   1.0206699371337891E-003
+(PID.TID 0000.0001)     Wall clock time:  0.47573447227478027
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25448608398437500
-(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25467181205749512
+(PID.TID 0000.0001)           User time:  0.21295166015625000
+(PID.TID 0000.0001)         System time:   1.7166137695312500E-005
+(PID.TID 0000.0001)     Wall clock time:  0.21383857727050781
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   131.00946044921875
-(PID.TID 0000.0001)         System time:   4.7953367233276367E-002
-(PID.TID 0000.0001)     Wall clock time:   131.30906605720520
+(PID.TID 0000.0001)           User time:   102.81030273437500
+(PID.TID 0000.0001)         System time:   5.2913427352905273E-002
+(PID.TID 0000.0001)     Wall clock time:   103.06543326377869
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   39.916198730468750
-(PID.TID 0000.0001)         System time:   3.1941890716552734E-002
-(PID.TID 0000.0001)     Wall clock time:   40.046990394592285
+(PID.TID 0000.0001)           User time:   31.618591308593750
+(PID.TID 0000.0001)         System time:   3.1926155090332031E-002
+(PID.TID 0000.0001)     Wall clock time:   31.804975986480713
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   37.345123291015625
-(PID.TID 0000.0001)         System time:   3.0938863754272461E-002
-(PID.TID 0000.0001)     Wall clock time:   37.447960138320923
+(PID.TID 0000.0001)           User time:   29.668762207031250
+(PID.TID 0000.0001)         System time:   2.8908491134643555E-002
+(PID.TID 0000.0001)     Wall clock time:   29.839739799499512
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   35.230316162109375
-(PID.TID 0000.0001)         System time:   5.0070285797119141E-003
-(PID.TID 0000.0001)     Wall clock time:   35.288981676101685
+(PID.TID 0000.0001)           User time:   26.139862060546875
+(PID.TID 0000.0001)         System time:   1.0159015655517578E-003
+(PID.TID 0000.0001)     Wall clock time:   26.154661893844604
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   117.83224487304688
-(PID.TID 0000.0001)         System time:   1.9931793212890625E-003
-(PID.TID 0000.0001)     Wall clock time:   118.01213693618774
+(PID.TID 0000.0001)           User time:   90.273468017578125
+(PID.TID 0000.0001)         System time:   4.9848556518554688E-003
+(PID.TID 0000.0001)     Wall clock time:   90.332365512847900
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0010375976562500
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   2.0052335262298584
+(PID.TID 0000.0001)           User time:   2.2960205078125000
+(PID.TID 0000.0001)         System time:   1.0013580322265625E-005
+(PID.TID 0000.0001)     Wall clock time:   2.2984681129455566
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.214050292968750
-(PID.TID 0000.0001)         System time:   9.9849700927734375E-003
-(PID.TID 0000.0001)     Wall clock time:   13.245513439178467
+(PID.TID 0000.0001)           User time:   11.376800537109375
+(PID.TID 0000.0001)         System time:   6.0062408447265625E-003
+(PID.TID 0000.0001)     Wall clock time:   11.391686677932739
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6199340820312500
-(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
-(PID.TID 0000.0001)     Wall clock time:   2.6209673881530762
+(PID.TID 0000.0001)           User time:   2.0982666015625000
+(PID.TID 0000.0001)         System time:   9.2077255249023438E-004
+(PID.TID 0000.0001)     Wall clock time:   2.1059541702270508
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8642272949218750
-(PID.TID 0000.0001)         System time:   3.3378601074218750E-006
-(PID.TID 0000.0001)     Wall clock time:   4.8720912933349609
+(PID.TID 0000.0001)           User time:   3.8683776855468750
+(PID.TID 0000.0001)         System time:   8.3446502685546875E-006
+(PID.TID 0000.0001)     Wall clock time:   3.8687660694122314
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35101318359375000
-(PID.TID 0000.0001)         System time:   2.3841857910156250E-006
-(PID.TID 0000.0001)     Wall clock time:  0.34997868537902832
+(PID.TID 0000.0001)           User time:  0.23242187500000000
+(PID.TID 0000.0001)         System time:   1.0027885437011719E-003
+(PID.TID 0000.0001)     Wall clock time:  0.23317146301269531
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   10.298889160156250
-(PID.TID 0000.0001)         System time:   1.2979745864868164E-002
-(PID.TID 0000.0001)     Wall clock time:   10.325238704681396
+(PID.TID 0000.0001)           User time:   5.0113525390625000
+(PID.TID 0000.0001)         System time:   1.0968923568725586E-002
+(PID.TID 0000.0001)     Wall clock time:   5.0261392593383789
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   119.93411254882812
-(PID.TID 0000.0001)         System time:   5.9981346130371094E-003
-(PID.TID 0000.0001)     Wall clock time:   120.58659982681274
+(PID.TID 0000.0001)           User time:   93.981201171875000
+(PID.TID 0000.0001)         System time:   3.0117034912109375E-003
+(PID.TID 0000.0001)     Wall clock time:   94.243011713027954
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3122558593750000E-003
+(PID.TID 0000.0001)           User time:   1.8310546875000000E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.4151496887207031E-004
+(PID.TID 0000.0001)     Wall clock time:   8.9025497436523438E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0609741210937500
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0620980262756348
+(PID.TID 0000.0001)           User time:  0.97308349609375000
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:  0.97355818748474121
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0190429687500000E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   9.1886520385742188E-004
+(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.8500976562500000E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9947509765625000
-(PID.TID 0000.0001)         System time:  0.14292597770690918
-(PID.TID 0000.0001)     Wall clock time:   2.7924988269805908
+(PID.TID 0000.0001)           User time:   2.2129516601562500
+(PID.TID 0000.0001)         System time:  0.13499402999877930
+(PID.TID 0000.0001)     Wall clock time:   2.6465494632720947
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0741882324218750
-(PID.TID 0000.0001)         System time:  0.42458105087280273
-(PID.TID 0000.0001)     Wall clock time:   4.4294097423553467
+(PID.TID 0000.0001)           User time:   2.6830749511718750
+(PID.TID 0000.0001)         System time:  0.41498398780822754
+(PID.TID 0000.0001)     Wall clock time:   3.7166821956634521
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   30.889190673828125
-(PID.TID 0000.0001)         System time:  0.83730268478393555
-(PID.TID 0000.0001)     Wall clock time:   33.231549263000488
+(PID.TID 0000.0001)           User time:   26.352630615234375
+(PID.TID 0000.0001)         System time:  0.90589570999145508
+(PID.TID 0000.0001)     Wall clock time:   28.170173406600952
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   7.7100830078125000
-(PID.TID 0000.0001)         System time:  0.15589308738708496
-(PID.TID 0000.0001)     Wall clock time:   7.9045157432556152
+(PID.TID 0000.0001)           User time:   6.8895568847656250
+(PID.TID 0000.0001)         System time:  0.15595579147338867
+(PID.TID 0000.0001)     Wall clock time:   7.0693445205688477
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6647949218750000
-(PID.TID 0000.0001)         System time:  0.12486314773559570
-(PID.TID 0000.0001)     Wall clock time:   3.9548799991607666
+(PID.TID 0000.0001)           User time:   3.0594482421875000
+(PID.TID 0000.0001)         System time:  0.11097717285156250
+(PID.TID 0000.0001)     Wall clock time:   3.2303359508514404
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6435546875000000
-(PID.TID 0000.0001)         System time:   8.5922241210937500E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8356411457061768
+(PID.TID 0000.0001)           User time:   3.0375976562500000
+(PID.TID 0000.0001)         System time:  0.10700511932373047
+(PID.TID 0000.0001)     Wall clock time:   3.2450160980224609
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3101.8679199218750
-(PID.TID 0000.0001)         System time:   5.8539824485778809
-(PID.TID 0000.0001)     Wall clock time:   3117.4510459899902
+(PID.TID 0000.0001)           User time:   2388.9636230468750
+(PID.TID 0000.0001)         System time:   6.1495852470397949
+(PID.TID 0000.0001)     Wall clock time:   2401.2389218807220
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2620.0974121093750
-(PID.TID 0000.0001)         System time:   3.9986462593078613
-(PID.TID 0000.0001)     Wall clock time:   2630.8883817195892
+(PID.TID 0000.0001)           User time:   2010.9022216796875
+(PID.TID 0000.0001)         System time:   4.2689809799194336
+(PID.TID 0000.0001)     Wall clock time:   2018.6668810844421
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   471.04101562500000
-(PID.TID 0000.0001)         System time:   1.3747816085815430
-(PID.TID 0000.0001)     Wall clock time:   474.67646813392639
+(PID.TID 0000.0001)           User time:   368.83483886718750
+(PID.TID 0000.0001)         System time:   1.4116501808166504
+(PID.TID 0000.0001)     Wall clock time:   372.10676431655884
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5078125000000000
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   5.5181679725646973
+(PID.TID 0000.0001)           User time:   4.0777587890625000
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:   4.0806746482849121
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8798828125000000E-002
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.8887519836425781E-002
+(PID.TID 0000.0001)           User time:   1.7211914062500000E-002
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   1.6993761062622070E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   424.62548828125000
-(PID.TID 0000.0001)         System time:  0.15482330322265625
-(PID.TID 0000.0001)     Wall clock time:   425.55639529228210
+(PID.TID 0000.0001)           User time:   329.80883789062500
+(PID.TID 0000.0001)         System time:  0.13584518432617188
+(PID.TID 0000.0001)     Wall clock time:   330.25045990943909
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.9020996093750000
-(PID.TID 0000.0001)         System time:  0.34568786621093750
-(PID.TID 0000.0001)     Wall clock time:   6.7598059177398682
+(PID.TID 0000.0001)           User time:   5.3073730468750000
+(PID.TID 0000.0001)         System time:  0.35691404342651367
+(PID.TID 0000.0001)     Wall clock time:   6.3964741230010986
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.4414062500000000E-003
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3720264434814453E-003
+(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
+(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
+(PID.TID 0000.0001)     Wall clock time:   2.1560192108154297E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   34.313232421875000
-(PID.TID 0000.0001)         System time:  0.87125778198242188
-(PID.TID 0000.0001)     Wall clock time:   36.141815900802612
+(PID.TID 0000.0001)           User time:   29.557495117187500
+(PID.TID 0000.0001)         System time:  0.91487741470336914
+(PID.TID 0000.0001)     Wall clock time:   31.285812854766846
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.1738281250000000E-002
-(PID.TID 0000.0001)         System time:   2.9973983764648438E-003
-(PID.TID 0000.0001)     Wall clock time:   3.9803981781005859E-002
+(PID.TID 0000.0001)           User time:   2.6855468750000000E-002
+(PID.TID 0000.0001)         System time:   3.9982795715332031E-003
+(PID.TID 0000.0001)     Wall clock time:   3.7813901901245117E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -7618,9 +7032,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         998836
+(PID.TID 0000.0001) //            No. barriers =        1019342
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         998836
+(PID.TID 0000.0001) //     Total barrier spins =        1019342
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecmwf.txt
+++ b/global_oce_llc90/results/output_adm.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68i
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node104.cm.cluster
-(PID.TID 0000.0001) // Build date:        Sat Jul 24 00:27:03 EDT 2021
+(PID.TID 0000.0001) // Build host:        node143
+(PID.TID 0000.0001) // Build date:        Sun May  8 00:44:45 EDT 2022
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node086.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node143
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -194,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -634,58 +634,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -763,6 +763,9 @@
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dFullAdjoint = /* use full hand written cg2d adjoint (no approximation) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
@@ -946,6 +949,9 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># =======================
+(PID.TID 0000.0001) ># pkg SMOOTH parameters :
+(PID.TID 0000.0001) ># =======================
 (PID.TID 0000.0001) > &SMOOTH_NML
 (PID.TID 0000.0001) > smooth2Dnbt(1)=300,
 (PID.TID 0000.0001) > smooth2Dtype(1)=1,
@@ -1247,6 +1253,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 1.080000000000000E+04
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1506,6 +1515,7 @@
 (PID.TID 0000.0001)  error file = some_T_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = saltatlas
@@ -1515,6 +1525,7 @@
 (PID.TID 0000.0001)  error file = some_S_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -2328,17 +2339,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -2346,10 +2360,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -2541,8 +2555,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -2559,7 +2573,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -2596,8 +2610,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -2612,6 +2626,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -4348,116 +4365,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.72117094882074E-18  1.83696321991941E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -2.57498015965307E-19  1.83696260959917E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537871882170E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928199448871E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716869365741E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500674803E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610669332E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271184883064E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135526403712E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006108230650E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948336591E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093945253E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537871773959E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928199495158E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716868341096E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500892941E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610936467E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271185790375E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135524458471E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006102106675E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948266407E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093715693E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4491391571296E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4213901650299E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.4232914061078E-07
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0607201288077E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2806591451429E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644806866E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276838944E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457646713E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307438000E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366152E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644813438E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276834041E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457646732E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307439589E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366872E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.9283278405307E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.3243304408083E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.1496778126279E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.3720577578596E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.4422291393815E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4124591383664E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2051174578904E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0288811373465E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7339517497189E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.7089493459863E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.8234328232956E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.9176186413066E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2780162917479E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5665230940286E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   8.7807579434710E-05
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   4.6266651909072E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.9675004378102E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2517097963553E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.9867314944212E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.6908028322819E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   9.0705289579314E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.2717672234884E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.9043092046162E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3235522587500E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.6633245063951E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.9869276838944E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1093644806866E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.6859457646713E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.4619307438000E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.1917372366152E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.9880862116240E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.8212645396146E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.2181652500606E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.1061803321270E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.0902570843317E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.2887484600790E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.3456649824157E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.3805926639245E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   6.8488985249435E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2422393707886E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.9869276838944E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1093644806866E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.6859457646713E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.4619307438000E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.1917372366152E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4469,144 +4410,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161606952156E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383871293355E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787134832964E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089852740E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551181005769E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880516821790E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226711472442E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448805758732E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162729533E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802143167E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028926122318E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878766652544E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153501754979E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5160664053478E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792288044606E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856410E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325209947E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557379819760E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920632770E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185560E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129465E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440441345E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937450960217E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306043983627E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946803565E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161605875621E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383870038178E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787142119801E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089950894E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551181129050E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880495608004E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226718296323E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448805013237E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162972656E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802285963E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028925456922E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878694530949E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153546888347E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5160664112783E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792285046444E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856724E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325210143E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557379819771E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920632748E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185709E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129456E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440441361E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937450960255E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306043983826E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946804461E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.84603070277445E-18  3.43370995147148E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.95156391047391E-18  3.43370715556454E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496063720032E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121848319825E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330078190156E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662138950986E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122667911754E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702195399E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005571766007E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556257537210E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937495455E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250277698E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221540597E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296551151225E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607471138E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724894E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556939E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256871216E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029922163E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171355217331E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204554910E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177003769E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496063701560E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121848421018E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330076349572E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662139307042E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122668315775E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702613560E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005571766039E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556256104014E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937856383E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250369461E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221540489E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296551151300E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607471404E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724902E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556876E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256865653E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029910929E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171355218371E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204555204E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177002332E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.7041562727298E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.2583967664088E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.5676042304190E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.2511477540409E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.8155213810896E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.4703497646094E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.2278257800179E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0046148454973E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.2534461779358E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5259435756222E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.3380766183825E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5293519661213E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.6221770591381E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6785252295038E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.4843822011391E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   9.3929930045893E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.6767660506591E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.1408786763028E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.7814429272369E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.3467041793022E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.7214525686844E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.5931770570312E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   4.0133044511783E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.6092760897670E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   9.2312581831941E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.0015029922163E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.1889256871216E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.3171355217331E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.0886204554910E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.3715177003769E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.9623062390186E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.6115254365767E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   5.2299476508036E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2157758186396E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1711883943522E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.5647654616689E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.6450064894379E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8153759247005E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.3620911423147E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.4700963240230E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.0015029922163E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.1889256871216E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.3171355217331E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0886204554910E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.3715177003769E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4618,144 +4483,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685037695643E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822503607E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327695701742E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959498615E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625054127E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255788321852E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329194999E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383167091635E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495836618554E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006634196E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268756297071E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543243011239E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140786430354E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978414929E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079083939328E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328845791E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799214818E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336113363660E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362871274457E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905007E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612417E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682656E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903702051871E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694340E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790262906E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685044238624E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822480379E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327706804405E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959335172E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625187110E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255786511446E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329541350E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383167635417E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495837255054E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006643331E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268756908567E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543240898546E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140798209024E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978376035E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079083293455E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328844543E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799215174E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336113363806E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362871274426E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905066E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612457E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682741E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903702052535E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694833E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790264043E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.08420217248550E-19  8.65061323507219E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -6.99310401253150E-18  8.65060080320657E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281455185E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124326332343E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021970381475E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718187324E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168901356621E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238428190263E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646479610014E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398904506368E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617743922E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464780936E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184580149E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510912567E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621928E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424462E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828722E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866219723E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105090459E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366123228E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962193059E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312603988E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281482780E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124326437179E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021973085776E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718213872E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168902563370E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238427764434E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646479531038E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398903174747E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617759140E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464307212E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184580090E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510912542E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621109E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424487E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828624E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866200788E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105083664E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366124441E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962193339E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312604495E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4335742768267E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8788314445495E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.1754564229002E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8478450474066E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.1384607543013E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.8044967982099E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.2224813395825E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7618809992690E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0332107011894E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   4.7957185637151E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.6206673102942E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.3156506148070E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.1819085872479E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.0358523505331E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.6467141308534E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.4289749817226E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.4299079429754E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.8341573178433E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.6552845173466E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   4.9922656332192E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.5405228950944E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -7.0038977941480E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.2643857784879E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   6.8846167018313E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3803018479574E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.0593105090459E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.2307866219723E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   7.9066366123228E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6283962193059E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.5377312603988E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.1922706918741E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.3739934933956E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.1149415742250E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8173163940750E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.2448339473645E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.2827775585190E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -9.9038790427450E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   1.4997677913271E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.0341847131728E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.6869949123860E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.0593105090459E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.2307866219723E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.9066366123228E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6283962193059E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.5377312603988E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4767,144 +4556,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897081506E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381512142515E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686560635593E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743287029E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580634032E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327696097868E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160265952168E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349640985E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852117030273E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467133888770E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005160991747E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201925840606E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324677100486E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335576182322E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484546100133E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990351892E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704100870E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114861866459E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4470273742491E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171764059947E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275750892E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595522E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882547951E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880772748E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285296287E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897347496E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381511732457E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686563339762E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743065105E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580919954E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327709305746E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160262773308E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349592601E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852118238792E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467134318462E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005168456048E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201926302156E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324681122516E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335575807941E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484545776402E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990350258E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704099775E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114861866742E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4470273742516E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171764059902E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275751743E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595538E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882549306E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880773818E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285296025E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   7.15573433840433E-18  1.48334044816889E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.24683249835833E-17  1.48333987422958E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641272223411E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655500095126E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181323094836E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916359562E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693178038E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981238656637E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342836962E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781611589489E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976539001E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041832690E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632468381E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272602793E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253153911E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628349385E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105032445E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558694353E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070826644E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703481579E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980616634E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893196855E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641270494238E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655501055503E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181325870953E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916303440E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693150459E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981237607666E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342746093E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781612809438E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976450921E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041917181E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632468255E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272602725E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253152558E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628349418E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105032427E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558791146E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070828320E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703481716E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980618154E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893218498E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8830810335290E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.4946287563705E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   8.0245045836867E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.4309663312696E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   5.4217376982225E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.3306631366382E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.0051568922093E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.1466842870210E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.6757945249348E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.5448649368987E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5469007810072E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.0981057825569E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.2944778932204E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4494904541002E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.2765394974083E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.9310265812611E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8898036906033E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.5592615046209E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.5279149357994E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   6.6496294615285E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.3331355840002E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.5320305287128E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   8.6021684400395E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.1680510643731E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.8462983121652E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2180070826644E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.2137558694353E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.0464703481579E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.1649980616634E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.6944893196855E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.5870853620716E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1111568121848E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   1.7759752427637E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4162149330913E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.3126658992288E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7079054424709E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3127623494329E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.4145485559294E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.7024809498903E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   4.8954061881471E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2180070826644E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.2137558694353E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.0464703481579E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.1649980616634E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.6944893196855E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.73784634267033E-01
@@ -4921,144 +4634,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474015568379E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829546507549E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975521585540E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041358247E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996434924E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982022933773E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483497606703E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417922096352E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430119475E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735853616530E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451470655493E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839515511626E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077774763256E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614826636144E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101974201242E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517548347E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357649139E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893440285351E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5569455531206E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692764136646E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679359017226E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952179668944E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9826126716833E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572376244580E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5878588704357E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474017935966E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829545842661E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975525367682E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041342076E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996523210E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982026467014E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483495298166E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417920361790E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430271081E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735854257611E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451455846449E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839512522070E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077780072038E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614825483641E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101973075824E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517544647E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357647463E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893440285770E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5569455531401E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692764136442E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679359019109E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952179668851E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9826126718925E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572376244729E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5878588699914E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   9.97465998686664E-18  2.12603795188483E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -3.15502832193282E-17  2.12603553815238E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517552897538E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705416864449E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042262624E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436317849E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800242817E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842635458150E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926762044073E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540619602E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630307684E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394656600E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337858E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329150855E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938815242E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675375565E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112879220E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406303056E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395101563E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819445E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026994637E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835686534E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517551433459E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705417797663E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042507601E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436249807E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800090410E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842633953395E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926763571855E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540989069E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630265742E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394487273E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337895E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329158149E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938814183E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675375623E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112879217E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406373862E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395103915E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819558E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026995617E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835669189E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.3195220125798E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.1061181700466E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.0681523909145E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.0029906172601E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.6682216104744E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.2906767175756E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.8725864415694E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2907591321818E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4329974369171E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0654125031126E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.8387472732496E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8454620748073E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.1752178340998E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.0960183454970E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.0316853458546E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.4448161609679E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.3555552545932E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.2848082883336E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.4053420967337E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   8.3226008173655E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.1001117266373E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.2196664781224E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0975407772898E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1474625890474E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.3297657716056E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5082395101563E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.0867406303056E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2989634819445E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.6959026994637E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   5.8362835686534E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.9807581253621E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.3825921723331E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.3927967384762E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.0132453670354E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.3747543628583E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1318979276329E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.6319237647723E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   3.2645290650785E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.3680995114298E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.0955879492843E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5082395101563E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.0867406303056E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.2989634819445E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.6959026994637E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   5.8362835686534E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5070,144 +4707,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425155767366E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589439067661E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340960843390E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802139831E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285752713200E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745259635614E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151327349550E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968625252766E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789020190E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634370471650E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626404185709E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529941972296E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210930279817E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913744527E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971818526E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522233007E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187747064E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671810636985E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6660388588201E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202407688280E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410493730073E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107032E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778046107829E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885253164189E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787564966E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425157928490E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589438264772E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340967502097E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802151677E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285753203237E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745262096085E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151328280322E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968623032768E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789124628E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634371041903E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626403716690E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529937456188E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210938472533E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913736981E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971926691E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522227130E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187745948E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671810637321E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6660388588786E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202407687807E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410493733251E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107084E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778046108007E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885253164362E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787554184E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   4.59701721133854E-17  2.73283074969873E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   5.63785129692462E-18  2.73282977988839E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399429311E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139803806685E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049017704E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557161881E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413278150778E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387091063845E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3685382021798E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273450305E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668862835E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264290092132E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730846679E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337439364E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392208774E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830781113E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723210658E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863409634E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389033245E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660751042E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936314343E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513476805E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399173882E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139804382041E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049083823E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557018076E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413277655963E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387090934935E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3685395713295E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273670063E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668850405E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264289737979E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730846802E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337449287E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392207903E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830781175E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723210602E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863594725E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389039756E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660751110E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936315344E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513492118E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7438231662645E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.7173404560976E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3000341574633E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.5630492300752E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.8665817224901E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   8.2588614595935E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.7669334972178E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6763112668102E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.2825051153972E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.3996845638703E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.3409969387472E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -4.7225299070019E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.5349613130868E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.8307617524641E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.3674917084714E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9699416016528E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.8660119617301E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.9665576970822E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.2935701786001E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.0154213361557E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.8419642370774E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5016676256249E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3363167777730E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.3820627270877E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.8390101435580E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.8133389033245E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.5434863409634E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.5490660751042E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.2226936314343E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.9666513476805E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.3734855910169E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.6511898712447E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   2.9338322961795E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.6082515365586E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.4320812897501E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.5549157316183E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.9470548921279E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.0022580442511E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.0308185857680E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.2881651514338E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.8133389033245E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.5434863409634E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.5490660751042E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.2226936314343E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.9666513476805E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5219,144 +4780,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944538023796E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368256751510E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518039278026E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646487941970E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993208928895E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190311478388E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736983028501E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351318863740E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614200055E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121318789E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055216348274E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809616712284E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505844261140E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923726462418E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132685764959E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678518482E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723190623E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449499478872E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743774000585E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701806423360E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289834558E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599912257E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572883346295E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197963359057E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664206470E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944541570523E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368255978464E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518046962971E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646488055997E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993209289209E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190315531134E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736976228290E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351317556963E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614294973E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121998450E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055197018545E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809638800384E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505859889419E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923726351253E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132686160753E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678504466E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723191991E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449499479067E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743774001907E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701806423301E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289839030E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599958659E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572883346419E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197963359242E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664193647E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.10335221462188E-17  3.23837038282247E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -8.32667268468867E-17  3.23836977129979E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517219089569E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678953690224E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247834999606E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028226131E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118514468E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700512941E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4147058633491E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551574598E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108795863E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122378688E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062758E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197065021E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380579092E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767736216E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518069895E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560460519767E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039946869875E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905896340912E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825566349E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274072163E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517218699400E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678952813710E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247835175209E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028109480E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118046557E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700416334E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4147066854521E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551923222E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108850006E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122596984E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062708E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197074381E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380577588E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767736253E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518069507E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560460288464E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039946872590E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905896340907E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825565450E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274028972E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1564765704629E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.2614335375642E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.5875840177814E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.0994250524546E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   8.9774588754660E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.0091220260516E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.8071855732216E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.0422583353079E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.2041854210065E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.7457064122456E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.1876275744945E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.6132851196204E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.8884616810119E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.6404864972176E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.7252366973037E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4742614841407E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2822757440575E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.7553801433004E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.1353647526331E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1634237533869E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.7203070198809E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.7373424284195E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.5552667614657E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.5993440090866E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.2684017906200E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1039946869875E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.2560460519767E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.7905896340912E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.7379825566349E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.0619274072163E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.7655009357933E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.9169793563798E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.6465385781995E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.2000209697717E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.4855036310882E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.9771431153070E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.2580126630875E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   4.9746819161719E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.6886664704129E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.4734852527798E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1039946869875E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -8.2560460519767E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.7905896340912E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.7379825566349E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.0619274072163E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5368,144 +4853,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807006856987E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950544278E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429212904840E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288457151E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650052245E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926601876887E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852190465851E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991951737E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823750027E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888235525E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436490681682E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034400142829E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766166847766E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051441230E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493698731462E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894401203E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584521391E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225890455076E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8820574721601E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0191745259197E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865315018597E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755468695E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367080723706E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510742378978E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528797540E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5806997643971E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950554824E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429221594464E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288625924E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650077018E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926618768951E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852189060678E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991306402E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823853386E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888320395E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436499049722E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034401681946E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766167583972E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051343342E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493699649990E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894380676E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584524030E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225890454827E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8820574723958E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0191745259736E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865315024191E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755531759E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367080723637E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510742379176E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528779764E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.72205346941013E-18  3.71564340234450E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -4.55364912443912E-18  3.71563950466507E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597027185571E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972455574338E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298772510E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076530320E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115831041E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935668909E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312407178391E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634710472E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316921864E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926863352835E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067431E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380586348E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240566285E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138088744E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884988499E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705832378493E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963105154E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170690049E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056205425E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127905109E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597026809424E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972454547201E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298234798E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076385702E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115339135E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935276491E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312398298978E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634391387E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316681014E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926862935591E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067514E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380595801E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240566216E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138088726E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884987764E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705832239644E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963112913E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170689764E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056204439E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127902497E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.5572291753488E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.9006090860186E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.1267582375862E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5971486359799E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0072708890915E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1731881480925E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8598866324039E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.3579618458267E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.1822263532822E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.0932176943796E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4285698367528E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3053083101964E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.2222270374866E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.5116848110510E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.0936731491131E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.9807912301336E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7276688771280E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.5925845829726E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.9674226609734E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3201854015369E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.1909750487665E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9726921970084E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7862018714936E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8145643272657E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.7023038391071E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4343963105154E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.9705832378493E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.0202170690049E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.2483056205425E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.1696127905109E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.1559273743638E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.1847879183490E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   4.9888301044046E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.7836915631459E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.5310000586710E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.3975589168757E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.5720511335408E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   6.8483203349296E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.3347223946082E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   9.6483848438844E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4343963105154E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.9705832378493E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.0202170690049E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.2483056205425E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.1696127905109E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
@@ -5537,31 +4946,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301269185E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318675402E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618140694228E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498356060E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703432017E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936337232144E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736327815E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154479197352E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748630558E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449441270E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358413850784E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053718714308E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797660747987E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892584101294E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976334029936E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116396947E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472775894E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000453876063E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891644629901E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756982119E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063317121E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452420690E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160350961058E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823662134474E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502580447E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301833600E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318639644E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618150700200E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498469560E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703510532E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936336807384E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736166978E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154478542848E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748802108E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449455200E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358410359088E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053703509103E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797663358196E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892583917816E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976333779129E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116370384E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472781772E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000453875432E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891644633170E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756983588E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063324529E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452479510E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160350960833E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823662134588E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502560277E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6060,237 +5469,237 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5523.7646013796329
-(PID.TID 0000.0001)         System time:   11.447837203741074
-(PID.TID 0000.0001)     Wall clock time:   5563.4919168949127
+(PID.TID 0000.0001)           User time:   4066.2582962512970
+(PID.TID 0000.0001)         System time:   11.224529206752777
+(PID.TID 0000.0001)     Wall clock time:   4100.3916988372803
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.634086728096008
-(PID.TID 0000.0001)         System time:  0.77282097935676575
-(PID.TID 0000.0001)     Wall clock time:   15.058910131454468
+(PID.TID 0000.0001)           User time:   10.669492423534393
+(PID.TID 0000.0001)         System time:  0.80924999713897705
+(PID.TID 0000.0001)     Wall clock time:   13.554706811904907
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2382.9896039962769
-(PID.TID 0000.0001)         System time:   5.1161379814147949
-(PID.TID 0000.0001)     Wall clock time:   2404.2536869049072
+(PID.TID 0000.0001)           User time:   1692.3285083770752
+(PID.TID 0000.0001)         System time:   4.2483478784561157
+(PID.TID 0000.0001)     Wall clock time:   1709.3201689720154
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   505.22842407226562
-(PID.TID 0000.0001)         System time:  0.85329818725585938
-(PID.TID 0000.0001)     Wall clock time:   508.84038329124451
+(PID.TID 0000.0001)           User time:   392.35034179687500
+(PID.TID 0000.0001)         System time:  0.71745157241821289
+(PID.TID 0000.0001)     Wall clock time:   395.35362768173218
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1618041992187500
-(PID.TID 0000.0001)         System time:   1.0340213775634766E-003
-(PID.TID 0000.0001)     Wall clock time:   8.1704804897308350
+(PID.TID 0000.0001)           User time:   6.1436157226562500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.1480123996734619
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.6223754882812500
-(PID.TID 0000.0001)         System time:  0.20071434974670410
-(PID.TID 0000.0001)     Wall clock time:   7.2516119480133057
+(PID.TID 0000.0001)           User time:   7.6816711425781250
+(PID.TID 0000.0001)         System time:  0.11590003967285156
+(PID.TID 0000.0001)     Wall clock time:   7.9565670490264893
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.7611694335937500
-(PID.TID 0000.0001)         System time:  0.11485958099365234
-(PID.TID 0000.0001)     Wall clock time:   6.2537572383880615
+(PID.TID 0000.0001)           User time:   6.9977111816406250
+(PID.TID 0000.0001)         System time:   7.8006267547607422E-002
+(PID.TID 0000.0001)     Wall clock time:   7.1881442070007324
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   4.2724609375000000E-004
-(PID.TID 0000.0001)         System time:   9.9706649780273438E-004
-(PID.TID 0000.0001)     Wall clock time:   2.2432804107666016E-003
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   8.7833404541015625E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60989379882812500
-(PID.TID 0000.0001)         System time:   1.5974044799804688E-005
-(PID.TID 0000.0001)     Wall clock time:  0.61283016204833984
+(PID.TID 0000.0001)           User time:  0.48220825195312500
+(PID.TID 0000.0001)         System time:   2.0277500152587891E-003
+(PID.TID 0000.0001)     Wall clock time:  0.48432922363281250
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25659179687500000
-(PID.TID 0000.0001)         System time:   1.0130405426025391E-003
-(PID.TID 0000.0001)     Wall clock time:  0.25837063789367676
+(PID.TID 0000.0001)           User time:  0.21401977539062500
+(PID.TID 0000.0001)         System time:   1.5497207641601562E-005
+(PID.TID 0000.0001)     Wall clock time:  0.21522760391235352
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   88.310333251953125
-(PID.TID 0000.0001)         System time:   8.0929994583129883E-002
-(PID.TID 0000.0001)     Wall clock time:   88.534942865371704
+(PID.TID 0000.0001)           User time:   67.578552246093750
+(PID.TID 0000.0001)         System time:   2.0950317382812500E-002
+(PID.TID 0000.0001)     Wall clock time:   67.820104122161865
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   35.366333007812500
-(PID.TID 0000.0001)         System time:   2.8001070022583008E-002
-(PID.TID 0000.0001)     Wall clock time:   35.442675828933716
+(PID.TID 0000.0001)           User time:   26.167633056640625
+(PID.TID 0000.0001)         System time:   2.0167827606201172E-003
+(PID.TID 0000.0001)     Wall clock time:   26.322521209716797
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   117.94125366210938
-(PID.TID 0000.0001)         System time:   1.1058092117309570E-002
-(PID.TID 0000.0001)     Wall clock time:   118.50565958023071
+(PID.TID 0000.0001)           User time:   90.331542968750000
+(PID.TID 0000.0001)         System time:   1.0056495666503906E-003
+(PID.TID 0000.0001)     Wall clock time:   91.274230718612671
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8569335937500000
-(PID.TID 0000.0001)         System time:   9.9802017211914062E-004
-(PID.TID 0000.0001)     Wall clock time:   1.8603386878967285
+(PID.TID 0000.0001)           User time:   1.8663635253906250
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   1.8731336593627930
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   17.486938476562500
-(PID.TID 0000.0001)         System time:   1.0073184967041016E-003
-(PID.TID 0000.0001)     Wall clock time:   17.508984804153442
+(PID.TID 0000.0001)           User time:   15.039276123046875
+(PID.TID 0000.0001)         System time:   1.2958049774169922E-002
+(PID.TID 0000.0001)     Wall clock time:   15.071886301040649
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6165161132812500
-(PID.TID 0000.0001)         System time:   9.9897384643554688E-004
-(PID.TID 0000.0001)     Wall clock time:   2.6258876323699951
+(PID.TID 0000.0001)           User time:   2.1010742187500000
+(PID.TID 0000.0001)         System time:   8.1062316894531250E-006
+(PID.TID 0000.0001)     Wall clock time:   2.1134395599365234
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8786010742187500
-(PID.TID 0000.0001)         System time:   6.9141387939453125E-006
-(PID.TID 0000.0001)     Wall clock time:   4.8819432258605957
+(PID.TID 0000.0001)           User time:   3.8611755371093750
+(PID.TID 0000.0001)         System time:   9.9611282348632812E-004
+(PID.TID 0000.0001)     Wall clock time:   3.8671965599060059
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.37823486328125000
-(PID.TID 0000.0001)         System time:   9.7990036010742188E-004
-(PID.TID 0000.0001)     Wall clock time:  0.37850952148437500
+(PID.TID 0000.0001)           User time:  0.25765991210937500
+(PID.TID 0000.0001)         System time:   1.0051727294921875E-003
+(PID.TID 0000.0001)     Wall clock time:  0.25989127159118652
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6134033203125000
-(PID.TID 0000.0001)         System time:   1.0163784027099609E-003
-(PID.TID 0000.0001)     Wall clock time:   7.6202070713043213
+(PID.TID 0000.0001)           User time:   5.7389221191406250
+(PID.TID 0000.0001)         System time:   1.3891458511352539E-002
+(PID.TID 0000.0001)     Wall clock time:   5.7632095813751221
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   120.06716918945312
-(PID.TID 0000.0001)         System time:   3.0035972595214844E-002
-(PID.TID 0000.0001)     Wall clock time:   120.45455098152161
+(PID.TID 0000.0001)           User time:   92.710174560546875
+(PID.TID 0000.0001)         System time:   9.9587440490722656E-004
+(PID.TID 0000.0001)     Wall clock time:   92.836520910263062
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2817382812500000E-003
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.4342231750488281E-004
+(PID.TID 0000.0001)           User time:   3.6621093750000000E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.9144706726074219E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2724304199218750
-(PID.TID 0000.0001)         System time:   2.1457672119140625E-006
-(PID.TID 0000.0001)     Wall clock time:   1.2772655487060547
+(PID.TID 0000.0001)           User time:  0.78945922851562500
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.78864669799804688
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4343261718750000E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.0718269348144531E-004
+(PID.TID 0000.0001)           User time:   1.5258789062500000E-004
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   8.6903572082519531E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9257812500000000
-(PID.TID 0000.0001)         System time:  0.12486815452575684
-(PID.TID 0000.0001)     Wall clock time:   2.3272032737731934
+(PID.TID 0000.0001)           User time:   1.8537597656250000
+(PID.TID 0000.0001)         System time:  0.14990973472595215
+(PID.TID 0000.0001)     Wall clock time:   2.2378172874450684
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.9008483886718750
-(PID.TID 0000.0001)         System time:  0.39254117012023926
-(PID.TID 0000.0001)     Wall clock time:   4.0798223018646240
+(PID.TID 0000.0001)           User time:   2.6652832031250000
+(PID.TID 0000.0001)         System time:  0.38885688781738281
+(PID.TID 0000.0001)     Wall clock time:   3.4767146110534668
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.311462402343750
-(PID.TID 0000.0001)         System time:  0.77225637435913086
-(PID.TID 0000.0001)     Wall clock time:   24.088607311248779
+(PID.TID 0000.0001)           User time:   19.137878417968750
+(PID.TID 0000.0001)         System time:  0.69974112510681152
+(PID.TID 0000.0001)     Wall clock time:   20.695022583007812
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   8.1458435058593750
-(PID.TID 0000.0001)         System time:  0.17481899261474609
-(PID.TID 0000.0001)     Wall clock time:   8.3743910789489746
+(PID.TID 0000.0001)           User time:   6.8879089355468750
+(PID.TID 0000.0001)         System time:  0.15394544601440430
+(PID.TID 0000.0001)     Wall clock time:   7.0777497291564941
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.5949707031250000
-(PID.TID 0000.0001)         System time:  0.12388420104980469
-(PID.TID 0000.0001)     Wall clock time:   3.8036489486694336
+(PID.TID 0000.0001)           User time:   3.0649414062500000
+(PID.TID 0000.0001)         System time:   8.9978218078613281E-002
+(PID.TID 0000.0001)     Wall clock time:   3.2590529918670654
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6118164062500000
-(PID.TID 0000.0001)         System time:   6.8928718566894531E-002
-(PID.TID 0000.0001)     Wall clock time:   3.7610151767730713
+(PID.TID 0000.0001)           User time:   3.0552978515625000
+(PID.TID 0000.0001)         System time:   8.7960720062255859E-002
+(PID.TID 0000.0001)     Wall clock time:   3.2460501194000244
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3121.9340820312500
-(PID.TID 0000.0001)         System time:   5.3660483360290527
-(PID.TID 0000.0001)     Wall clock time:   3136.6145489215851
+(PID.TID 0000.0001)           User time:   2357.1400146484375
+(PID.TID 0000.0001)         System time:   5.9889793395996094
+(PID.TID 0000.0001)     Wall clock time:   2371.0116178989410
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2678.2888183593750
-(PID.TID 0000.0001)         System time:   3.6438078880310059
-(PID.TID 0000.0001)     Wall clock time:   2688.7843997478485
+(PID.TID 0000.0001)           User time:   2010.3614501953125
+(PID.TID 0000.0001)         System time:   4.3147134780883789
+(PID.TID 0000.0001)     Wall clock time:   2019.8368494510651
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   433.18652343750000
-(PID.TID 0000.0001)         System time:   1.2876443862915039
-(PID.TID 0000.0001)     Wall clock time:   436.44056916236877
+(PID.TID 0000.0001)           User time:   337.50866699218750
+(PID.TID 0000.0001)         System time:   1.2374382019042969
+(PID.TID 0000.0001)     Wall clock time:   340.76504778862000
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4755859375000000
-(PID.TID 0000.0001)         System time:   7.9617500305175781E-003
-(PID.TID 0000.0001)     Wall clock time:   5.4893879890441895
+(PID.TID 0000.0001)           User time:   4.0101318359375000
+(PID.TID 0000.0001)         System time:   1.1920928955078125E-005
+(PID.TID 0000.0001)     Wall clock time:   4.0173218250274658
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8798828125000000E-002
-(PID.TID 0000.0001)         System time:   7.6293945312500000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.8664836883544922E-002
+(PID.TID 0000.0001)           User time:   1.7333984375000000E-002
+(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
+(PID.TID 0000.0001)     Wall clock time:   1.7010450363159180E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   394.12792968750000
-(PID.TID 0000.0001)         System time:  0.16871690750122070
-(PID.TID 0000.0001)     Wall clock time:   395.00411438941956
+(PID.TID 0000.0001)           User time:   304.94946289062500
+(PID.TID 0000.0001)         System time:  0.14079856872558594
+(PID.TID 0000.0001)     Wall clock time:   305.66043210029602
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8129882812500000
-(PID.TID 0000.0001)         System time:  0.32769966125488281
-(PID.TID 0000.0001)     Wall clock time:   6.6646199226379395
+(PID.TID 0000.0001)           User time:   5.3232421875000000
+(PID.TID 0000.0001)         System time:  0.35486364364624023
+(PID.TID 0000.0001)     Wall clock time:   6.2857165336608887
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3438930511474609E-003
+(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
+(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
+(PID.TID 0000.0001)     Wall clock time:   2.1343231201171875E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   27.086914062500000
-(PID.TID 0000.0001)         System time:  0.78025817871093750
-(PID.TID 0000.0001)     Wall clock time:   28.589029788970947
+(PID.TID 0000.0001)           User time:   23.142944335937500
+(PID.TID 0000.0001)         System time:  0.73973846435546875
+(PID.TID 0000.0001)     Wall clock time:   24.709894657135010
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.6855468750000000E-002
-(PID.TID 0000.0001)         System time:   1.9989013671875000E-003
-(PID.TID 0000.0001)     Wall clock time:   3.5665750503540039E-002
+(PID.TID 0000.0001)           User time:   2.8564453125000000E-002
+(PID.TID 0000.0001)         System time:   2.0060539245605469E-003
+(PID.TID 0000.0001)     Wall clock time:   3.6079883575439453E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6330,9 +5739,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         904724
+(PID.TID 0000.0001) //            No. barriers =         903306
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         904724
+(PID.TID 0000.0001) //     Total barrier spins =         903306
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.txt
+++ b/global_oce_llc90/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68a
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68i
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node104.cm.cluster
-(PID.TID 0000.0001) // Build date:        Sat Jul 24 00:27:03 EDT 2021
+(PID.TID 0000.0001) // Build host:        node143
+(PID.TID 0000.0001) // Build date:        Sun May  8 00:44:45 EDT 2022
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 18 ) = node104.cm.cluster
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node143
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -194,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -662,6 +662,9 @@
 (PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dFullAdjoint = /* use full hand written cg2d adjoint (no approximation) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -844,6 +847,9 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Parameter file "data.smooth"
 (PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) ># =======================
+(PID.TID 0000.0001) ># pkg SMOOTH parameters :
+(PID.TID 0000.0001) ># =======================
 (PID.TID 0000.0001) > &SMOOTH_NML
 (PID.TID 0000.0001) > smooth2Dnbt(1)=300,
 (PID.TID 0000.0001) > smooth2Dtype(1)=1,
@@ -1145,6 +1151,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 1.080000000000000E+04
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 3.153600000000000E+07
 (PID.TID 0000.0001)     ;
@@ -1397,6 +1406,7 @@
 (PID.TID 0000.0001)  error file = some_T_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = saltatlas
@@ -1406,6 +1416,7 @@
 (PID.TID 0000.0001)  error file = some_S_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -2219,17 +2230,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -2237,10 +2251,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -2432,8 +2446,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -2450,7 +2464,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -2487,8 +2501,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -2503,6 +2517,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -4181,126 +4198,40 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.79470760369927E-19  1.84309793280673E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -2.15485181781494E-18  1.84309982363234E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.1459157266173E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5768947429151E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0778407570682E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0303724211776E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8329322381987E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   6.0051175616277E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.7231133109931E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.5426525259826E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8463706384720E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6989254141585E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.1459157738474E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5768947554055E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0778405913170E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0303723754958E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8329322170671E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   6.0051173540135E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.7231133813769E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.5426530360021E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8463706709566E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6989254193329E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4400857037059E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.3997217673701E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   6.0303766892200E-08
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0756317462372E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2962614968558E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1376260634596E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.0173058327527E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7754842496061E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.6566382327324E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.2588466886379E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1376260633642E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -3.0173058326681E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.7754842495830E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.6566382327420E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.2588466886375E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.6432471954215E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.6849253686293E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   3.2154960449108E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.5778212645028E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.5681455795341E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.4926240172158E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.2093696762948E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.0340932335011E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7576682060133E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   8.9854267398048E-05
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   5.5964313899561E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.1301260310331E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.4012061902143E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.5893070450970E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   9.0547833099532E-05
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   4.7390577319326E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4079805758563E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.7997309443545E-05
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1283518347182E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.2741597706962E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2626743143404E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -9.8414145940823E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.9115964108831E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.1378753304558E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.0069238210393E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   5.7986913909438E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5721521903667E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   7.3610191082749E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.0212236159262E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.8751918542410E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.0691363055666E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.5764551692943E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   3.4869700733562E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.3913526118534E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.5579407284827E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   3.0173058327527E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1376260634596E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.7754842496061E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   5.6566382327324E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   1.2588466886379E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   4.1126834840557E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.8770001593335E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -8.6356451336775E-08
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   6.2220314989669E-05
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   1.1296353353060E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.3997217673701E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -3.4400857037059E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -6.0303766892200E-08
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   7.0756317462372E-05
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.2962614968558E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.0173058327527E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.1376260634596E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.7754842496061E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   5.6566382327324E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.2588466886379E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4312,154 +4243,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9117486616016E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7454196650693E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3731275410624E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3556688496224E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4883111565235E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2895318693685E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4212412417728E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5274851585061E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2810480685805E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3335518766647E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3433380102214E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2697686979440E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.4912887040170E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6781620686559E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.3552182162964E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5615209118999E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4711018659199E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5553183696541E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2251419914253E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1087861514700E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5477231234611E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7817415615290E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937353013399E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6310813382494E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0397259044081E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9117479325432E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7454197316665E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3731286936522E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3556688386428E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4883112368909E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2895320162126E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4212414011943E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5274845567944E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2810480872235E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3335517455094E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3433376458926E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.2697686660719E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.4912893921228E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6781622078008E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.3552182391645E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5615209110456E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4711018659750E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5553183696502E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2251419914309E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1087861516193E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5477231234598E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7817415538840E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937353013215E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6310813382657E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0397259044218E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.05709711817337E-18  3.47579959862151E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -6.17995238316738E-18  3.47581106287913E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0826448515962E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1068039445752E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1349654174112E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.0759649132455E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.0639808319626E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7087891877364E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.0761072798695E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.7531790357443E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.4496886598887E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6293525430486E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8766512619839E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.7913596973606E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.5796208114512E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4135978531540E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5854685211077E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.2752931689100E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.3847670882830E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.5474837458220E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1306429659152E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.5119787035076E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0826448597015E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1068039351715E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1349649449470E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   6.0759648846225E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.0639807219103E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7087891844232E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.0761073191863E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.7531791053434E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.4496886887492E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6293526498207E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8766512616719E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.7913596973478E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.5796208111451E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4135978531543E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5854685211052E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.2752931695070E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.3847670897126E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.5474837458300E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1306429659228E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.5119787035004E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.2611402807045E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.3372123779035E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.7269603922338E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.3130066647351E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   3.1098966717595E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5423674947313E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.9687356592922E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -3.0034243573894E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3438616264778E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.6212294563513E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.6593483782256E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.5939888674658E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.7114761468979E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.7745462324501E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.5903484280740E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.7427766138802E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.7628912926801E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -2.1900201969064E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.3797358375152E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   9.0986756561793E-06
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.5562675365605E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -7.2766320053453E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   3.9517140252794E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.4493901322048E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   9.5752907324923E-06
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.1186836141373E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -9.0016008873685E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   1.4524958129651E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.0339156351268E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.7341456387161E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   2.0759224675336E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -3.0214853860816E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   6.8742214038901E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.7338735429159E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   8.9917303253818E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   6.3847670882830E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -2.2752931689100E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   5.5474837458220E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.1306429659152E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   2.5119787035076E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   8.2188530522840E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -5.7519920557392E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0102639385445E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.2432690719471E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.2546489062502E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.7913596973606E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -6.8766512619839E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.5796208114512E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   1.4135978531540E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.5854685211077E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   6.3847670882830E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -2.2752931689100E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   5.5474837458220E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.1306429659152E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.5119787035076E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4471,154 +4316,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0561996595408E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3540688584464E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5304791573174E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8232640876234E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.8004086178859E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2266329275387E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2641972662360E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1332468918435E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6532379526226E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7841649290781E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.3223619088173E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7501907477882E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.5007039224119E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.6485213659225E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.9449101009030E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2836283860417E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2063681966264E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3329302251454E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3369995061549E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6587095915407E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3215904243118E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3173268546986E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902741084102E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9460617360449E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5588538851755E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0561971261939E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3540688371527E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5304816127349E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8232640744944E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.8004086248431E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2266319362050E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2641973655718E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1332469620828E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6532379802600E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7841648917891E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.3223624350253E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7501904068999E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   3.5007078737156E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   8.6485213706285E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.9449100668515E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2836283858472E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2063681967042E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3329302251361E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3369995061690E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6587095920030E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3215904243220E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3173268536734E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902741083681E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9460617361107E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5588538851753E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.76471553983804E-18  8.80668375058152E-04
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   4.87890977618477E-19  8.80670025370393E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7976098019584E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2135977548035E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.9714440900126E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1842583242343E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   9.2689170654860E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.0844002577333E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0606679251681E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.5086888761401E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0442055676520E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.4120772455240E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0308972150266E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3174487583539E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.9034129379779E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1183573645595E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8676110580278E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.4145321147638E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5817471491673E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.3191293384116E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6944373481319E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7573187073559E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7976097964457E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2135977008447E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.9714436126315E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1842583197110E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   9.2689165970081E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   3.0844003294602E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0606679215030E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.5086894112584E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0442055615451E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.4120768310505E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0308972149837E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3174487583565E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.9034129383362E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1183573645617E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8676110580310E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.4145321125907E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5817471505915E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -8.3191293384543E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6944373481661E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7573187073960E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.3853438913316E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.0061277281683E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.4664370147908E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.9664654171669E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.6387880484896E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   2.9997093368432E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.4684380549055E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7237203949102E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.0537456335688E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   5.0146221857741E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   3.0037927363948E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.4140012187572E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   5.4316987638976E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   9.2569376300877E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   4.8966286528571E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   5.8416616138935E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.4327658893664E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -3.7124645128873E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.9908449545193E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   1.7060355488175E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   9.4912774951071E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.1394848576256E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   6.1368404244985E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.9774802028259E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   1.5956010038077E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   1.6153251642495E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.3791028724843E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.1633796775583E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.0536942433156E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   5.5940828956760E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   3.2409840041336E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -4.3429519030116E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.0248605966868E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   7.0684859625184E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.3395056773891E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.5817471491673E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -3.4145321147638E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   8.3191293384116E+04
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.6944373481319E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7573187073559E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.2318355803247E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -8.6243720788377E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -3.4091529013519E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.8633926760940E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   3.3743216399652E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.3174487583539E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.0308972150266E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.9034129379779E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1183573645595E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.8676110580278E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   9.5817471491673E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -3.4145321147638E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   8.3191293384116E+04
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.6944373481319E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   3.7573187073559E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4630,154 +4389,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4751732629201E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6384567615239E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7700900354822E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2462809259943E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3638388891582E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3354000238443E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4168044263028E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3580184660699E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9941142518245E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3710040232608E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.0373840770037E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.5986120845034E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -3.6348536708011E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4290399699373E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2646826093215E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7104659779683E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9413302430201E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1105120028603E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4482265450343E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0202671210367E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0954411272537E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7565347798251E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864538209808E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2606434158198E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0771789013703E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4751730183428E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6384567217646E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7700903888732E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2462809259779E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3638388786155E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3353976741804E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4168046481569E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3580185384859E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9941143914634E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3710040275262E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.0373847270980E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.5986128548955E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -3.6348538483414E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4290399287637E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2646824938323E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7104659774759E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9413302432398E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1105120028374E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4482265450532E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0202671210918E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0954411276432E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7565347788832E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864538208797E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2606434159068E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0771789011701E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.06251812903579E-17  1.51546581642152E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   2.16840434497101E-19  1.51546501155504E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.0577020339422E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5876807936802E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.4270644922521E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9073327634388E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.4122280962272E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2909803107600E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.8371015933055E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.8891801269476E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6635187082134E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2813377740878E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3735851357031E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7547136295613E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.8808548108999E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.8224341868546E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.1467725714850E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.5548563850827E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2777653024341E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1093103800706E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.2567175716357E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.9995714010005E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.0577020516333E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5876807584378E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.4270641034134E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9073327616076E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.4122280439221E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2909802701527E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.8371015508350E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.8891807069298E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6635187050246E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2813377661001E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3735851356690E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7547136298811E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.8808548123203E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.8224341868580E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.1467725714871E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.5548563843016E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2777653025555E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.1093103800741E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.2567175716499E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.9995714009811E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8420159058074E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.6752400985776E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.3331621256259E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.6185203968217E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.1549789207001E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   4.7257442119561E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.4309744156461E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -9.0404074431148E-03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.7119594385036E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   7.9278419147169E-04
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   4.5903812224157E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.1168595132654E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   8.7752572862075E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.4880501858547E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   7.7242819432836E-04
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   9.1824176356985E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.6250517295267E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -5.3313408931181E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   5.4926079723754E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.0966500564410E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   6.7918415948465E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.0181606828033E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   8.4742235996716E-04
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   5.6918195271134E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2634582674881E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.0694512362815E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.8527242050059E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.9086159738233E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   4.0906346613472E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.5734749676494E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   4.4951623641191E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -5.6193350253027E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.3703447916825E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   9.4353997837165E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   1.7886433543292E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.2777653024341E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -4.5548563850827E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.1093103800706E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.2567175716357E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   4.9995714010005E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   1.6410223459431E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.1492923739945E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -5.2436357361168E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.4830026746733E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   4.4917537556850E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.7547136295613E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.3735851357031E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -4.8808548108999E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.8224341868546E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   5.1467725714850E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2777653024341E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.5548563850827E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.1093103800706E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.2567175716357E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   4.9995714010005E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00378020371994E+00  1.73700015025699E-01
@@ -4794,154 +4467,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2432870860343E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2844634833995E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7026334660121E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1481047957202E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2567811016782E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.7037751393118E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8509373500389E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0242982974042E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1190722026240E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.3158922628335E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.5012340652959E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -6.6448132444300E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0179185441045E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.9860703309396E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.6298314062989E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1365102143413E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6759162929704E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8880493660145E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5587619587375E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2739332549602E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8692505169756E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1957828487074E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9821738687757E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1574885639697E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5945817326198E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2432869072058E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2844634498038E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7026336942037E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1481047965577E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2567810980502E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.7037730495555E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8509375485219E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0242984558232E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1190722162745E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.3158922551260E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.5012347720419E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -6.6448130669398E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.0179187156646E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.9860703093170E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.6298313685662E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1365102135719E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6759162933149E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8880493659751E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5587619587586E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2739332550223E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8692505178831E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1957828480340E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9821738686050E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1574885639770E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5945817321455E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -5.09575021068187E-17  2.18167383062257E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.06251812903579E-17  2.18167420113588E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   8.7366134616177E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.1443455900466E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3220506297485E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7536756220208E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.9377030247252E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2722161421303E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2868110797519E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.2653834876566E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3904079166692E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7654124854909E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.7151599609709E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1911272802602E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   7.0626241640481E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.5246864410612E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.4193444978207E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.6945034381852E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5973136681176E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.3859909459740E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8185654219917E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.2295349037621E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   8.7366133651514E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.1443455981944E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3220505511644E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7536756188514E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.9377029417189E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2722162300165E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2868109780420E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.2653835191643E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3904079254744E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.7654124656173E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.7151599609599E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1911272807342E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   7.0626241658863E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.5246864410655E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.4193444978282E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.6945034405337E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5973136684107E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.3859909459764E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8185654220332E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.2295349043276E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.2961660694223E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.3445467883748E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   6.3058986045457E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.2682386897473E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.6690764024145E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   6.8760112102570E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -3.5106179433835E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.2680706978900E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   2.4884831756649E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.1243592671441E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   6.9563193428764E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.8823589096814E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.2503318510101E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.1546037107867E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1016905386427E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3491019451471E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.0446918283930E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -7.0746238356533E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   7.4450043098199E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.9642441310636E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   1.2643492381711E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.4930898782573E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.0971736288664E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   7.6918727134646E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   3.1183356528935E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   2.9008052527149E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.2853302085910E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   3.6985049766867E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   5.1554346765436E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   9.6006965732778E-06
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   5.8404489312082E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -6.9070770333836E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   1.7327623721723E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.1868890827137E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.2530265427025E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.5973136681176E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -5.6945034381852E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.3859909459740E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8185654219917E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   6.2295349037621E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.0495876448868E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.4353225014184E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -7.1854618991565E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.1012698036356E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   5.6040784611633E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.1911272802602E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -1.7151599609709E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -7.0626241640481E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   3.5246864410612E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   6.4193444978207E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.5973136681176E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -5.6945034381852E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.3859909459740E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.8185654219917E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.2295349037621E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -4953,154 +4540,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0380334664305E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2620269948290E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6421129749063E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6351421370071E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3933746542041E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2845422820656E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5206865943202E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0748743185529E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6083141748580E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.5275265028993E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0177503448333E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.1993088416089E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.7491354620574E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.4257401153408E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.7826383195305E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5616239404707E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4100651327787E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6655422354161E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6685804581885E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5267599673800E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6429856671437E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6350141654768E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777398274000E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3888710409113E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1122193656950E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0380327848128E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2620269980243E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6421135627989E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6351421390029E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3933745877423E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2845385506490E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5206869726435E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0748743617175E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6083141964299E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.5275264980585E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0177503772975E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.1993048022534E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.7491358790843E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.4257400900893E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.7826382902091E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5616239396319E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4100651333792E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6655422353272E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6685804582460E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5267599676002E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6429856686709E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6350141652860E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777398273612E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3888710409206E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1122193648458E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.23345647532014E-17  2.82609713947343E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.06251812903579E-17  2.82609696851587E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.1447898412872E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.7823959594880E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7061866717855E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6985448749226E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.4798547335916E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1611998146931E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.9315029261943E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6626424481917E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.2096690268435E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.2820199144464E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0558694825367E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6269044368759E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0044747350291E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.2262075105979E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.6871740764645E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.8300591709878E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.9177857932782E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.6628313894493E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.3776276883887E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4477338623450E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.1447898540902E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.7823959144999E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7061866355202E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6985448868212E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.4798545871356E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1611997888349E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.9315032080947E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6626424482158E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.2096690238858E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.2820198713359E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0558694825219E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6269044373804E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0044747353159E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.2262075106059E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.6871740765304E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.8300591804426E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.9177857930780E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.6628313894828E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.3776276884855E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   7.4477338658311E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7480204567690E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.0140828831781E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.9076870455000E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.9180369146036E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   9.1486312347752E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   9.0427739179541E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -4.7020038691979E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.6359870947112E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   3.3609711811887E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.4831604288112E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   9.5556847484581E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -5.2227367659484E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6440278323707E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   2.9118710925987E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.4692515120434E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.2858074860992E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3195984052221E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -8.7488305379349E-04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   9.6799978016285E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.0066615487712E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.0435769315791E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.0099630190156E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.3507536634885E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.0122036375151E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.4814968224413E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8312662762439E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -2.7782714100330E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   4.5617016986111E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   6.2587748395845E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.1750736913138E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   7.2805799319818E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -8.1512516282770E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.1169684730169E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.4406254326817E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   2.7452827022975E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   1.9177857932782E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -6.8300591709878E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.6628313894493E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.3776276883887E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   7.4477338623450E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.4577177570865E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -1.7206628940516E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -9.6533719958130E-07
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   3.7189885909455E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   6.7136219743437E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   2.6269044368759E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.0558694825367E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0044747350291E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.2262075105979E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   7.6871740764645E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.9177857932782E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -6.8300591709878E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.6628313894493E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.3776276883887E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   7.4477338623450E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5112,154 +4613,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.8086732723888E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5420286125690E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4650543262333E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1680725286819E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.6912086193136E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0353827009282E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3834189791711E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4120646861903E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1488698631096E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.9098021761757E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.1012662162274E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.0319098769143E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.6156090729822E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6601822884972E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4248987967754E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9856773639198E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1437252225059E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4429366506704E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7777563412219E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7788857847490E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4166072393493E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0801723270609E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572014009561E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6202632702739E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6299671106363E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.8086708389193E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5420285448480E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4650550222632E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1680725337094E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.6912085814030E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0353763470209E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3834194280849E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4120648667796E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1488698866228E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.9098022168334E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.1012661298198E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.0319096420033E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.6156085365249E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.6601822896869E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4248989102644E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9856773628058E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1437252237116E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4429366505237E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7777563413308E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7788857850699E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4166072415912E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0801723270999E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572014008915E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6202632702766E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6299671088972E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   1.30104260698261E-18  3.42522118313852E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -4.81385764583564E-17  3.42522679146320E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4016871132294E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.3793603695123E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0670308517641E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.7177641864612E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.0197074527474E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.5051609013028E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.0650998614652E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.0630693527412E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.1051441717089E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.8127329035505E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3957376764461E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0621964139827E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3722963180527E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.9257168393705E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.9488050427941E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.9506657665906E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1914202818700E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.9390346185319E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9337219635444E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.6667219588768E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4016870970520E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.3793604057994E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.0670309597572E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.7177642023617E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.0197073444396E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.5051608102279E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.0651011799130E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.0630693100597E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.1051442097320E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.8127330550075E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3957376764427E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0621964132479E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.3722963187203E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.9257168393820E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.9488050428565E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.9506657684562E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1914202815130E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.9390346185604E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.9337219636053E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.6667219606776E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1970722176906E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.6839889038956E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =  -2.8078485949922E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5660072580536E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0602962857014E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.1057338263959E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -5.8089743671608E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -1.9805540890659E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   4.3071162971226E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.8581769772517E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.2189809260795E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -6.3613018748310E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.0417141220622E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   3.7448059303804E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.8593110593299E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.0994674469706E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.6776741761546E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.0111809045643E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.1674370380604E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   4.8146327681438E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.2189962627341E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.2850893624038E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.6125346691178E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2313598834381E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   5.3990765971853E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.4954945259575E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.2426731936591E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.2079200944066E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   7.2522732877226E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.3581007502997E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.0549419916004E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -9.2714988944027E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.4464082856940E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.6541989309916E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.1315206705097E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.1914202818700E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -7.9506657665906E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.9390346185319E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.9337219635444E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   8.6667219588768E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   2.8655613614961E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.0052410982882E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.2554994552799E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.3352680648762E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   7.8189548124887E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.0621964139827E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.3957376764461E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.3722963180527E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   4.9257168393705E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   8.9488050427941E-07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.1914202818700E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.9506657665906E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   1.9390346185319E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   3.9337219635444E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   8.6667219588768E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5271,154 +4686,68 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.6378469229058E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1098471635779E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0631814251570E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7308407751878E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.2081372647205E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.9186744354760E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4003283040805E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0912853539266E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7230382604165E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2376629621555E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3942763893914E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1746802126295E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3466395998626E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.7354734120575E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4806128039697E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.4085618123630E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8768537728430E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2201749195106E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8863893724921E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0303562113254E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1900711844653E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5315513303741E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4365860509956E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8516761247145E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1485740096042E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.6378447249352E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1098471575564E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0631818988408E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7308407867081E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.2081372724337E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.9186688424617E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.4003278220195E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0912853573094E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7230382889236E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2376629668709E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3942768398887E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1746803745100E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3466395459160E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.7354733914717E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.4806126792487E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.4085618108870E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8768537740375E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2201749192780E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8863893726406E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0303562117087E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1900711874484E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5315513304825E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4365860508907E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8516761247154E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1485740070370E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   4.77048955893622E-18  3.92697912650105E-03
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   3.12250225675825E-17  3.92697074388115E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.6283012430406E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.0087133045335E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.3744942537973E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.7932884456611E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.5462566128343E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.8346989606242E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.5261977737393E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.4531000527076E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.0601541489695E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.3395357313066E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.7350576244154E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4965139256334E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0631441124039E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.6164096032959E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.0202880125332E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.0353237359624E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4445215701600E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.2147933048579E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.4870470556466E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.8690123544427E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.6283012573475E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.0087133074189E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.3744944232412E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.7932884748583E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.5462566144042E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.8346989126678E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.5261996354343E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.4531000026017E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.0601542296673E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.3395361364650E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.7350576243059E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4965139211518E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   1.0631441134345E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.6164096033085E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.0202880125395E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.0353237378121E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4445215702687E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.2147933048706E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.4870470556382E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.8690123539962E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.6437887356290E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -5.3544909412031E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.1256159994071E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   5.1867181019255E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.2100290704437E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2794981308728E+01
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -6.7708791035137E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.2726852254371E-02
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   5.3106490993382E-01
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.2363438308640E-03
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.4723238290970E+01
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -7.3631828603106E+00
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   2.4300506702729E-02
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   4.6394393276870E-01
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.2593043644942E-03
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.3296246264526E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -2.0285589283237E-01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -1.1385808402104E-03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3747730421765E-02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.6970539792851E-05
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.7901268317752E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -2.4201662027517E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   1.8565281691418E-03
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.4658789822475E-02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.3219896641656E-05
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.8223603400273E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.7284431957253E-02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   5.9739067140204E-04
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   8.2537407503041E-03
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   1.5499475437000E-05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   8.6068436276226E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0337375874268E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.8099342041846E+00
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   1.8694063193673E+01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   3.5311314422429E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   2.4445215701600E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -9.0353237359624E+06
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   2.2147933048579E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   4.4870470556466E+05
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   9.8690123544427E+02
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.2725190201466E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -2.2893380003346E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -1.0981091354791E-06
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   4.9460156486765E-04
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   8.9182120554959E-07
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   3.4965139256334E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -2.7350576244154E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -1.0631441124039E-06
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   5.6164096032959E-04
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   1.0202880125332E-06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   2.4445215701600E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -9.0353237359624E+06
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   2.2147933048579E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   4.4870470556466E+05
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   9.8690123544427E+02
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
@@ -5450,31 +4779,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9930191378103E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3992997238554E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6850185585653E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2534889798711E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4146503297227E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0974561368859E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1490405641979E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3151606009566E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2205418146383E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4469794571266E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3465575413422E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.6017286219914E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4297605825433E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2052529111164E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.9928256123635E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8301821699540E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.6094158880793E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.9972563626565E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9946125163717E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2811436513423E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9633266087554E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9834690484516E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6158823668121E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0831251998477E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6675933323453E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9930177022204E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3992997164150E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6850186211539E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2534889955157E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.4146503409464E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0974556343888E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1490405207087E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3151606226649E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2205418379321E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4469794591860E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3465569957187E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -8.6017286272047E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.4297606000341E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2052528937771E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.9928255651545E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8301821681353E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.6094158892449E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.9972563623450E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9946125165621E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2811436518239E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9633266124497E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9834690485795E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6158823666713E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0831251998401E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6675933290847E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5973,231 +5302,231 @@ grad-res -------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5351.6975942850113
-(PID.TID 0000.0001)         System time:   8.5260327756404877
-(PID.TID 0000.0001)     Wall clock time:   5409.7569811344147
+(PID.TID 0000.0001)           User time:   3929.4594741463661
+(PID.TID 0000.0001)         System time:   10.528205335140228
+(PID.TID 0000.0001)     Wall clock time:   3962.6680150032043
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.618197977542877
-(PID.TID 0000.0001)         System time:  0.73539304733276367
-(PID.TID 0000.0001)     Wall clock time:   18.996614933013916
+(PID.TID 0000.0001)           User time:   9.9977798759937286
+(PID.TID 0000.0001)         System time:  0.75567999482154846
+(PID.TID 0000.0001)     Wall clock time:   13.709433078765869
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   2310.4545917510986
-(PID.TID 0000.0001)         System time:   3.3261749744415283
-(PID.TID 0000.0001)     Wall clock time:   2339.5019850730896
+(PID.TID 0000.0001)           User time:   1638.6252241134644
+(PID.TID 0000.0001)         System time:   4.1103827953338623
+(PID.TID 0000.0001)     Wall clock time:   1655.3390619754791
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   391.03820800781250
-(PID.TID 0000.0001)         System time:  0.52853381633758545
-(PID.TID 0000.0001)     Wall clock time:   395.44285964965820
+(PID.TID 0000.0001)           User time:   302.84176635742188
+(PID.TID 0000.0001)         System time:  0.60351586341857910
+(PID.TID 0000.0001)     Wall clock time:   305.64242959022522
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1604919433593750
-(PID.TID 0000.0001)         System time:   1.4424324035644531E-005
-(PID.TID 0000.0001)     Wall clock time:   8.1747930049896240
+(PID.TID 0000.0001)           User time:   6.1425476074218750
+(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
+(PID.TID 0000.0001)     Wall clock time:   6.1562047004699707
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.4479980468750000
-(PID.TID 0000.0001)         System time:   5.6818723678588867E-002
-(PID.TID 0000.0001)     Wall clock time:   7.4586560726165771
+(PID.TID 0000.0001)           User time:   4.4741210937500000
+(PID.TID 0000.0001)         System time:   7.5869560241699219E-002
+(PID.TID 0000.0001)     Wall clock time:   4.8429036140441895
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.5788574218750000
-(PID.TID 0000.0001)         System time:   2.8923511505126953E-002
-(PID.TID 0000.0001)     Wall clock time:   6.5197761058807373
+(PID.TID 0000.0001)           User time:   3.7937927246093750
+(PID.TID 0000.0001)         System time:   3.5942077636718750E-002
+(PID.TID 0000.0001)     Wall clock time:   4.0787165164947510
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.6550292968750000E-003
-(PID.TID 0000.0001)         System time:   9.9897384643554688E-004
-(PID.TID 0000.0001)     Wall clock time:   9.0622901916503906E-004
+(PID.TID 0000.0001)           User time:   1.2207031250000000E-003
+(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.0718269348144531E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60864257812500000
-(PID.TID 0000.0001)         System time:   1.0728836059570312E-005
-(PID.TID 0000.0001)     Wall clock time:  0.60887026786804199
+(PID.TID 0000.0001)           User time:  0.45294189453125000
+(PID.TID 0000.0001)         System time:   1.0163784027099609E-003
+(PID.TID 0000.0001)     Wall clock time:  0.45676565170288086
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25454711914062500
-(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25722837448120117
+(PID.TID 0000.0001)           User time:  0.21188354492187500
+(PID.TID 0000.0001)         System time:   1.4066696166992188E-005
+(PID.TID 0000.0001)     Wall clock time:  0.21394491195678711
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.809783935546875
-(PID.TID 0000.0001)         System time:   8.9949369430541992E-003
-(PID.TID 0000.0001)     Wall clock time:   13.834371805191040
+(PID.TID 0000.0001)           User time:   11.501586914062500
+(PID.TID 0000.0001)         System time:   1.2992620468139648E-002
+(PID.TID 0000.0001)     Wall clock time:   11.539720535278320
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   116.74505615234375
-(PID.TID 0000.0001)         System time:   3.9958953857421875E-003
-(PID.TID 0000.0001)     Wall clock time:   116.91865682601929
+(PID.TID 0000.0001)           User time:   89.508239746093750
+(PID.TID 0000.0001)         System time:   3.0512809753417969E-003
+(PID.TID 0000.0001)     Wall clock time:   89.647543430328369
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2863464355468750
-(PID.TID 0000.0001)         System time:   9.9754333496093750E-004
-(PID.TID 0000.0001)     Wall clock time:   2.2894222736358643
+(PID.TID 0000.0001)           User time:   1.9497070312500000
+(PID.TID 0000.0001)         System time:   1.5735626220703125E-005
+(PID.TID 0000.0001)     Wall clock time:   1.9500637054443359
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.159210205078125
-(PID.TID 0000.0001)         System time:   2.9981136322021484E-003
-(PID.TID 0000.0001)     Wall clock time:   16.179602146148682
+(PID.TID 0000.0001)           User time:   13.395812988281250
+(PID.TID 0000.0001)         System time:   1.5936851501464844E-002
+(PID.TID 0000.0001)     Wall clock time:   13.427810192108154
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6193542480468750
-(PID.TID 0000.0001)         System time:   9.8729133605957031E-004
-(PID.TID 0000.0001)     Wall clock time:   2.6248073577880859
+(PID.TID 0000.0001)           User time:   2.1044921875000000
+(PID.TID 0000.0001)         System time:   1.2636184692382812E-005
+(PID.TID 0000.0001)     Wall clock time:   2.1090009212493896
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.9893493652343750
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   4.9929099082946777
+(PID.TID 0000.0001)           User time:   3.8854675292968750
+(PID.TID 0000.0001)         System time:   1.0728836059570312E-005
+(PID.TID 0000.0001)     Wall clock time:   3.9854130744934082
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25991821289062500
+(PID.TID 0000.0001)           User time:  0.20700073242187500
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.26265597343444824
+(PID.TID 0000.0001)     Wall clock time:  0.20881700515747070
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.2197875976562500
-(PID.TID 0000.0001)         System time:   3.9751529693603516E-003
-(PID.TID 0000.0001)     Wall clock time:   7.2309224605560303
+(PID.TID 0000.0001)           User time:   5.7264709472656250
+(PID.TID 0000.0001)         System time:   1.2964487075805664E-002
+(PID.TID 0000.0001)     Wall clock time:   5.7559201717376709
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   84.127593994140625
-(PID.TID 0000.0001)         System time:   1.0011196136474609E-003
-(PID.TID 0000.0001)     Wall clock time:   84.231177091598511
+(PID.TID 0000.0001)           User time:   65.299072265625000
+(PID.TID 0000.0001)         System time:   2.9892921447753906E-003
+(PID.TID 0000.0001)     Wall clock time:   65.690090894699097
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2512207031250000E-003
+(PID.TID 0000.0001)           User time:   1.4648437500000000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.3936920166015625E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0122222900390625E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1271362304687500
+(PID.TID 0000.0001)           User time:  0.78894042968750000
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.1278192996978760
+(PID.TID 0000.0001)     Wall clock time:  0.79044032096862793
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.5776367187500000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9526176452636719E-004
+(PID.TID 0000.0001)           User time:   9.7656250000000000E-004
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   8.5806846618652344E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0145568847656250
-(PID.TID 0000.0001)         System time:  0.10594892501831055
-(PID.TID 0000.0001)     Wall clock time:   2.5100038051605225
+(PID.TID 0000.0001)           User time:   1.7936401367187500
+(PID.TID 0000.0001)         System time:  0.12689685821533203
+(PID.TID 0000.0001)     Wall clock time:   2.2338478565216064
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6250610351562500
-(PID.TID 0000.0001)         System time:  0.33881783485412598
-(PID.TID 0000.0001)     Wall clock time:   3.7344808578491211
+(PID.TID 0000.0001)           User time:   2.3323669433593750
+(PID.TID 0000.0001)         System time:  0.34674096107482910
+(PID.TID 0000.0001)     Wall clock time:   3.4391465187072754
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   22.469940185546875
-(PID.TID 0000.0001)         System time:  0.63365173339843750
-(PID.TID 0000.0001)     Wall clock time:   28.381501197814941
+(PID.TID 0000.0001)           User time:   19.208221435546875
+(PID.TID 0000.0001)         System time:  0.73461866378784180
+(PID.TID 0000.0001)     Wall clock time:   21.902542114257812
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   8.1640319824218750
-(PID.TID 0000.0001)         System time:  0.14392209053039551
-(PID.TID 0000.0001)     Wall clock time:   8.3338489532470703
+(PID.TID 0000.0001)           User time:   6.8945312500000000
+(PID.TID 0000.0001)         System time:  0.15595817565917969
+(PID.TID 0000.0001)     Wall clock time:   7.0765471458435059
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6506347656250000
-(PID.TID 0000.0001)         System time:  0.10493707656860352
-(PID.TID 0000.0001)     Wall clock time:   4.7168910503387451
+(PID.TID 0000.0001)           User time:   3.0572509765625000
+(PID.TID 0000.0001)         System time:  0.14198017120361328
+(PID.TID 0000.0001)     Wall clock time:   3.2432260513305664
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.6447753906250000
-(PID.TID 0000.0001)         System time:   8.2979202270507812E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8014991283416748
+(PID.TID 0000.0001)           User time:   3.0625000000000000
+(PID.TID 0000.0001)         System time:   8.3996772766113281E-002
+(PID.TID 0000.0001)     Wall clock time:   3.5516660213470459
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3022.3291015625000
-(PID.TID 0000.0001)         System time:   4.2765235900878906
-(PID.TID 0000.0001)     Wall clock time:   3042.7398819923401
+(PID.TID 0000.0001)           User time:   2274.7166748046875
+(PID.TID 0000.0001)         System time:   5.4361505508422852
+(PID.TID 0000.0001)     Wall clock time:   2286.8245251178741
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2677.3806152343750
-(PID.TID 0000.0001)         System time:   3.2333774566650391
-(PID.TID 0000.0001)     Wall clock time:   2690.8929340839386
+(PID.TID 0000.0001)           User time:   2005.5218505859375
+(PID.TID 0000.0001)         System time:   4.1886305809020996
+(PID.TID 0000.0001)     Wall clock time:   2014.6356070041656
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   344.67163085937500
-(PID.TID 0000.0001)         System time:   1.0241599082946777
-(PID.TID 0000.0001)     Wall clock time:   351.20337080955505
+(PID.TID 0000.0001)           User time:   268.95251464843750
+(PID.TID 0000.0001)         System time:   1.1895380020141602
+(PID.TID 0000.0001)     Wall clock time:   271.85663533210754
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4589843750000000
-(PID.TID 0000.0001)         System time:   9.8800659179687500E-004
-(PID.TID 0000.0001)     Wall clock time:   5.4697675704956055
+(PID.TID 0000.0001)           User time:   4.0108642578125000
+(PID.TID 0000.0001)         System time:   1.0004043579101562E-003
+(PID.TID 0000.0001)     Wall clock time:   4.0146009922027588
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7822265625000000E-002
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.8740653991699219E-002
+(PID.TID 0000.0001)           User time:   1.6601562500000000E-002
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   1.6965389251708984E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   305.37841796875000
-(PID.TID 0000.0001)         System time:   5.9753894805908203E-002
-(PID.TID 0000.0001)     Wall clock time:   307.40846824645996
+(PID.TID 0000.0001)           User time:   236.29187011718750
+(PID.TID 0000.0001)         System time:   9.6802711486816406E-002
+(PID.TID 0000.0001)     Wall clock time:   236.81897473335266
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8703613281250000
-(PID.TID 0000.0001)         System time:  0.30576372146606445
-(PID.TID 0000.0001)     Wall clock time:   6.7206749916076660
+(PID.TID 0000.0001)           User time:   5.3382568359375000
+(PID.TID 0000.0001)         System time:  0.34393501281738281
+(PID.TID 0000.0001)     Wall clock time:   6.2240965366363525
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7089843750000000E-003
+(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
 (PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.3658275604248047E-003
+(PID.TID 0000.0001)     Wall clock time:   2.1457672119140625E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   27.250000000000000
-(PID.TID 0000.0001)         System time:  0.65564775466918945
-(PID.TID 0000.0001)     Wall clock time:   30.883779764175415
+(PID.TID 0000.0001)           User time:   23.229736328125000
+(PID.TID 0000.0001)         System time:  0.74578762054443359
+(PID.TID 0000.0001)     Wall clock time:   24.708699703216553
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   5.3466796875000000E-002
-(PID.TID 0000.0001)         System time:   1.9998550415039062E-003
-(PID.TID 0000.0001)     Wall clock time:   6.0159921646118164E-002
+(PID.TID 0000.0001)           User time:   2.7099609375000000E-002
+(PID.TID 0000.0001)         System time:   2.0027160644531250E-003
+(PID.TID 0000.0001)     Wall clock time:   3.4371852874755859E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6237,9 +5566,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         897304
+(PID.TID 0000.0001) //            No. barriers =         895662
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         897304
+(PID.TID 0000.0001) //     Total barrier spins =         895662
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,11 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #611: due to single prec tapes (isbyte=4), switching to local tapes
+    in gad_advection.F affects AD-grad of ecco_v4 exp. (6 matching digits left)
+    and AD monitor (in all 4 llc90 + 2 cs32 exp); update all 4 llc90 output_adm
+    reference output.
+
 checkpoint68i (2022/04/27) synchronised with main MITgcm code.
   - post PR #587 & #609: cleaning/updating some parameter files
 


### PR DESCRIPTION
After merging PR 611 ( https://github.com/MITgcm/MITgcm/pull/611 ), update all 4 global_oce_llc90 ADM ref output.

This is a side effect of using single prec tapes (isbyte=4), since switching to local tapes
in gad_advection.F with less recomputations results in differences (vs recomputing some terms 
in full prec). For the same reason (isbyte=4), AD-monitor in exp. global_oce_cs32 are also affected 
but not as much (not updated here).

Note: AD-grad (or Cost or FWD grad) were not affected, except for ecco_v4 AD-test
with only 6 matching digits remains (--> fail to pass). So updating the 3 others ADM outp
was not strictly necessary. However, since AD-monitor were affected in all 4 tests
(with only 5 matching digits remaining for some of them) this would have made detection of
future changes more tricky to detect without this update.
