### PR TITLE
remove retired parameters useSmoothCorrel2/3D

### DIFF
--- a/global_oce_cs32/code/CTRL_OPTIONS.h
+++ b/global_oce_cs32/code/CTRL_OPTIONS.h
@@ -43,13 +43,6 @@ C o sets of controls
 #define ALLOW_GENARR2D_CONTROL
 #define ALLOW_GENARR3D_CONTROL
 
-C  o use pkg/smooth correlation operator (incl. smoother) for 3D controls (Weaver, Courtier 01)
-C    This CPP option just sets the default for ctrlSmoothCorrel23 to .TRUE.
-#define ALLOW_SMOOTH_CORREL3D
-C  o use pkg/smooth correlation operator (incl. smoother) for 2D controls (Weaver, Courtier 01)
-C    This CPP option just sets the default for ctrlSmoothCorrel2D to .TRUE.
-#define ALLOW_SMOOTH_CORREL2D
-
 C  o impose bounds on controls
 #define ALLOW_ADCTRLBOUND
 
@@ -61,4 +54,3 @@ C   ==================================================================
 #endif /* ndef ECCO_CPPOPTIONS_H */
 #endif /* ALLOW_CTRL */
 #endif /* CTRL_OPTIONS_H */
-

--- a/global_oce_cs32/input_ad.sens/data.ctrl
+++ b/global_oce_cs32/input_ad.sens/data.ctrl
@@ -3,8 +3,6 @@
 # **********************
  &ctrl_nml
  doSinglePrecTapelev=.TRUE.,
- ctrlSmoothCorrel2D=.TRUE.,
- ctrlSmoothCorrel3D=.FALSE.,
  &
 #
 # *********************
@@ -69,4 +67,3 @@
  mult_genarr3d(3) = 0.,
 #
  &
-

--- a/global_oce_cs32/input_ad/data.ctrl
+++ b/global_oce_cs32/input_ad/data.ctrl
@@ -3,8 +3,6 @@
 # **********************
  &ctrl_nml
  doSinglePrecTapelev=.TRUE.,
- ctrlSmoothCorrel2D=.TRUE.,
- ctrlSmoothCorrel3D=.FALSE.,
  &
 #
 # *********************

--- a/global_oce_llc90/code/CTRL_OPTIONS.h
+++ b/global_oce_llc90/code/CTRL_OPTIONS.h
@@ -43,13 +43,6 @@ C o sets of controls
 #define ALLOW_GENARR2D_CONTROL
 #define ALLOW_GENARR3D_CONTROL
 
-C  o use pkg/smooth correlation operator (incl. smoother) for 3D controls (Weaver, Courtier 01)
-C    This CPP option just sets the default for ctrlSmoothCorrel23 to .TRUE.
-#define ALLOW_SMOOTH_CORREL3D
-C  o use pkg/smooth correlation operator (incl. smoother) for 2D controls (Weaver, Courtier 01)
-C    This CPP option just sets the default for ctrlSmoothCorrel2D to .TRUE.
-#define ALLOW_SMOOTH_CORREL2D
-
 C  o impose bounds on controls
 #define ALLOW_ADCTRLBOUND
 
@@ -61,4 +54,3 @@ C   ==================================================================
 #endif /* ndef ECCO_CPPOPTIONS_H */
 #endif /* ALLOW_CTRL */
 #endif /* CTRL_OPTIONS_H */
-

--- a/global_oce_llc90/input_ad.core2/data.ctrl
+++ b/global_oce_llc90/input_ad.core2/data.ctrl
@@ -2,8 +2,6 @@
 # ECCO controlvariables
 # *********************
  &ctrl_nml
- ctrlSmoothCorrel2D=.TRUE.,
- ctrlSmoothCorrel3D=.TRUE.,
  &
 #
 # *********************
@@ -57,4 +55,3 @@
  mult_genarr3d(3) = 1.,
 #
  &
-

--- a/global_oce_llc90/input_ad.ecco_v4/data.ctrl
+++ b/global_oce_llc90/input_ad.ecco_v4/data.ctrl
@@ -2,8 +2,6 @@
 # ECCO controlvariables
 # *********************
  &ctrl_nml
- ctrlSmoothCorrel2D=.TRUE.,
- ctrlSmoothCorrel3D=.TRUE.,
  &
 #
 # *********************
@@ -57,4 +55,3 @@
  mult_genarr3d(3) = 1.,
 #
  &
-

--- a/global_oce_llc90/input_ad.ecmwf/data.ctrl
+++ b/global_oce_llc90/input_ad.ecmwf/data.ctrl
@@ -2,8 +2,6 @@
 # ECCO controlvariables
 # *********************
  &ctrl_nml
- ctrlSmoothCorrel2D=.TRUE.,
- ctrlSmoothCorrel3D=.TRUE.,
  &
 #
 # *********************
@@ -57,4 +55,3 @@
  mult_genarr3d(3) = 1.,
 #
  &
-

--- a/global_oce_llc90/input_ad/data.ctrl
+++ b/global_oce_llc90/input_ad/data.ctrl
@@ -3,8 +3,6 @@
 # *********************
  &ctrl_nml
  doSinglePrecTapelev=.TRUE.,
- ctrlSmoothCorrel2D=.TRUE.,
- ctrlSmoothCorrel3D=.TRUE.,
  &
 #
 # *********************
@@ -58,4 +56,3 @@
  mult_genarr3d(3) = 1.,
 #
  &
-

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - remove both parameters "useSmoothCorrel2D/3D" from data.ctrl and options
+    ALLOW_SMOOTH_CORREL2D/3D from CTRL_OPTIONS.h in experiments: glogal_oce_cs32
+    and global_oce_llc90 (not doing anything outside ECCO_CTRL_DEPRECATED code).
   - post PR #637: define new CPP options GM_INPUT_K3D_GM & GM_INPUT_K3D_REDI
     (in GMREDI_OPTIONS.h) to use ALLOW_KAPGM_CONTROL & ALLOW_KAPREDI_CONTROL
 


### PR DESCRIPTION
In PR [#631](https://github.com/MITgcm/MITgcm/pull/631) the smoothing code within pkg/ctrl was removed and the associated runtime and CPP-flags were retired. Adjust global_oce_cs32 and global_oce_llc90 to remove these runtime flags. Results do not change.