### PR TITLE
Post pr637 gmredi ctrl

### DIFF
--- a/global_oce_cs32/code/CTRL_OPTIONS.h
+++ b/global_oce_cs32/code/CTRL_OPTIONS.h
@@ -33,9 +33,7 @@ C o I/O and pack settings
 
 C This allows for GMREDI controls
 #define ALLOW_KAPGM_CONTROL
-# undef ALLOW_KAPGM_CONTROL_OLD
 #define ALLOW_KAPREDI_CONTROL
-# undef ALLOW_KAPREDI_CONTROL_OLD
 
 C This allows for DIFFKR controls
 #define ALLOW_DIFFKR_CONTROL

--- a/global_oce_cs32/code/GMREDI_OPTIONS.h
+++ b/global_oce_cs32/code/GMREDI_OPTIONS.h
@@ -18,6 +18,11 @@ C -- exclude the clipping/tapering part of the code that is not used
 C #define GM_EXCLUDE_TAPERING
 #define GM_EXCLUDE_SUBMESO
 
+C Allows to read-in background 3-D Redi and GM diffusivity coefficients
+C Note: need these to be defined for use as control (pkg/ctrl) parameters
+#define GM_READ_K3D_REDI
+#define GM_READ_K3D_GM
+
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
 C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi

--- a/global_oce_llc90/code/CTRL_OPTIONS.h
+++ b/global_oce_llc90/code/CTRL_OPTIONS.h
@@ -33,9 +33,7 @@ C o I/O and pack settings
 
 C This allows for GMREDI controls
 #define ALLOW_KAPGM_CONTROL
-# undef ALLOW_KAPGM_CONTROL_OLD
 #define ALLOW_KAPREDI_CONTROL
-# undef ALLOW_KAPREDI_CONTROL_OLD
 
 C This allows for DIFFKR controls
 #define ALLOW_DIFFKR_CONTROL

--- a/global_oce_llc90/code/GMREDI_OPTIONS.h
+++ b/global_oce_llc90/code/GMREDI_OPTIONS.h
@@ -18,6 +18,11 @@ C -- exclude the clipping/tapering part of the code that is not used
 C #define GM_EXCLUDE_TAPERING
 #define GM_EXCLUDE_SUBMESO
 
+C Allows to read-in background 3-D Redi and GM diffusivity coefficients
+C Note: need these to be defined for use as control (pkg/ctrl) parameters
+#define GM_READ_K3D_REDI
+#define GM_READ_K3D_GM
+
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
 C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #637: define new CPP options GM_INPUT_K3D_GM & GM_INPUT_K3D_REDI
+    (in GMREDI_OPTIONS.h) to use ALLOW_KAPGM_CONTROL & ALLOW_KAPREDI_CONTROL
+
 checkpoint68j (2022/06/28) synchronised with main MITgcm code.
   - post PR #611: due to single prec tapes (isbyte=4), switching to local tapes
     in gad_advection.F affects AD-grad of ecco_v4 exp. (6 matching digits left)


### PR DESCRIPTION
Define new options GM_INPUT_K3D_GM and GM_INPUT_K3D_REDI for experiments global_oce_cs32 and global_oce_ll90 since this is now needed (after merging PR https://github.com/MITgcm/MITgcm/pull/637)  to use KAPGM_CONTROL ans KAPREDI_CONTROL