### PR TITLE
Post pr714 output update

### DIFF
--- a/global_oce_cs32/code/GGL90_OPTIONS.h
+++ b/global_oce_cs32/code/GGL90_OPTIONS.h
@@ -21,5 +21,14 @@ C     Use horizontal averaging for viscosity and diffusivity as
 C     originally implemented in OPA.
 #define ALLOW_GGL90_SMOOTH
 
+C     allow IDEMIX model
+#undef ALLOW_GGL90_IDEMIX
+
+C     include Langmuir circulation parameterization
+#undef ALLOW_GGL90_LANGMUIR
+
+C     recover old bug prior to Jun 2023
+#undef GGL90_MISSING_HFAC_BUG
+
 #endif /* ALLOW_GGL90 */
 #endif /* GGL90_OPTIONS_H */

--- a/global_oce_cs32/results/output.txt
+++ b/global_oce_cs32/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint65z
-(PID.TID 0000.0001) // Build user:        gforget
-(PID.TID 0000.0001) // Build host:        GLACIER2.MIT.EDU
-(PID.TID 0000.0001) // Build date:        Tue Oct 11 13:36:40 EDT 2016
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // Build user:        jm_c
+(PID.TID 0000.0001) // Build host:        villon
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:33:31 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -30,9 +30,9 @@
 (PID.TID 0000.0001) // Computational Grid Specification ( see files "SIZE.h" )
 (PID.TID 0000.0001) //                                  ( and "eedata"       )
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001)      nPx =   24 ; /* No. processes in X */
+(PID.TID 0000.0001)      nPx =    8 ; /* No. processes in X */
 (PID.TID 0000.0001)      nPy =    1 ; /* No. processes in Y */
-(PID.TID 0000.0001)      nSx =    1 ; /* No. tiles in X per process */
+(PID.TID 0000.0001)      nSx =    3 ; /* No. tiles in X per process */
 (PID.TID 0000.0001)      nSy =    1 ; /* No. tiles in Y per process */
 (PID.TID 0000.0001)      sNx =   16 ; /* Tile size in X */
 (PID.TID 0000.0001)      sNy =   16 ; /* Tile size in Y */
@@ -43,31 +43,33 @@
 (PID.TID 0000.0001)       Nr =   50 ; /* No. levels in the vertical   */
 (PID.TID 0000.0001)       Nx =  384 ; /* Total domain size in X ( = nPx*nSx*sNx ) */
 (PID.TID 0000.0001)       Ny =   16 ; /* Total domain size in Y ( = nPy*nSy*sNy ) */
-(PID.TID 0000.0001)   nTiles =    1 ; /* Total no. tiles per process ( = nSx*nSy ) */
-(PID.TID 0000.0001)   nProcs =   24 ; /* Total no. processes ( = nPx*nPy ) */
+(PID.TID 0000.0001)   nTiles =    3 ; /* Total no. tiles per process ( = nSx*nSy ) */
+(PID.TID 0000.0001)   nProcs =    8 ; /* Total no. processes ( = nPx*nPy ) */
 (PID.TID 0000.0001) nThreads =    1 ; /* Total no. threads per process ( = nTx*nTy ) */
 (PID.TID 0000.0001) usingMPI =    T ; /* Flag used to control whether MPI is in use */
 (PID.TID 0000.0001)                   /*  note: To execute a program with MPI calls */
 (PID.TID 0000.0001)                   /*  it must be launched appropriately e.g     */
 (PID.TID 0000.0001)                   /*  "mpirun -np 64 ......"                    */
-(PID.TID 0000.0001) useCoupler=    F ;/* Flag used to control communications with   */
+(PID.TID 0000.0001) useCoupler=   F ; /* Flag used to control communications with   */
 (PID.TID 0000.0001)                   /*  other model components, through a coupler */
+(PID.TID 0000.0001) useNest2W_parent =    F ;/* Control 2-W Nesting comm */
+(PID.TID 0000.0001) useNest2W_child  =    F ;/* Control 2-W Nesting comm */
 (PID.TID 0000.0001) debugMode =    F ; /* print debug msg. (sequence of S/R calls)  */
 (PID.TID 0000.0001) printMapIncludesZeros=    F ; /* print zeros in Std.Output maps */
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len: 16 ) = GLACIER2.MIT.EDU
-(PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 23,0:  0)
+(PID.TID 0000.0001)  My Processor Name (len:  6 ) = villon
+(PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0:  7,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:   384,1:    16)
 (PID.TID 0000.0001)  North neighbor = processor 0000
 (PID.TID 0000.0001)  South neighbor = processor 0000
 (PID.TID 0000.0001)   East neighbor = processor 0001
-(PID.TID 0000.0001)   West neighbor = processor 0023
+(PID.TID 0000.0001)   West neighbor = processor 0007
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // Mapping of tiles to threads
 (PID.TID 0000.0001) // ======================================================
-(PID.TID 0000.0001) // -o- Thread   1, tiles (   1:   1,   1:   1)
+(PID.TID 0000.0001) // -o- Thread   1, tiles (   1:   3,   1:   1)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) W2_READPARMS: opening data.exch2
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.exch2
@@ -129,9 +131,9 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># Continuous equation parameters
 (PID.TID 0000.0001) > &PARM01
-(PID.TID 0000.0001) > tRef               = 3*23.,3*22.,21.,2*20.,19.,2*18.,17.,2*16.,15.,14.,13.,
-(PID.TID 0000.0001) >                      12.,11.,2*9.,8.,7.,2*6.,2*5.,3*4.,3*3.,4*2.,12*1.,
-(PID.TID 0000.0001) > sRef               = 50*34.5,
+(PID.TID 0000.0001) > tRef = 3*23., 3*22., 21., 2*20., 19., 2*18., 17., 2*16., 15., 14., 13.,
+(PID.TID 0000.0001) >        12., 11., 2*9., 8., 7., 2*6., 2*5., 3*4., 3*3., 4*2., 12*1.,
+(PID.TID 0000.0001) > sRef = 50*34.5,
 (PID.TID 0000.0001) > no_slip_sides  = .TRUE.,
 (PID.TID 0000.0001) > no_slip_bottom = .TRUE.,
 (PID.TID 0000.0001) >#
@@ -156,7 +158,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -219,12 +221,10 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > pChkptFreq  =31536000.0,
 (PID.TID 0000.0001) > chkptFreq   =31536000.0,
-(PID.TID 0000.0001) ># taveFreq    =31536000.0,
 (PID.TID 0000.0001) ># dumpFreq    =31536000.0,
 (PID.TID 0000.0001) > monitorFreq = 3600.0,
 (PID.TID 0000.0001) > dumpInitAndLast = .TRUE.,
-(PID.TID 0000.0001) > adjMonitorFreq = 864000.0,
-(PID.TID 0000.0001) > pickupStrictlyMatch=.FALSE.,
+(PID.TID 0000.0001) >#pickupStrictlyMatch=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -249,7 +249,6 @@
 (PID.TID 0000.0001) ># bathyFile      ='bathy_south.bin',
 (PID.TID 0000.0001) > hydrogThetaFile='some_T_atlas.bin',
 (PID.TID 0000.0001) > hydrogSaltFile ='some_S_atlas.bin',
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
@@ -271,6 +270,7 @@
 (PID.TID 0000.0001) ># Packages
 (PID.TID 0000.0001) > &PACKAGES
 (PID.TID 0000.0001) > useEXF             = .TRUE.,
+(PID.TID 0000.0001) > useCAL             = .TRUE.,
 (PID.TID 0000.0001) > useGMRedi          = .TRUE.,
 (PID.TID 0000.0001) > useSeaice          = .TRUE.,
 (PID.TID 0000.0001) > useGGL90           = .TRUE.,
@@ -315,7 +315,6 @@
  pkg/mom_common           compiled   and   used ( momStepping              = T )
  pkg/mom_vecinv           compiled   and   used ( +vectorInvariantMomentum = T )
  pkg/monitor              compiled   and   used ( monitorFreq > 0.         = T )
- pkg/timeave              compiled but not used ( taveFreq > 0.            = F )
  pkg/debug                compiled but not used ( debugMode                = F )
  pkg/exch2                compiled   and   used
  pkg/rw                   compiled   and   used
@@ -360,7 +359,6 @@
 (PID.TID 0000.0001) > humid_fac         = .608,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > exf_iprec         = 32,
-(PID.TID 0000.0001) > exf_yftype        = 'RL',
 (PID.TID 0000.0001) > useExfCheckRange  = .FALSE.,
 (PID.TID 0000.0001) > repeatPeriod      = 31536000.,
 (PID.TID 0000.0001) > useAtmWind        = .TRUE.,
@@ -614,6 +612,8 @@
 (PID.TID 0000.0001) > mxlSurfFlag=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001)  GGL90_READPARMS ; starts to read GGL90_PARM01
+(PID.TID 0000.0001)  GGL90_READPARMS: read GGL90_PARM01 : OK
 (PID.TID 0000.0001)  GGL90_READPARMS: finished reading data.ggl90
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // GGL90 configuration
@@ -622,58 +622,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -738,6 +738,15 @@
 (PID.TID 0000.0001) >      HsnowFile='siHSNOW.ini',
 (PID.TID 0000.0001) >      uIceFile='siUICE.ini',
 (PID.TID 0000.0001) >      vIceFile='siVICE.ini',
+(PID.TID 0000.0001) >#the following is needed to recover old default values
+(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >      SEAICE_drag=0.002,
+(PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
+(PID.TID 0000.0001) >      SEAICEetaZmethod=0,
+(PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
+(PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
+(PID.TID 0000.0001) >      SEAICE_OLx=0,
+(PID.TID 0000.0001) >      SEAICE_OLy=0,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
@@ -844,6 +853,7 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -867,7 +877,10 @@
 (PID.TID 0000.0001) ># ECCO cost functions
 (PID.TID 0000.0001) ># *******************
 (PID.TID 0000.0001) > &ECCO_COST_NML
+(PID.TID 0000.0001) > ecco_output_sterGloH=.TRUE.,
+(PID.TID 0000.0001) > ecco_keepTSeriesOutp_open=.TRUE.,
 (PID.TID 0000.0001) > /
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># ***************************
 (PID.TID 0000.0001) ># ECCO generic cost functions
 (PID.TID 0000.0001) ># ***************************
@@ -906,7 +919,6 @@
 (PID.TID 0000.0001) > mult_gencost(2) = 1.,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: finished reading #1: ecco_cost_nml
 (PID.TID 0000.0001) ECCO_READPARMS: finished reading #2: ecco_gencost_nml
@@ -937,23 +949,30 @@
 (PID.TID 0000.0001) // Parameter file "data.diagnostics"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Diagnostic Package Choices
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-(PID.TID 0000.0001) >#               > 0 : write time-average output every multiple of frequency (iter)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
 (PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-(PID.TID 0000.0001) >#                 when this entry is missing, select all common levels of this list
-(PID.TID 0000.0001) >#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file
-(PID.TID 0000.0001) >#                 for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#--------------------------------------------------------------------
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &diagnostics_list
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
 (PID.TID 0000.0001) >   dumpatlast = .TRUE.,
+(PID.TID 0000.0001) >   diagMdsDir = 'diags',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(1) = 2635200.0,
-(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 (PID.TID 0000.0001) >#stuff that is not quite state variables (and may not be quite
 (PID.TID 0000.0001) >#synchroneous) but are added here to reduce number of files
 (PID.TID 0000.0001) >                 'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -964,7 +983,6 @@
 (PID.TID 0000.0001) >                 'ADVxSNOW','ADVySNOW','DFxESNOW','DFyESNOW',
 (PID.TID 0000.0001) >                 'SIuice  ','SIvice  ',
 (PID.TID 0000.0001) >   filename(1) = 'state_2d_set1',
-(PID.TID 0000.0001) >#  filename(1) = 'diags/state_2d_set1',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(2) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:3,2) = 'THETA   ','SALT    ',
@@ -975,7 +993,6 @@
 (PID.TID 0000.0001) >#                'GGL90TKE','GGL90Lmx','GGL90Prl',
 (PID.TID 0000.0001) >#                'GGL90ArU','GGL90ArV','GGL90Kr ',
 (PID.TID 0000.0001) >   filename(2) = 'state_3d_set1',
-(PID.TID 0000.0001) >#  filename(2) = 'diags/state_3d_set1',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(3) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:5,3) = 'UVELMASS','VVELMASS','WVELMASS',
@@ -985,7 +1002,6 @@
 (PID.TID 0000.0001) >#full 3D temperature fluxes : 'DFxE_TH ','DFyE_TH ','DFrE_TH ','DFrI_TH ','ADVx_TH ','ADVy_TH ','ADVr_TH ',
 (PID.TID 0000.0001) >#but for present computations I only need the vertically integrated horizontal components (see trsp_3d_set2)
 (PID.TID 0000.0001) >   filename(3) = 'trsp_3d_set1',
-(PID.TID 0000.0001) >#  filename(3) = 'diags/trsp_3d_set1',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(4) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:8,4) = 'DFxE_TH ','DFyE_TH ','ADVx_TH ','ADVy_TH ',
@@ -997,20 +1013,20 @@
 (PID.TID 0000.0001) >  frequency(5) = -2635200.0,
 (PID.TID 0000.0001) >   fields(1:6,5) = 'ETAN    ','SIheff  ','SIhsnow ',
 (PID.TID 0000.0001) >                 'SIarea  ','sIceLoad','PHIBOT  ',
-(PID.TID 0000.0001) >#  filename(5) = 'diags/budg2d_snap_set1',
+(PID.TID 0000.0001) >#  filename(5) = 'budg2d_snap_set1',
 (PID.TID 0000.0001) >   timePhase(5)= 0.,
 (PID.TID 0000.0001) >   fileFlags(5) = 'D       ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(6) = -2635200.0,
 (PID.TID 0000.0001) >   fields(1:2,6) = 'THETA   ','SALT    ',
-(PID.TID 0000.0001) >#  filename(6) = 'diags/budg2d_snap_set2',
+(PID.TID 0000.0001) >#  filename(6) = 'budg2d_snap_set2',
 (PID.TID 0000.0001) >   timePhase(6)= 0.,
 (PID.TID 0000.0001) >   fileFlags(6) = 'DI      ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(7) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:7,7) = 'oceFWflx','SIatmFW ','TFLUX   ','SItflux ',
 (PID.TID 0000.0001) >                   'SFLUX   ','oceQsw  ','oceSPflx',
-(PID.TID 0000.0001) >#  filename(7) = 'diags/budg2d_zflux_set1',
+(PID.TID 0000.0001) >#  filename(7) = 'budg2d_zflux_set1',
 (PID.TID 0000.0001) >   fileFlags(7) = 'D       ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(8) = 2635200.0,
@@ -1019,13 +1035,13 @@
 (PID.TID 0000.0001) >                 'ADVx_SLT','ADVy_SLT','DFxE_SLT','DFyE_SLT',
 (PID.TID 0000.0001) >#the following are not transports but tendencies
 (PID.TID 0000.0001) >                 'oceSPtnd','AB_gT   ','AB_gS   ',
-(PID.TID 0000.0001) >#  filename(8) = 'diags/budg2d_hflux_set2',
+(PID.TID 0000.0001) >#  filename(8) = 'budg2d_hflux_set2',
 (PID.TID 0000.0001) >   fileFlags(8) = 'DI      ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(9) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:8,9) ='ADVxHEFF','ADVyHEFF','DFxEHEFF','DFyEHEFF',
 (PID.TID 0000.0001) >                 'ADVxSNOW','ADVySNOW','DFxESNOW','DFyESNOW',
-(PID.TID 0000.0001) >#  filename(9) = 'diags/budg2d_hflux_set1',
+(PID.TID 0000.0001) >#  filename(9) = 'budg2d_hflux_set1',
 (PID.TID 0000.0001) >   fileFlags(9) = 'D       ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) ># this one is important because it activates the vertical advection diags
@@ -1033,7 +1049,7 @@
 (PID.TID 0000.0001) >   fields(1:7,10) = 'ADVr_TH ','DFrE_TH ','DFrI_TH ',
 (PID.TID 0000.0001) >                  'ADVr_SLT','DFrE_SLT','DFrI_SLT',
 (PID.TID 0000.0001) >                  'WVELMASS',
-(PID.TID 0000.0001) >#  filename(10) = 'diags/budg2d_zflux_set3_11',
+(PID.TID 0000.0001) >#  filename(10) = 'budg2d_zflux_set3_11',
 (PID.TID 0000.0001) >   levels(1, 10)= 11.,
 (PID.TID 0000.0001) >   fileFlags(10) = 'D       ',
 (PID.TID 0000.0001) >#---
@@ -1041,7 +1057,7 @@
 (PID.TID 0000.0001) >   fields(1:10,11) ='SRELAX  ','TRELAX  ','WTHMASS ','WSLTMASS',
 (PID.TID 0000.0001) >                 'oceSflux','oceQnet ','SIatmQnt',
 (PID.TID 0000.0001) >                 'SIaaflux','SIsnPrcp','SIacSubl',
-(PID.TID 0000.0001) >#  filename(11) = 'diags/budg2d_zflux_set2',
+(PID.TID 0000.0001) >#  filename(11) = 'budg2d_zflux_set2',
 (PID.TID 0000.0001) >   fileFlags(11) = 'D       ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(12) = 2635200.0,
@@ -1049,7 +1065,7 @@
 (PID.TID 0000.0001) >                 'ADVx_TH ','ADVy_TH ','DFxE_TH ','DFyE_TH ',
 (PID.TID 0000.0001) >                 'ADVx_SLT','ADVy_SLT','DFxE_SLT','DFyE_SLT',
 (PID.TID 0000.0001) >                 'oceSPtnd','AB_gT   ','AB_gS   ',
-(PID.TID 0000.0001) >#  filename(12) = 'diags/budg2d_hflux_set3_11',
+(PID.TID 0000.0001) >#  filename(12) = 'budg2d_hflux_set3_11',
 (PID.TID 0000.0001) >   levels(1:40,12) = 11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,
 (PID.TID 0000.0001) >                     21.,22.,23.,24.,25.,26.,27.,28.,29.,30.,
 (PID.TID 0000.0001) >                     31.,32.,33.,34.,35.,36.,37.,38.,39.,40.,
@@ -1058,7 +1074,7 @@
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(13) = -2635200.0,
 (PID.TID 0000.0001) >   fields(1:2,13) = 'THETA   ','SALT    ',
-(PID.TID 0000.0001) >#  filename(13) = 'diags/budg2d_snap_set3_11',
+(PID.TID 0000.0001) >#  filename(13) = 'budg2d_snap_set3_11',
 (PID.TID 0000.0001) >   timePhase(13)= 0.,
 (PID.TID 0000.0001) >   levels(1:40,13) = 11.,12.,13.,14.,15.,16.,17.,18.,19.,20.,
 (PID.TID 0000.0001) >                     21.,22.,23.,24.,25.,26.,27.,28.,29.,30.,
@@ -1069,39 +1085,44 @@
 (PID.TID 0000.0001) >  frequency(14) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:8,14) = 'DFxE_TH ','DFyE_TH ','ADVx_TH ','ADVy_TH ',
 (PID.TID 0000.0001) >                 'DFxE_SLT','DFyE_SLT','ADVx_SLT','ADVy_SLT',
-(PID.TID 0000.0001) >#  filename(14) = 'diags/trsp_2d_set1',
+(PID.TID 0000.0001) >#  filename(14) = 'trsp_2d_set1',
 (PID.TID 0000.0001) >#vertically integrate fields we only use to compute vertically integr.
 (PID.TID 0000.0001) >#meridional transports (also omit vertical transports, both to save space)
 (PID.TID 0000.0001) >   fileFlags(14) = ' I      ',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(15) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:3,15) = 'RHOAnoma','PHIHYD  ','oceSPtnd',
-(PID.TID 0000.0001) >#  filename(15) = 'diags/state_3d_set2',
+(PID.TID 0000.0001) >#  filename(15) = 'state_3d_set2',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(16) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:7,16) = 'ADVr_TH ','DFrE_TH ','DFrI_TH ',
 (PID.TID 0000.0001) >        'ADVr_SLT','DFrE_SLT','DFrI_SLT','WVELMASS',
-(PID.TID 0000.0001) >#  filename(16) = 'diags/trsp_3d_set3',
+(PID.TID 0000.0001) >#  filename(16) = 'trsp_3d_set3',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(17) = 2635200.0,
 (PID.TID 0000.0001) >   fields(1:7,17) = 'TFLUX   ','SItflux ','SFLUX   ',
 (PID.TID 0000.0001) >        'oceQsw  ','oceSPflx','SIsnPrcp','SIacSubl',
-(PID.TID 0000.0001) >#  filename(17) = 'diags/state_2d_set2',
+(PID.TID 0000.0001) >#  filename(17) = 'state_2d_set2',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
 (PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 (PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-(PID.TID 0000.0001) >#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) > &DIAG_STATIS_PARMS
 (PID.TID 0000.0001) ># diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 (PID.TID 0000.0001) ># nSetRegMskFile=1,
@@ -1110,17 +1131,17 @@
 (PID.TID 0000.0001) ># val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 (PID.TID 0000.0001) >#                10.,11.,12.,13.,14.,15.,16.,17.
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-(PID.TID 0000.0001) >#                   'UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >#                   'THETA   ','SALT    ',
+(PID.TID 0000.0001) ># stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+(PID.TID 0000.0001) >#                      'UVEL    ','VVEL    ','WVEL    ',
+(PID.TID 0000.0001) >#                      'THETA   ','SALT    ',
 (PID.TID 0000.0001) >#    stat_fname(1)= 'dynStDiag',
 (PID.TID 0000.0001) >#     stat_freq(1)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 (PID.TID 0000.0001) >#                   10,11,12,13,14,15,16,17
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-(PID.TID 0000.0001) >#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-(PID.TID 0000.0001) >#                   'oceQnet ','oceSflux','oceFWflx',
+(PID.TID 0000.0001) ># stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+(PID.TID 0000.0001) >#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+(PID.TID 0000.0001) >#                      'oceQnet ','oceSflux','oceFWflx',
 (PID.TID 0000.0001) >#    stat_fname(2)= 'surfStDiag',
 (PID.TID 0000.0001) >#     stat_freq(2)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -1137,6 +1158,12 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  diag_mnc =   /* write NetCDF output files */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagMdsDir = /* directory for mds diagnostics output */
+(PID.TID 0000.0001)               'diags'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  diagMdsDirCreate = /* call mkdir to create diagMdsDir */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  useMissingValue = /* put MissingValue where mask = 0 */
 (PID.TID 0000.0001)                   F
@@ -1184,9 +1211,15 @@
 (PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SET_PARMS: done
-==> SYSTEM CALL (from INI_MODEL_IO): > mkdir -p profiles <
+==> SYSTEM CALL (from PROFILES_INI_IO): > mkdir -p profiles <
+ ==> SYSTEM CALL (from DIAGNOSTICS_INI_IO): > mkdir -p diags <
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) Enter INI_VERTICAL_GRID: setInterFDr=    T ; setCenterDr=    F
 (PID.TID 0000.0001) tile:   1 ; Read from file grid_cs32.face001.bin
+(PID.TID 0000.0001)   => xC yC dxF dyF rA xG yG dxV dyU rAz dxC dyC rAw rAs dxG dyG AngleCS AngleSN
+(PID.TID 0000.0001) tile:   2 ; Read from file grid_cs32.face001.bin
+(PID.TID 0000.0001)   => xC yC dxF dyF rA xG yG dxV dyU rAz dxC dyC rAw rAs dxG dyG AngleCS AngleSN
+(PID.TID 0000.0001) tile:   3 ; Read from file grid_cs32.face001.bin
 (PID.TID 0000.0001)   => xC yC dxF dyF rA xG yG dxV dyU rAz dxC dyC rAw rAs dxG dyG AngleCS AngleSN
 (PID.TID 0000.0001) %MON XC_max                       =   1.7854351589505E+02
 (PID.TID 0000.0001) %MON XC_min                       =  -1.7854351589505E+02
@@ -1385,11 +1418,17 @@
 (PID.TID 0000.0001) exf_output_interp = /* output directly interpolation result */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) diags_opOceWeighted = /* weight flux diags by open-ocean fraction */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_debugLev = /* select EXF-debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 3.600000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 3.153600000000000E+07
@@ -1451,22 +1490,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -1535,26 +1583,20 @@
 (PID.TID 0000.0001) // ALLOW_DOWNWARD_RADIATION:           defined
 (PID.TID 0000.0001) // ALLOW_BULKFORMULAE:                 defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Net shortwave flux forcing starts at                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing period is                0.
-(PID.TID 0000.0001)    Net shortwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001)    interpolate "swflux" (method=  1 ):
-(PID.TID 0000.0001)    lon0= 6.173E+04, nlon=    32, lon_inc= 1.235E+05
-(PID.TID 0000.0001)    lat0= 6.173E+04, nlat=    32, lat_inc= 1.235E+05
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Zonal wind forcing starts at                  -31568400.
 (PID.TID 0000.0001)    Zonal wind forcing period is                      21600.
+(PID.TID 0000.0001)    Zonal wind forcing repeat-cycle is             31536000.
 (PID.TID 0000.0001)    Zonal wind forcing is read from file:
-(PID.TID 0000.0001)    >>  CORE2_u10m_6hrly_r2_cnyf  <<
+(PID.TID 0000.0001)    >> CORE2_u10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "uwind" (method= 12 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Meridional wind forcing starts at             -31568400.
 (PID.TID 0000.0001)    Meridional wind forcing period is                 21600.
+(PID.TID 0000.0001)    Meridional wind forcing repeat-cycle is        31536000.
 (PID.TID 0000.0001)    Meridional wind forcing is read from file:
-(PID.TID 0000.0001)    >>  CORE2_v10m_6hrly_r2_cnyf  <<
+(PID.TID 0000.0001)    >> CORE2_v10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "vwind" (method= 22 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
@@ -1562,67 +1604,53 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Atmospheric temperature starts at             -31568400.
 (PID.TID 0000.0001)    Atmospheric temperature period is                 21600.
+(PID.TID 0000.0001)    Atmospheric temperature repeat-cycle is        31536000.
 (PID.TID 0000.0001)    Atmospheric temperature is read from file:
-(PID.TID 0000.0001)    >>  CORE2_tmp10m_6hrly_r2_cnyf  <<
+(PID.TID 0000.0001)    >> CORE2_tmp10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "atemp" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)    Atmospheric specific humidity starts at       -31568400.
 (PID.TID 0000.0001)    Atmospheric specific humidity period is           21600.
+(PID.TID 0000.0001)    Atmospheric specific humidity rep-cycle is     31536000.
 (PID.TID 0000.0001)    Atmospheric specific humidity is read from file:
-(PID.TID 0000.0001)    >>  CORE2_spfh10m_6hrly_r2_cnyf  <<
+(PID.TID 0000.0001)    >> CORE2_spfh10m_6hrly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "aqh" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Net longwave flux forcing starts at                 0.
-(PID.TID 0000.0001)    Net longwave flux forcing period is                 0.
-(PID.TID 0000.0001)    Net longwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001)    interpolate "lwflux" (method=  1 ):
-(PID.TID 0000.0001)    lon0= 6.173E+04, nlon=    32, lon_inc= 1.235E+05
-(PID.TID 0000.0001)    lat0= 6.173E+04, nlat=    32, lat_inc= 1.235E+05
+(PID.TID 0000.0001) // ALLOW_READ_TURBFLUXES:          NOT defined
+(PID.TID 0000.0001) // EXF_READ_EVAP:                  NOT defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Precipitation data set starts at              -30326400.
+(PID.TID 0000.0001)    Precipitation data starts at                  -30326400.
 (PID.TID 0000.0001)    Precipitation data period is                    2628000.
+(PID.TID 0000.0001)    Precipitation data repeat-cycle is             31536000.
 (PID.TID 0000.0001)    Precipitation data is read from file:
-(PID.TID 0000.0001)    >>  CORE2_rain_monthly_r2_cnyf  <<
+(PID.TID 0000.0001)    >> CORE2_rain_monthly_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "precip" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // EXF_READ_EVAP:                  NOT defined
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_RUNOFF:                       defined
-(PID.TID 0000.0001)    Runoff starts at               0.
-(PID.TID 0000.0001)    Runoff period is         2628000.
-(PID.TID 0000.0001)    Runoff is read from file:
-(PID.TID 0000.0001)    >>    <<
 (PID.TID 0000.0001) // ALLOW_RUNOFTEMP:                NOT defined
-(PID.TID 0000.0001)    assume "runoff" on model-grid (no interpolation)
+(PID.TID 0000.0001) // ALLOW_SALTFLX:                      defined
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Downward shortwave flux forcing starts at        -31536000.
-(PID.TID 0000.0001)    Downward shortwave flux forcing period is            86400.
-(PID.TID 0000.0001)    Downward shortwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>  CORE2_dsw_daily_r2_cnyf  <<
+(PID.TID 0000.0001)    Downward shortwave flux starts at             -31536000.
+(PID.TID 0000.0001)    Downward shortwave flux period is                 86400.
+(PID.TID 0000.0001)    Downward shortwave flux repeat-cycle is        31536000.
+(PID.TID 0000.0001)    Downward shortwave flux is read from file:
+(PID.TID 0000.0001)    >> CORE2_dsw_daily_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "swdown" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Downward longwave flux forcing starts at         -31536000.
-(PID.TID 0000.0001)    Downward longwave flux forcing period is             86400.
-(PID.TID 0000.0001)    Downward longwave flux forcing is read from file:
-(PID.TID 0000.0001)    >>  CORE2_dlw_daily_r2_cnyf  <<
+(PID.TID 0000.0001)    Downward longwave flux starts at              -31536000.
+(PID.TID 0000.0001)    Downward longwave flux period is                  86400.
+(PID.TID 0000.0001)    Downward longwave flux repeat-cycle is         31536000.
+(PID.TID 0000.0001)    Downward longwave flux is read from file:
+(PID.TID 0000.0001)    >> CORE2_dlw_daily_r2_cnyf <<
 (PID.TID 0000.0001)    interpolate "lwdown" (method=  1 ):
-(PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
-(PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Atmospheric pressure forcing starts at                0.
-(PID.TID 0000.0001)    Atmospheric pressure forcing period is            21600.
-(PID.TID 0000.0001)    Atmospheric pressureforcing is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001)    interpolate "apressure" (method=  1 ):
 (PID.TID 0000.0001)    lon0=   0.00000, nlon=   192, lon_inc= 1.8750000
 (PID.TID 0000.0001)    lat0= -88.54200, nlat=    94, inc(min,max)= 1.88880 1.90480
 (PID.TID 0000.0001) 
@@ -1631,20 +1659,12 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSST_RELAXATION:           defined
+(PID.TID 0000.0001)    climsst relaxation is NOT used
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) // ALLOW_CLIMSSS_RELAXATION:           defined
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Climatological SST starts at                   0.
-(PID.TID 0000.0001)    Climatological SST period is                   0.
-(PID.TID 0000.0001)    Climatological SST is read from file:
-(PID.TID 0000.0001)    >>    <<
-(PID.TID 0000.0001)    interpolate "climsst" (method=  2 ):
-(PID.TID 0000.0001)    lon0= 6.173E+04, nlon=    32, lon_inc= 1.235E+05
-(PID.TID 0000.0001)    lat0= 6.173E+04, nlat=    32, lat_inc= 1.235E+05
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Climatological SSS starts at                   0.
-(PID.TID 0000.0001)    Climatological SSS period is                 -12.
+(PID.TID 0000.0001)    Climatological SSS period is                        -12.
 (PID.TID 0000.0001)    Climatological SSS is read from file:
-(PID.TID 0000.0001)    >>  some_SSS_atlas.bin  <<
+(PID.TID 0000.0001)    >> some_SSS_atlas.bin <<
 (PID.TID 0000.0001)    assume "climsss" on model-grid (no interpolation)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -1670,6 +1690,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = sststep
 (PID.TID 0000.0001) -------------
@@ -1683,6 +1704,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -1701,19 +1723,484 @@
 (PID.TID 0000.0001)   profilesDoNcOutput     F
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) profiles file   1 is some_TS_atlas.sortedInTime
-(PID.TID 0000.0001)   local tile is bi=  1 bj=  1
-(PID.TID 0000.0001)   # of depth levels     =   50
-(PID.TID 0000.0001)   total # of profiles   =     4420
-(PID.TID 0000.0001)   local # of profiles   =      237
-(PID.TID 0000.0001)   variable #  1 is prof_T and theta
-(PID.TID 0000.0001)   variable #  2 is prof_S and salt
+(PID.TID 0000.0001) profiles file #  1 is some_TS_atlas.sortedInTime
+(PID.TID 0000.0001)   current tile is bi,bj                      =   1,   1
+(PID.TID 0000.0001)   # of depth levels in file                  =       50
+(PID.TID 0000.0001)   # of profiles in file                      =     4420
+(PID.TID 0000.0001)   # of profiles with erroneous HHMMSS values =        0
+(PID.TID 0000.0001)   # of profiles within tile and time period  =      237
+(PID.TID 0000.0001)   variable #  1 is            prof_T and theta
+(PID.TID 0000.0001)   variable #  2 is            prof_S and salt
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) profiles file #  1 is some_TS_atlas.sortedInTime
+(PID.TID 0000.0001)   current tile is bi,bj                      =   2,   1
+(PID.TID 0000.0001)   # of depth levels in file                  =       50
+(PID.TID 0000.0001)   # of profiles in file                      =     4420
+(PID.TID 0000.0001)   # of profiles with erroneous HHMMSS values =        0
+(PID.TID 0000.0001)   # of profiles within tile and time period  =      152
+(PID.TID 0000.0001)   variable #  1 is            prof_T and theta
+(PID.TID 0000.0001)   variable #  2 is            prof_S and salt
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) profiles file #  1 is some_TS_atlas.sortedInTime
+(PID.TID 0000.0001)   current tile is bi,bj                      =   3,   1
+(PID.TID 0000.0001)   # of depth levels in file                  =       50
+(PID.TID 0000.0001)   # of profiles in file                      =     4420
+(PID.TID 0000.0001)   # of profiles with erroneous HHMMSS values =        0
+(PID.TID 0000.0001)   # of profiles within tile and time period  =      205
+(PID.TID 0000.0001)   variable #  1 is            prof_T and theta
+(PID.TID 0000.0001)   variable #  2 is            prof_S and salt
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // insitu profiles model sampling >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) ctrl-wet 1:    nvarlength =        32097
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice time stepping configuration   > START <
+(PID.TID 0000.0001)    ----------------------------------------------
+(PID.TID 0000.0001) SEAICE_deltaTtherm= /* thermodynamic timestep */
+(PID.TID 0000.0001)                 3.600000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_deltaTdyn  = /* dynamic timestep */
+(PID.TID 0000.0001)                 3.600000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_deltaTevp  = /* EVP timestep */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEupdateOceanStress= /* update Ocean surf. stress */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice dynamics configuration   > START <
+(PID.TID 0000.0001)    ------------------------------------------
+(PID.TID 0000.0001) SEAICEuseDYNAMICS = /* use dynamics */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) model grid type   = /* type of sea ice model grid */
+(PID.TID 0000.0001)               'C-GRID'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseStrImpCpl = /* use strongly implicit coupling */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEusePicardAsPrecon = /* Picard as preconditioner */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseEVP      = /* use EVP solver rather than LSR */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseJFNK     = /* use JFNK solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseFREEDRIFT = /* use free drift solution */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OCEAN_drag        = /* air-ocean drag coefficient */
+(PID.TID 0000.0001)                 1.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_drag       = /* air-ice drag coefficient */
+(PID.TID 0000.0001)                 2.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
+(PID.TID 0000.0001)                 2.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag (no units) */
+(PID.TID 0000.0001)                 5.344995140913508E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag (no units) */
+(PID.TID 0000.0001)                 5.344995140913508E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEdWatMin = /* minimum linear water-ice drag (in m/s) */
+(PID.TID 0000.0001)                 2.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseTEM      = /* use truncated ellipse rheology */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_strength   = /* sea-ice strength Pstar */
+(PID.TID 0000.0001)                 2.250000000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_cStar      = /* sea-ice strength parameter cStar */
+(PID.TID 0000.0001)                 2.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEpressReplFac= /* press. replacement method factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_tensilFac  = /* sea-ice tensile strength factor */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_tensilDepth= /* crit. depth for tensile strength */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEpresH0   = /* sea-ice strength Heff threshold */
+(PID.TID 0000.0001)                 2.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEpresPow0 = /* exponent for Heff<SEAICEpresH0 */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEpresPow1 = /* exponent for Heff>SEAICEpresH0 */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEetaZmethod = /* method computing eta at Z-point */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_zetaMaxFac = /* factor for upper viscosity bound */
+(PID.TID 0000.0001)                 2.500000000000000E+08
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_zetaMin    = /* lower bound for viscosity */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_eccen    = /* elliptical yield curve eccent */
+(PID.TID 0000.0001)                 2.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEstressFactor    = /* wind stress scaling factor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_airTurnAngle    = /* air-ice turning angle */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_2ndOrderBC = /* 2nd order no slip boundary conditions */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_clipVeloctities = /* impose max. vels. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useHB87stressCoupling  = /* altern. ice-ocean stress */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEscaleSurfStress  = /* scale atm. and ocean-surface stress with AREA */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_maskRHS    = /* mask RHS of solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEaddSnowMass = /* add snow mass to seaiceMassC/U/V */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) LSR_mixIniGuess = /* mix free-drift sol. into LSR initial Guess */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_LSRrelaxU  = /* LSR solver: relaxation parameter */
+(PID.TID 0000.0001)                 9.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_LSRrelaxV  = /* LSR solver: relaxation parameter */
+(PID.TID 0000.0001)                 9.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) LSR_ERROR         = /* sets accuracy of LSR solver */
+(PID.TID 0000.0001)                 2.000000000000000E-04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SOLV_NCHECK       = /* test interval for LSR solver */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseMultiTileSolver = /* use full domain tri-diag solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_OLx = /* overlap for LSR/preconditioner */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_OLy = /* overlap for LSR/preconditioner */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEnonLinIterMax = /* max. number of nonlinear solver steps */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
+(PID.TID 0000.0001)                     500
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice advection diffusion config,   > START <
+(PID.TID 0000.0001)    -----------------------------------------------
+(PID.TID 0000.0001) SEAICEmomAdvection = /* advect sea ice momentum */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvHeff = /* advect effective ice thickness */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvArea = /* advect fractional ice area */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvSnow = /* advect snow layer together with ice */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvScheme   = /* advection scheme for ice */
+(PID.TID 0000.0001)                      33
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvSchArea   = /* advection scheme for area */
+(PID.TID 0000.0001)                      33
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvSchHeff   = /* advection scheme for thickness */
+(PID.TID 0000.0001)                      33
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEadvSchSnow   = /* advection scheme for snow */
+(PID.TID 0000.0001)                      33
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEdiffKhArea   = /* diffusivity (m^2/s) for area */
+(PID.TID 0000.0001)                 4.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEdiffKhHeff   = /* diffusivity (m^2/s) for heff */
+(PID.TID 0000.0001)                 4.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEdiffKhSnow   = /* diffusivity (m^2/s) for snow */
+(PID.TID 0000.0001)                 4.000000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) DIFF1             = /* parameter used in advect.F [m/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice thermodynamics configuration   > START <
+(PID.TID 0000.0001)    -----------------------------------------------
+(PID.TID 0000.0001) SEAICE_rhoIce     = /* density of sea ice (kg/m3) */
+(PID.TID 0000.0001)                 9.100000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_rhoSnow    = /* density of snow (kg/m3) */
+(PID.TID 0000.0001)                 3.300000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_rhoAir     = /* density of air (kg/m3) */
+(PID.TID 0000.0001)                 1.220000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) usePW79thermodynamics  = /* default 0-layer TD */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_lhEvap     = /* latent heat of evaporation */
+(PID.TID 0000.0001)                 2.500000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_lhFusion   = /* latent heat of fusion */
+(PID.TID 0000.0001)                 3.340000000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_mcPheePiston = /* turbulent flux "piston velocity" a la McPhee (m/s) */
+(PID.TID 0000.0001)                 3.858024691358025E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_mcPheeTaper = /* tapering of turbulent flux (0.< <1.) for AREA=1. */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_mcPheeStepFunc = /* replace linear tapering with step funct. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_frazilFrac = /* frazil (T<tempFrz) to seaice conversion rate (0.< <1.) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_tempFrz0   = /* freezing temp. of sea water (intercept) */
+(PID.TID 0000.0001)                -1.960000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_dTempFrz_dS= /* freezing temp. of sea water (slope) */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_growMeltByConv  = /* grow,melt by vert. conv. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_doOpenWaterGrowth = /* grow by open water */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_doOpenWaterMelt = /* melt by open water */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_areaGainFormula = /* ice cover gain formula (1,2)*/
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     1=from growth by ATM
+(PID.TID 0000.0001)     2=from predicted growth by ATM
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_areaLossFormula = /* ice cover loss formula (1,2)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     1=from all but only melt conributions by ATM and OCN
+(PID.TID 0000.0001)     2=from net melt-grow>0 by ATM and OCN
+(PID.TID 0000.0001)     3=from predicted melt by ATM
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HO                = /* nominal thickness of new ice */
+(PID.TID 0000.0001)                 5.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HO_south               = /* Southern Ocean HO */
+(PID.TID 0000.0001)                 5.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_area_max        = /* set to les than 1. to mimic open leads */
+(PID.TID 0000.0001)                 9.700000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_salt0   = /* constant sea ice salinity */
+(PID.TID 0000.0001)                 4.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_salinityTracer = /* test SITR varia. salinity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseFlooding = /* turn submerged snow into ice */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice air-sea fluxes configuration,   > START <
+(PID.TID 0000.0001)    -----------------------------------------------
+(PID.TID 0000.0001) SEAICEheatConsFix  = /* accound for ocn<->seaice advect. heat flux */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
+(PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
+(PID.TID 0000.0001)     6 @  0.000000000000000E+00              /* K =  2:  7 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) IMAX_TICE         = /* iterations for ice surface temp */
+(PID.TID 0000.0001)                      10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) postSolvTempIter= /* flux calculation after surf. temp iter */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_dryIceAlb  = /* winter albedo */
+(PID.TID 0000.0001)                 7.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_wetIceAlb  = /* summer albedo */
+(PID.TID 0000.0001)                 6.600000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_drySnowAlb = /* dry snow albedo */
+(PID.TID 0000.0001)                 8.400000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_wetSnowAlb = /* wet snow albedo */
+(PID.TID 0000.0001)                 7.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_dryIceAlb_south = /* Southern Ocean dryIceAlb */
+(PID.TID 0000.0001)                 7.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_wetIceAlb_south = /* Southern Ocean wetIceAlb */
+(PID.TID 0000.0001)                 6.600000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_drySnowAlb_south= /* Southern Ocean drySnowAlb */
+(PID.TID 0000.0001)                 8.400000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_wetSnowAlb_south= /* Southern Ocean wetSnowAlb */
+(PID.TID 0000.0001)                 7.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_wetAlbTemp= /* Temp (o.C) threshold for wet-albedo */
+(PID.TID 0000.0001)                -1.000000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_snow_emiss = /* snow emissivity */
+(PID.TID 0000.0001)                 9.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_ice_emiss = /* seaice emissivity */
+(PID.TID 0000.0001)                 9.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_cpAir      = /* heat capacity of air */
+(PID.TID 0000.0001)                 1.005000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_dalton     = /* constant dalton number */
+(PID.TID 0000.0001)                 1.750000000000000E-03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_iceConduct = /* sea-ice conductivity */
+(PID.TID 0000.0001)                 2.165600000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_snowConduct= /* snow conductivity */
+(PID.TID 0000.0001)                 3.100000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_snowThick  = /* cutoff snow thickness (for albedo) */
+(PID.TID 0000.0001)                 1.500000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_shortwave  = /* penetration shortwave radiation */
+(PID.TID 0000.0001)                 3.000000000000000E-01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMaykutSatVapPoly = /* use Maykut Polynomial for Sat.Vap.Pr */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) MIN_ATEMP         = /* minimum air temperature */
+(PID.TID 0000.0001)                -4.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) MIN_LWDOWN        = /* minimum downward longwave */
+(PID.TID 0000.0001)                 6.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) MIN_TICE          = /* minimum ice temperature */
+(PID.TID 0000.0001)                -4.000000000000000E+01
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice initialization and IO config.,   > START <
+(PID.TID 0000.0001)    -------------------------------------------------
+(PID.TID 0000.0001) SEAICE_initialHEFF= /* initial sea-ice thickness */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) AreaFile = /* Initial ice concentration File */
+(PID.TID 0000.0001)               'siAREA.ini'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HeffFile = /* Initial effective ice thickness File */
+(PID.TID 0000.0001)               'siHEFF.ini'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) HsnowFile = /* Initial snow thickness File */
+(PID.TID 0000.0001)               'siHSNOW.ini'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) uIceFile = /* Initial U-ice velocity File */
+(PID.TID 0000.0001)               'siUICE.ini'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) vIceFile = /* Initial V-ice velocity File */
+(PID.TID 0000.0001)               'siVICE.ini'
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEwriteState  = /* write sea ice state to file */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_monFreq  = /* monitor frequency */
+(PID.TID 0000.0001)                 3.600000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001)    Seaice regularization numbers,   > START <
+(PID.TID 0000.0001)    -----------------------------------------------
+(PID.TID 0000.0001) SEAICE_deltaMin   = /* reduce singularities in Delta */
+(PID.TID 0000.0001)                 1.000000000000000E-10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_EPS        = /* small number */
+(PID.TID 0000.0001)                 1.000000000000000E-10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_EPS_SQ     = /* small number squared */
+(PID.TID 0000.0001)                 1.000000000000000E-20
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_area_reg   = /* reduce derivative singularities */
+(PID.TID 0000.0001)                 1.000000000000000E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_hice_reg   = /* reduce derivative singularities */
+(PID.TID 0000.0001)                 5.000000000000000E-02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_area_floor = /* reduce derivative singularities */
+(PID.TID 0000.0001)                 1.000000000000000E-05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) ctrl-wet 1:    nvarlength =        78927
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          237
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          228
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          233
@@ -2177,8 +2664,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:          557358
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:          557358
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2191,523 +2678,102 @@
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
 (PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 010699 010456 010085
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 006514 006422 005882
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 009096 008680 008935
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice time stepping configuration   > START <
-(PID.TID 0000.0001)    ----------------------------------------------
-(PID.TID 0000.0001) SEAICE_deltaTtherm= /* thermodynamic timestep */
-(PID.TID 0000.0001)                 3.600000000000000E+03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_deltaTdyn  = /* dynamic timestep */
-(PID.TID 0000.0001)                 3.600000000000000E+03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_deltaTevp  = /* EVP timestep */
-(PID.TID 0000.0001)                 1.234567000000000E+05
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseBDF2  = /* use backw. differencing for mom. eq. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICErestoreUnderIce  = /* restore T and S under ice */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice dynamics configuration   > START <
-(PID.TID 0000.0001)    ------------------------------------------
-(PID.TID 0000.0001) SEAICEuseDYNAMICS = /* use dynamics */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) model grid type   = /* type of sea ice model grid */
-(PID.TID 0000.0001)               'C-GRID'
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseStrImpCpl = /* use strongly implicit coupling */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEusePicardAsPrecon = /* Picard as preconditioner */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseEVP      = /* use EVP solver rather than LSR */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseJFNK     = /* use JFNK solver */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseFREEDRIFT = /* use free drift solution */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) OCEAN_drag        = /* air-ocean drag coefficient */
-(PID.TID 0000.0001)                 1.000000000000000E-03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_drag       = /* air-ice drag coefficient */
-(PID.TID 0000.0001)                 2.000000000000000E-03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_drag_south      = /* Southern Ocean SEAICE_drag */
-(PID.TID 0000.0001)                 2.000000000000000E-03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag  = /* water-ice drag * density */
-(PID.TID 0000.0001)                 5.500000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterDrag_south = /* Southern Ocean waterDrag */
-(PID.TID 0000.0001)                 5.500000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseTilt     = /* include surface tilt in dyna. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseTEM      = /* use truncated ellipse rheology */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_strength   = /* sea-ice strength Pstar */
-(PID.TID 0000.0001)                 2.250000000000000E+04
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_cStar      = /* sea-ice strength parameter cStar */
-(PID.TID 0000.0001)                 2.000000000000000E+01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEpressReplFac= /* press. replacement method factor */
-(PID.TID 0000.0001)                 1.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tensilFac  = /* sea-ice tensile strength factor */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tensilDepth= /* crit. depth for tensile strength */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEpresH0   = /* sea-ice strength Heff threshold */
-(PID.TID 0000.0001)                 2.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEpresPow0 = /* exponent for Heff<SEAICEpresH0 */
-(PID.TID 0000.0001)                       1
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEpresPow1 = /* exponent for Heff>SEAICEpresH0 */
-(PID.TID 0000.0001)                       1
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEetaZmethod = /* method computing eta at Z-point */
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_zetaMin    = /* lower bound for viscosity */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_eccen    = /* elliptical yield curve eccent */
-(PID.TID 0000.0001)                 2.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEstressFactor    = /* wind stress scaling factor */
-(PID.TID 0000.0001)                 1.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_airTurnAngle    = /* air-ice turning angle */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_clipVeloctities = /* impose max. vels. */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useHB87stressCoupling  = /* altern. ice-ocean stress */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEscaleSurfStress  = /* scale atm. and ocean-surface stress with AREA */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_maskRHS    = /* mask RHS of solver */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) LSR_mixIniGuess = /* mix free-drift sol. into LSR initial Guess */
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_LSRrelaxU  = /* LSR solver: relaxation parameter */
-(PID.TID 0000.0001)                 9.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_LSRrelaxV  = /* LSR solver: relaxation parameter */
-(PID.TID 0000.0001)                 9.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) LSR_ERROR         = /* sets accuracy of LSR solver */
-(PID.TID 0000.0001)                 2.000000000000000E-04
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SOLV_NCHECK       = /* test interval for LSR solver */
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMultiTileSolver = /* use full domain tri-diag solver */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_OLx = /* overlap for LSR/preconditioner */
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_OLy = /* overlap for LSR/preconditioner */
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEnonLinIterMax = /* max. number of nonlinear solver steps */
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
-(PID.TID 0000.0001)                    1500
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice advection diffusion config,   > START <
-(PID.TID 0000.0001)    -----------------------------------------------
-(PID.TID 0000.0001) SEAICEadvHeff = /* advect effective ice thickness */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvArea = /* advect fractional ice area */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSnow = /* advect snow layer together with ice */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvScheme   = /* advection scheme for ice */
-(PID.TID 0000.0001)                      33
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchArea   = /* advection scheme for area */
-(PID.TID 0000.0001)                      33
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchHeff   = /* advection scheme for thickness */
-(PID.TID 0000.0001)                      33
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchSnow   = /* advection scheme for snow */
-(PID.TID 0000.0001)                      33
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhArea   = /* diffusivity (m^2/s) for area */
-(PID.TID 0000.0001)                 4.000000000000000E+02
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhHeff   = /* diffusivity (m^2/s) for heff */
-(PID.TID 0000.0001)                 4.000000000000000E+02
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhSnow   = /* diffusivity (m^2/s) for snow */
-(PID.TID 0000.0001)                 4.000000000000000E+02
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) DIFF1             = /* parameter used in advect.F [m/s] */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice thermodynamics configuration   > START <
-(PID.TID 0000.0001)    -----------------------------------------------
-(PID.TID 0000.0001) SEAICE_rhoIce     = /* density of sea ice (kg/m3) */
-(PID.TID 0000.0001)                 9.100000000000000E+02
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_rhoSnow    = /* density of snow (kg/m3) */
-(PID.TID 0000.0001)                 3.300000000000000E+02
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_rhoAir     = /* density of air (kg/m3) */
-(PID.TID 0000.0001)                 1.220000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) usePW79thermodynamics  = /* default 0-layer TD */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_lhEvap     = /* latent heat of evaporation */
-(PID.TID 0000.0001)                 2.500000000000000E+06
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_lhFusion   = /* latent heat of fusion */
-(PID.TID 0000.0001)                 3.340000000000000E+05
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_mcPheePiston = /* turbulent flux "piston velocity" a la McPhee (m/s) */
-(PID.TID 0000.0001)                 3.858024691358025E-05
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_mcPheeTaper = /* tapering of turbulent flux (0.< <1.) for AREA=1. */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_mcPheeStepFunc = /* replace linear tapering with step funct. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_frazilFrac = /* frazil (T<tempFrz) to seaice conversion rate (0.< <1.) */
-(PID.TID 0000.0001)                 1.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tempFrz0   = /* freezing temp. of sea water (intercept) */
-(PID.TID 0000.0001)                -1.960000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_dTempFrz_dS= /* freezing temp. of sea water (slope) */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_growMeltByConv  = /* grow,melt by vert. conv. */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_doOpenWaterGrowth = /* grow by open water */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_doOpenWaterMelt = /* melt by open water */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_areaGainFormula = /* ice cover gain formula (1,2)*/
-(PID.TID 0000.0001)                       1
-(PID.TID 0000.0001)     1=from growth by ATM
-(PID.TID 0000.0001)     2=from predicted growth by ATM
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_areaLossFormula = /* ice cover loss formula (1,2)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     1=from all but only melt conributions by ATM and OCN
-(PID.TID 0000.0001)     2=from net melt-grow>0 by ATM and OCN
-(PID.TID 0000.0001)     3=from predicted melt by ATM
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) HO                = /* nominal thickness of new ice */
-(PID.TID 0000.0001)                 5.000000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) HO_south               = /* Southern Ocean HO */
-(PID.TID 0000.0001)                 5.000000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_area_max        = /* set to les than 1. to mimic open leads */
-(PID.TID 0000.0001)                 9.700000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_salt0   = /* constant sea ice salinity */
-(PID.TID 0000.0001)                 4.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_salinityTracer = /* test SITR varia. salinity */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseFlooding = /* turn submerged snow into ice */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice air-sea fluxes configuration,   > START <
-(PID.TID 0000.0001)    -----------------------------------------------
-(PID.TID 0000.0001) SEAICEheatConsFix  = /* accound for ocn<->seaice advect. heat flux */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
-(PID.TID 0000.0001)                       1
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
-(PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
-(PID.TID 0000.0001)     6 @  0.000000000000000E+00              /* K =  2:  7 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) IMAX_TICE         = /* iterations for ice surface temp */
-(PID.TID 0000.0001)                      10
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) postSolvTempIter= /* flux calculation after surf. temp iter */
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_dryIceAlb  = /* winter albedo */
-(PID.TID 0000.0001)                 7.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_wetIceAlb  = /* summer albedo */
-(PID.TID 0000.0001)                 6.600000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_drySnowAlb = /* dry snow albedo */
-(PID.TID 0000.0001)                 8.400000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_wetSnowAlb = /* wet snow albedo */
-(PID.TID 0000.0001)                 7.000000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_dryIceAlb_south = /* Southern Ocean dryIceAlb */
-(PID.TID 0000.0001)                 7.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_wetIceAlb_south = /* Southern Ocean wetIceAlb */
-(PID.TID 0000.0001)                 6.600000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_drySnowAlb_south= /* Southern Ocean drySnowAlb */
-(PID.TID 0000.0001)                 8.400000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_wetSnowAlb_south= /* Southern Ocean wetSnowAlb */
-(PID.TID 0000.0001)                 7.000000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_wetAlbTemp= /* Temp (o.C) threshold for wet-albedo */
-(PID.TID 0000.0001)                -1.000000000000000E-03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_snow_emiss = /* snow emissivity */
-(PID.TID 0000.0001)                 9.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_ice_emiss = /* seaice emissivity */
-(PID.TID 0000.0001)                 9.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_cpAir      = /* heat capacity of air */
-(PID.TID 0000.0001)                 1.005000000000000E+03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_dalton     = /* constant dalton number */
-(PID.TID 0000.0001)                 1.750000000000000E-03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_iceConduct = /* sea-ice conductivity */
-(PID.TID 0000.0001)                 2.165600000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_snowConduct= /* snow conductivity */
-(PID.TID 0000.0001)                 3.100000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_snowThick  = /* cutoff snow thickness (for albedo) */
-(PID.TID 0000.0001)                 1.500000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_shortwave  = /* penetration shortwave radiation */
-(PID.TID 0000.0001)                 3.000000000000000E-01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useMaykutSatVapPoly = /* use Maykut Polynomial for Sat.Vap.Pr */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) MIN_ATEMP         = /* minimum air temperature */
-(PID.TID 0000.0001)                -4.000000000000000E+01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) MIN_LWDOWN        = /* minimum downward longwave */
-(PID.TID 0000.0001)                 6.000000000000000E+01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) MIN_TICE          = /* minimum ice temperature */
-(PID.TID 0000.0001)                -4.000000000000000E+01
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice initialization and IO config.,   > START <
-(PID.TID 0000.0001)    -------------------------------------------------
-(PID.TID 0000.0001) SEAICE_initialHEFF= /* initial sea-ice thickness */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) AreaFile = /* Initial ice concentration File */
-(PID.TID 0000.0001)               'siAREA.ini'
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) HeffFile = /* Initial effective ice thickness File */
-(PID.TID 0000.0001)               'siHEFF.ini'
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) HsnowFile = /* Initial snow thickness File */
-(PID.TID 0000.0001)               'siHSNOW.ini'
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uIceFile = /* Initial U-ice velocity File */
-(PID.TID 0000.0001)               'siUICE.ini'
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) vIceFile = /* Initial V-ice velocity File */
-(PID.TID 0000.0001)               'siVICE.ini'
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEwriteState  = /* write sea ice state to file */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_monFreq  = /* monitor frequency */
-(PID.TID 0000.0001)                 3.600000000000000E+03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)    Seaice regularization numbers,   > START <
-(PID.TID 0000.0001)    -----------------------------------------------
-(PID.TID 0000.0001) SEAICE_deltaMin   = /* reduce singularities in Delta */
-(PID.TID 0000.0001)                 1.000000000000000E-10
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_EPS        = /* small number */
-(PID.TID 0000.0001)                 1.000000000000000E-10
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_EPS_SQ     = /* small number squared */
-(PID.TID 0000.0001)                 1.000000000000000E-20
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_area_reg   = /* reduce derivative singularities */
-(PID.TID 0000.0001)                 1.000000000000000E-05
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_hice_reg   = /* reduce derivative singularities */
-(PID.TID 0000.0001)                 5.000000000000000E-02
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_area_floor = /* reduce derivative singularities */
-(PID.TID 0000.0001)                 1.000000000000000E-05
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   296
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   223 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   226 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   228 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   296 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   240 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   247 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   267 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   271 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   272 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   277 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   279 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   232 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   233 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   216 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   217 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   114 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   115 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   111 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   112 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   122 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   118 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   119 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   267  ADVxHEFF , Parms: UU      M1 , mate:   268
-(PID.TID 0000.0001)   set mate pointer for diag #   268  ADVyHEFF , Parms: VV      M1 , mate:   267
-(PID.TID 0000.0001)   set mate pointer for diag #   271  DFxEHEFF , Parms: UU      M1 , mate:   272
-(PID.TID 0000.0001)   set mate pointer for diag #   272  DFyEHEFF , Parms: VV      M1 , mate:   271
-(PID.TID 0000.0001)   set mate pointer for diag #   277  ADVxSNOW , Parms: UU      M1 , mate:   278
-(PID.TID 0000.0001)   set mate pointer for diag #   278  ADVySNOW , Parms: VV      M1 , mate:   277
-(PID.TID 0000.0001)   set mate pointer for diag #   279  DFxESNOW , Parms: UU      M1 , mate:   280
-(PID.TID 0000.0001)   set mate pointer for diag #   280  DFyESNOW , Parms: VV      M1 , mate:   279
-(PID.TID 0000.0001)   set mate pointer for diag #   232  SIuice   , Parms: UU      M1 , mate:   233
-(PID.TID 0000.0001)   set mate pointer for diag #   233  SIvice   , Parms: VV      M1 , mate:   232
+(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
+(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
+(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
+(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
+(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
+(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   216  GM_PsiX  , Parms: UU      LR , mate:   217
-(PID.TID 0000.0001)   set mate pointer for diag #   217  GM_PsiY  , Parms: VV      LR , mate:   216
-(PID.TID 0000.0001)   set mate pointer for diag #   114  DFxE_TH  , Parms: UU      MR , mate:   115
-(PID.TID 0000.0001)   set mate pointer for diag #   115  DFyE_TH  , Parms: VV      MR , mate:   114
-(PID.TID 0000.0001)   set mate pointer for diag #   111  ADVx_TH  , Parms: UU      MR , mate:   112
-(PID.TID 0000.0001)   set mate pointer for diag #   112  ADVy_TH  , Parms: VV      MR , mate:   111
-(PID.TID 0000.0001)   set mate pointer for diag #   121  DFxE_SLT , Parms: UU      MR , mate:   122
-(PID.TID 0000.0001)   set mate pointer for diag #   122  DFyE_SLT , Parms: VV      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   118  ADVx_SLT , Parms: UU      MR , mate:   119
-(PID.TID 0000.0001)   set mate pointer for diag #   119  ADVy_SLT , Parms: VV      MR , mate:   118
+(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
+(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
+(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
+(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
+(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
+(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
+(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
+(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2790,8 +2856,95 @@
 (PID.TID 0000.0001)     4 @  2.000000000000000E+00,             /* K = 35: 38 */
 (PID.TID 0000.0001)    12 @  1.000000000000000E+00              /* K = 39: 50 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -2827,6 +2980,9 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2leithD = /* Leith harmonic viscosity factor (on grad(div),non-dim.)*/
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) viscC2LeithQG = /* QG Leith harmonic viscosity factor (non-dim.)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) viscC2smag = /* Smagorinsky harmonic viscosity factor (non-dim.) */
@@ -2919,9 +3075,15 @@
 (PID.TID 0000.0001) eosType =  /* Type of Equation of State */
 (PID.TID 0000.0001)               'JMD95Z'
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) eosRefP0 = /* Reference atmospheric pressure for EOS ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectP_inEOS_Zc = /* select pressure to use in EOS (0,1,2,3) */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= -g*rhoConst*z ; 1= pRef (from tRef,sRef); 2= Hyd P ; 3= Hyd+NH P
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) surf_pRef = /* Surface reference pressure ( Pa ) */
+(PID.TID 0000.0001)                 1.013250000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) HeatCapacity_Cp =  /* Specific heat capacity ( J/kg/K ) */
 (PID.TID 0000.0001)                 3.994000000000000E+03
@@ -2977,17 +3139,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2Dflow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -2995,10 +3160,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3020,7 +3185,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -3029,7 +3194,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -3071,8 +3236,9 @@
 (PID.TID 0000.0001) implicitViscosity = /* Implicit viscosity on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implBottomFriction= /* Implicit bottom friction on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectImplicitDrag= /* Implicit bot Drag options (0,1,2)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3093,14 +3259,12 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useEnergyConservingCoriolis= /* Flx-Form Coriolis scheme flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartWetPoints= /* Coriolis WetPoints method flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
+(PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
+(PID.TID 0000.0001)    = 2 : hFac weighted average (Angular Mom. conserving)
+(PID.TID 0000.0001)    = 3 : energy conserving scheme using hFac weighted average
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useAbsVorticity= /* V.I Works with f+zeta in Coriolis */
 (PID.TID 0000.0001)                   F
@@ -3112,6 +3276,9 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) upwindVorticity= /* V.I Upwind bias vorticity flag */
 (PID.TID 0000.0001)                   F
@@ -3126,6 +3293,9 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) momTidalForcing = /* Momentum Tidal forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momPressureForcing =  /* Momentum pressure term on/off flag */
@@ -3185,8 +3355,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3202,6 +3372,15 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : myIter (I10.10) ;   = 1 : 100*myTime (100th sec) ;
+(PID.TID 0000.0001)    = 2 : myTime (seconds);   = 3 : myTime/360 (10th of hr);
+(PID.TID 0000.0001)    = 4 : myTime/3600 (hours)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  globalFiles = /* write "global" (=not per tile) files */
 (PID.TID 0000.0001)                   F
@@ -3222,14 +3401,17 @@
 (PID.TID 0000.0001) debugLevel =  /* select debug printing level */
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001)  plotLevel =  /* select PLOT_FIELD printing level */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Elliptic solver(s) paramters ( PARM02 in namelist )
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3244,6 +3426,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -3295,7 +3480,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
 (PID.TID 0000.0001)                       0
@@ -3326,9 +3511,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickup_read_mdsio =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) pickup_write_immed =   /* Model IO flag. */
-(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) writePickupAtEnd =   /* Model IO flag. */
 (PID.TID 0000.0001)                   T
@@ -3380,6 +3562,18 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) usingCurvilinearGrid = /* Curvilinear coordinates flag ( True/False ) */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useMin4hFacEdges = /* set hFacW,S as minimum of adjacent hFacC factor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interViscAr_pCell = /* account for partial-cell in interior vert. viscosity */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) interDiffKr_pCell = /* account for partial-cell in interior vert. diffusion */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) pCellMix_select = /* option to enhance mixing near surface & bottom */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectSigmaCoord = /* Hybrid-Sigma Vert. Coordinate option */
 (PID.TID 0000.0001)                       0
@@ -3524,7 +3718,39 @@
 (PID.TID 0000.0001)                -1.291089806302069E+01,      /* I = 13 */
 (PID.TID 0000.0001)                -9.291807802719402E+00,      /* I = 14 */
 (PID.TID 0000.0001)                -5.603475335822332E+00,      /* I = 15 */
-(PID.TID 0000.0001)                -1.872608513033445E+00       /* I = 16 */
+(PID.TID 0000.0001)                -1.872608513033445E+00,      /* I = 16 */
+(PID.TID 0000.0001)                 1.872608513033445E+00,      /* I = 17 */
+(PID.TID 0000.0001)                 5.603475335822332E+00,      /* I = 18 */
+(PID.TID 0000.0001)                 9.291807802719402E+00,      /* I = 19 */
+(PID.TID 0000.0001)                 1.291089806302069E+01,      /* I = 20 */
+(PID.TID 0000.0001)                 1.643630800555134E+01,      /* I = 21 */
+(PID.TID 0000.0001)                 1.984640717127058E+01,      /* I = 22 */
+(PID.TID 0000.0001)                 2.312261250426344E+01,      /* I = 23 */
+(PID.TID 0000.0001)                 2.624932223028290E+01,      /* I = 24 */
+(PID.TID 0000.0001)                 2.921355965632675E+01,      /* I = 25 */
+(PID.TID 0000.0001)                 3.200434569041793E+01,      /* I = 26 */
+(PID.TID 0000.0001)                 3.461179367094151E+01,      /* I = 27 */
+(PID.TID 0000.0001)                 3.702585158682200E+01,      /* I = 28 */
+(PID.TID 0000.0001)                 3.923446288487304E+01,      /* I = 29 */
+(PID.TID 0000.0001)                 4.122055553388957E+01,      /* I = 30 */
+(PID.TID 0000.0001)                 4.295641272275883E+01,      /* I = 31 */
+(PID.TID 0000.0001)                 4.439521994760536E+01,      /* I = 32 */
+(PID.TID 0000.0001)                -4.364490324992833E+01,      /* I = 33 */
+(PID.TID 0000.0001)                -4.093268771156353E+01,      /* I = 34 */
+(PID.TID 0000.0001)                -3.821449311785297E+01,      /* I = 35 */
+(PID.TID 0000.0001)                -3.548661856694081E+01,      /* I = 36 */
+(PID.TID 0000.0001)                -3.274577371214319E+01,      /* I = 37 */
+(PID.TID 0000.0001)                -2.998921061819286E+01,      /* I = 38 */
+(PID.TID 0000.0001)                -2.721482732194908E+01,      /* I = 39 */
+(PID.TID 0000.0001)                -2.442123987207341E+01,      /* I = 40 */
+(PID.TID 0000.0001)                -2.160782193728863E+01,      /* I = 41 */
+(PID.TID 0000.0001)                -1.877471294668040E+01,      /* I = 42 */
+(PID.TID 0000.0001)                -1.592279705047260E+01,      /* I = 43 */
+(PID.TID 0000.0001)                -1.305365599512185E+01,      /* I = 44 */
+(PID.TID 0000.0001)                -1.016949940404567E+01,      /* I = 45 */
+(PID.TID 0000.0001)                -7.273076082698362E+00,      /* I = 46 */
+(PID.TID 0000.0001)                -4.367569947789942E+00,      /* I = 47 */
+(PID.TID 0000.0001)                -1.456484104946475E+00       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) yC =  /* yC(1,:,1,:) : P-point Y coord ( deg. or m if cartesian) */
 (PID.TID 0000.0001)                -3.497677942598243E+01,      /* J =  1 */
@@ -3655,47 +3881,6 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -3724,7 +3909,38 @@
 (PID.TID 0000.0001)                 2.944742915095688E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.978501920522794E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 3.000967749619962E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.012190981969055E+05       /* I = 16 */
+(PID.TID 0000.0001)     2 @  3.012190981969055E+05,             /* I = 16: 17 */
+(PID.TID 0000.0001)                 3.000967749619962E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.978501920522794E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.944742915095688E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.899590699694043E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.842862532064524E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.774243179696503E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.693210245495156E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.598919724358304E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.490022710862746E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.364352994647058E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.218350349844185E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.045883481718707E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.835530058121492E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.563594089971120E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.202082051331828E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.012844832048790E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.017314519159184E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.026061571839506E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.038712499122208E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.054733694195115E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.073460170047538E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.094129252024922E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.115916488673079E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.137971415338805E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.159451387866950E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.179552321069062E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.197535693737994E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.212751560265627E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.224657535572011E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.232833825614068E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.236994750082736E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dxF =  /* dxF(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 1.202082051331828E+05,      /* J =  1 */
@@ -3760,7 +3976,38 @@
 (PID.TID 0000.0001)                 2.945429307892709E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.979171143158405E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 3.001626787528886E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.012844832048790E+05       /* I = 16 */
+(PID.TID 0000.0001)     2 @  3.012844832048790E+05,             /* I = 16: 17 */
+(PID.TID 0000.0001)                 3.001626787528886E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.979171143158405E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.945429307892709E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.900303768613599E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.843615645344775E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.775055554645015E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.694110134598581E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.599949918261881E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.491250781852558E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.365892017348392E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.220405216043041E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.048868197919576E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.840412227747703E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.572908084538706E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.202082051331828E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.012190981969055E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.016675528553907E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.025451404065074E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.038143430929827E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.054215712079756E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.073000594641912E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.093732589453273E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.115584474900804E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.137703202065625E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.159243816151009E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.179400237154126E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.197432274745630E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.212688630823077E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.224625867238719E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.232823418193404E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.236994750082736E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dyF =  /* dyF(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 1.202082051331828E+05,      /* J =  1 */
@@ -3796,7 +4043,38 @@
 (PID.TID 0000.0001)                 2.944035815526416E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.977867909042096E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 3.000380090330854E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.011625828699101E+05       /* I = 16 */
+(PID.TID 0000.0001)     2 @  3.011625828699101E+05,             /* I = 16: 17 */
+(PID.TID 0000.0001)                 3.000380090330854E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.977867909042096E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.944035815526416E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.898778860929753E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.841906470085516E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.773091043277394E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.691790288994575E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.597126963772147E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.487693460283865E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.361211699596122E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.213884732245467E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.038999045536999E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.823321598773926E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.534505834330338E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.009837800879055E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.014246674484008E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.018694497480782E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.027399364062562E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.039990657490951E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.055938607351786E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.074582577767738E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.095164322685570E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.116863538419811E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.138833384868975E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.160234197751047E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.180264208293543E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.198186602283748E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.213352627063766E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.225220686282585E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.233371474853745E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.237519587277332E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dxG =  /* dxG(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 1.009837800879055E+05,      /* J =  1 */
@@ -3832,7 +4110,39 @@
 (PID.TID 0000.0001)                 2.924298293668651E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.963715635865306E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 2.991805843171258E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.008638765647886E+05       /* I = 16 */
+(PID.TID 0000.0001)                 3.008638765647886E+05,      /* I = 16 */
+(PID.TID 0000.0001)                 3.014246674484008E+05,      /* I = 17 */
+(PID.TID 0000.0001)                 3.008638765647886E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.991805843171258E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.963715635865306E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.924298293668651E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.873420591008078E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.810845823202647E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.736173771018112E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.648750305193301E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.547526806712889E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.430829951739083E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.295958105911512E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.138410773065497E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.950254041626018E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.716197227386011E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.403701524205398E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.011625828699101E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.013880313304323E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.020546438966793E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.031337933484788E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.045796060304602E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.063315047037455E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.083173884297931E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.104571666747115E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.126663860714039E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.148597400258051E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.169543146344334E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.188724835261090E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.205444100809708E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.219101453522735E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.229213257990267E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.235424806617432E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dyG =  /* dyG(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 1.009837800879055E+05,      /* J =  1 */
@@ -3868,7 +4178,39 @@
 (PID.TID 0000.0001)                 2.923599955312932E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.963038832565530E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 2.991142470004740E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.007982711627968E+05       /* I = 16 */
+(PID.TID 0000.0001)                 3.007982711627968E+05,      /* I = 16 */
+(PID.TID 0000.0001)                 3.013593857228136E+05,      /* I = 17 */
+(PID.TID 0000.0001)                 3.007982711627968E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.991142470004740E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.963038832565530E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.923599955312932E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.872689479506990E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.810065951609633E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.735321911346108E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.647791839299727E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.546408290696998E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.429464709770498E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.294195678257306E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.135964483342134E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.946503699269892E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.709574999026266E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.391343389937106E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.012281885409289E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.014528555318499E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.021172674809921E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.031928954490276E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.046340673197290E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.063804565966232E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.083602390447406E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.104936054761689E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.126963716684348E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.148834765567928E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.169722218029966E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.188851642086189E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.205526180491640E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.219147544224371E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.229233008154936E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.235428501703109E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dxC =  /* dxC(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 1.114203141013064E+05,      /* J =  1 */
@@ -3904,7 +4246,38 @@
 (PID.TID 0000.0001)                 2.944741346384699E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.978547649292580E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 3.001044073506459E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.012281885409289E+05       /* I = 16 */
+(PID.TID 0000.0001)     2 @  3.012281885409289E+05,             /* I = 16: 17 */
+(PID.TID 0000.0001)                 3.001044073506459E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.978547649292580E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.944741346384699E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.899523122489403E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.842706922224557E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.773972106720365E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.692787333338535E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.598293319150326E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.489113743322025E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.363029564123586E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.216367828252819E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.042717761866506E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.829777599966776E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.549545757850771E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.114203141013064E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.013593857228136E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.018056440786431E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.026789946729719E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.039422096857757E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.055420860601236E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.074122965148668E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.094767373001940E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.116531025121516E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.138564503561421E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.160025832904765E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.180111244362097E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.198082246942282E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.213288727261454E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.225188028454169E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.233360067886980E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.237518583690030E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dyC =  /* dyC(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 1.114203141013064E+05,      /* J =  1 */
@@ -3940,7 +4313,39 @@
 (PID.TID 0000.0001)                 2.922844849381675E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.962371870847826E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 2.990534755671296E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.007409169495504E+05       /* I = 16 */
+(PID.TID 0000.0001)                 3.007409169495504E+05,      /* I = 16 */
+(PID.TID 0000.0001)                 3.013031486919771E+05,      /* I = 17 */
+(PID.TID 0000.0001)                 3.007409169495504E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.990534755671296E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.962371870847826E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.922844849381675E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.871811105274442E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.809019351693761E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.734046499619031E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.646201463834826E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.544372984215561E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.426774358027003E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.290479919481738E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.130490056267208E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.937548202849060E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.691744868129062E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.333130744933864E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.013686170436881E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.015922136961168E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.022533948177109E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.033238888442880E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.047583645125296E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.064969104248934E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.084681464323149E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.105926959662063E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.127867656729039E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.149656255235069E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.170468416979250E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.189531711639232E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.206150718566154E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.219728125807783E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.229781834933111E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.235958148230841E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dxV =  /* dxV(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 8.015229982413632E+04,      /* J =  1 */
@@ -3976,7 +4381,39 @@
 (PID.TID 0000.0001)                 2.923567890694162E+05,      /* I = 13 */
 (PID.TID 0000.0001)                 2.963063101754721E+05,      /* I = 14 */
 (PID.TID 0000.0001)                 2.991205495886625E+05,      /* I = 15 */
-(PID.TID 0000.0001)                 3.008068453676764E+05       /* I = 16 */
+(PID.TID 0000.0001)                 3.008068453676764E+05,      /* I = 16 */
+(PID.TID 0000.0001)                 3.013686170436881E+05,      /* I = 17 */
+(PID.TID 0000.0001)                 3.008068453676764E+05,      /* I = 18 */
+(PID.TID 0000.0001)                 2.991205495886625E+05,      /* I = 19 */
+(PID.TID 0000.0001)                 2.963063101754721E+05,      /* I = 20 */
+(PID.TID 0000.0001)                 2.923567890694162E+05,      /* I = 21 */
+(PID.TID 0000.0001)                 2.872580915202295E+05,      /* I = 22 */
+(PID.TID 0000.0001)                 2.809856491525217E+05,      /* I = 23 */
+(PID.TID 0000.0001)                 2.734980225206389E+05,      /* I = 24 */
+(PID.TID 0000.0001)                 2.647274964828301E+05,      /* I = 25 */
+(PID.TID 0000.0001)                 2.545652950875683E+05,      /* I = 26 */
+(PID.TID 0000.0001)                 2.428369969078989E+05,      /* I = 27 */
+(PID.TID 0000.0001)                 2.292584591272880E+05,      /* I = 28 */
+(PID.TID 0000.0001)                 2.133486626971531E+05,      /* I = 29 */
+(PID.TID 0000.0001)                 1.942331448101592E+05,      /* I = 30 */
+(PID.TID 0000.0001)                 1.701080315742101E+05,      /* I = 31 */
+(PID.TID 0000.0001)                 1.362652340208229E+05,      /* I = 32 */
+(PID.TID 0000.0001)                 3.013031486919771E+05,      /* I = 33 */
+(PID.TID 0000.0001)                 3.015274890091515E+05,      /* I = 34 */
+(PID.TID 0000.0001)                 3.021908563699420E+05,      /* I = 35 */
+(PID.TID 0000.0001)                 3.032648502024415E+05,      /* I = 36 */
+(PID.TID 0000.0001)                 3.047039405458409E+05,      /* I = 37 */
+(PID.TID 0000.0001)                 3.064479682824742E+05,      /* I = 38 */
+(PID.TID 0000.0001)                 3.084252792046263E+05,      /* I = 39 */
+(PID.TID 0000.0001)                 3.105562173056038E+05,      /* I = 40 */
+(PID.TID 0000.0001)                 3.127567211383312E+05,      /* I = 41 */
+(PID.TID 0000.0001)                 3.149418154158797E+05,      /* I = 42 */
+(PID.TID 0000.0001)                 3.170288504389129E+05,      /* I = 43 */
+(PID.TID 0000.0001)                 3.189403993331409E+05,      /* I = 44 */
+(PID.TID 0000.0001)                 3.206067683235888E+05,      /* I = 45 */
+(PID.TID 0000.0001)                 3.219681053727232E+05,      /* I = 46 */
+(PID.TID 0000.0001)                 3.229761089393431E+05,      /* I = 47 */
+(PID.TID 0000.0001)                 3.235953450756532E+05       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) dyU =  /* dyU(1,:,1,:) ( units: m ) */
 (PID.TID 0000.0001)                 8.015229982413632E+04,      /* J =  1 */
@@ -4012,7 +4449,39 @@
 (PID.TID 0000.0001)                 8.674306976737517E+10,      /* I = 13 */
 (PID.TID 0000.0001)                 8.874277443041928E+10,      /* I = 14 */
 (PID.TID 0000.0001)                 9.008620045350865E+10,      /* I = 15 */
-(PID.TID 0000.0001)                 9.076111290418457E+10       /* I = 16 */
+(PID.TID 0000.0001)                 9.076111290418457E+10,      /* I = 16 */
+(PID.TID 0000.0001)                 9.076111290422060E+10,      /* I = 17 */
+(PID.TID 0000.0001)                 9.008620045354469E+10,      /* I = 18 */
+(PID.TID 0000.0001)                 8.874277443041928E+10,      /* I = 19 */
+(PID.TID 0000.0001)                 8.674306976741121E+10,      /* I = 20 */
+(PID.TID 0000.0001)                 8.410423102799828E+10,      /* I = 21 */
+(PID.TID 0000.0001)                 8.084683449728902E+10,      /* I = 22 */
+(PID.TID 0000.0001)                 7.699293007098555E+10,      /* I = 23 */
+(PID.TID 0000.0001)                 7.256353271748119E+10,      /* I = 24 */
+(PID.TID 0000.0001)                 6.757541173817516E+10,      /* I = 25 */
+(PID.TID 0000.0001)                 6.203683527772523E+10,      /* I = 26 */
+(PID.TID 0000.0001)                 5.594154126611156E+10,      /* I = 27 */
+(PID.TID 0000.0001)                 4.925938996118163E+10,      /* I = 28 */
+(PID.TID 0000.0001)                 4.192037169898667E+10,      /* I = 29 */
+(PID.TID 0000.0001)                 3.378518544304265E+10,      /* I = 30 */
+(PID.TID 0000.0001)                 2.459906945574446E+10,      /* I = 31 */
+(PID.TID 0000.0001)                 1.401900702259215E+10,      /* I = 32 */
+(PID.TID 0000.0001)                 9.076111290422060E+10,      /* I = 33 */
+(PID.TID 0000.0001)                 9.103111035233499E+10,      /* I = 34 */
+(PID.TID 0000.0001)                 9.156064070993231E+10,      /* I = 35 */
+(PID.TID 0000.0001)                 9.232920428260213E+10,      /* I = 36 */
+(PID.TID 0000.0001)                 9.330709899483766E+10,      /* I = 37 */
+(PID.TID 0000.0001)                 9.445660930090860E+10,      /* I = 38 */
+(PID.TID 0000.0001)                 9.573349030317511E+10,      /* I = 39 */
+(PID.TID 0000.0001)                 9.708868016530809E+10,      /* I = 40 */
+(PID.TID 0000.0001)                 9.847017339806476E+10,      /* I = 41 */
+(PID.TID 0000.0001)                 9.982498936271980E+10,      /* I = 42 */
+(PID.TID 0000.0001)                 1.011011716698855E+11,      /* I = 43 */
+(PID.TID 0000.0001)                 1.022497537646060E+11,      /* I = 44 */
+(PID.TID 0000.0001)                 1.032266241858423E+11,      /* I = 45 */
+(PID.TID 0000.0001)                 1.039942233001552E+11,      /* I = 46 */
+(PID.TID 0000.0001)                 1.045230037451501E+11,      /* I = 47 */
+(PID.TID 0000.0001)                 1.047926024841940E+11       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rA  =  /* rA (1,:,1,:) ( units: m^2 ) */
 (PID.TID 0000.0001)                 1.401900702255611E+10,      /* J =  1 */
@@ -4048,7 +4517,39 @@
 (PID.TID 0000.0001)                 8.549360686473492E+10,      /* I = 13 */
 (PID.TID 0000.0001)                 8.781353403175085E+10,      /* I = 14 */
 (PID.TID 0000.0001)                 8.948571540392021E+10,      /* I = 15 */
-(PID.TID 0000.0001)                 9.049530583086168E+10       /* I = 16 */
+(PID.TID 0000.0001)                 9.049530583086168E+10,      /* I = 16 */
+(PID.TID 0000.0001)                 9.083293515008307E+10,      /* I = 17 */
+(PID.TID 0000.0001)                 9.049530583087070E+10,      /* I = 18 */
+(PID.TID 0000.0001)                 8.948571540391121E+10,      /* I = 19 */
+(PID.TID 0000.0001)                 8.781353403174185E+10,      /* I = 20 */
+(PID.TID 0000.0001)                 8.549360686467184E+10,      /* I = 21 */
+(PID.TID 0000.0001)                 8.254500894890933E+10,      /* I = 22 */
+(PID.TID 0000.0001)                 7.898934631434262E+10,      /* I = 23 */
+(PID.TID 0000.0001)                 7.484854821844795E+10,      /* I = 24 */
+(PID.TID 0000.0001)                 7.014205907742783E+10,      /* I = 25 */
+(PID.TID 0000.0001)                 6.488320895111514E+10,      /* I = 26 */
+(PID.TID 0000.0001)                 5.907428494299063E+10,      /* I = 27 */
+(PID.TID 0000.0001)                 5.269930713599078E+10,      /* I = 28 */
+(PID.TID 0000.0001)                 4.571243814190767E+10,      /* I = 29 */
+(PID.TID 0000.0001)                 3.801790263325260E+10,      /* I = 30 */
+(PID.TID 0000.0001)                 2.943712825251114E+10,      /* I = 31 */
+(PID.TID 0000.0001)                 1.974052138509018E+10,      /* I = 32 */
+(PID.TID 0000.0001)                 9.071447638299399E+10,      /* I = 33 */
+(PID.TID 0000.0001)                 9.085012105610597E+10,      /* I = 34 */
+(PID.TID 0000.0001)                 9.125179254955583E+10,      /* I = 35 */
+(PID.TID 0000.0001)                 9.190392048045309E+10,      /* I = 36 */
+(PID.TID 0000.0001)                 9.278126467409492E+10,      /* I = 37 */
+(PID.TID 0000.0001)                 9.384993610263170E+10,      /* I = 38 */
+(PID.TID 0000.0001)                 9.506874487174457E+10,      /* I = 39 */
+(PID.TID 0000.0001)                 9.639080978465117E+10,      /* I = 40 */
+(PID.TID 0000.0001)                 9.776536132335065E+10,      /* I = 41 */
+(PID.TID 0000.0001)                 9.913967116446748E+10,      /* I = 42 */
+(PID.TID 0000.0001)                 1.004610434085146E+11,      /* I = 43 */
+(PID.TID 0000.0001)                 1.016788034168886E+11,      /* I = 44 */
+(PID.TID 0000.0001)                 1.027462190489479E+11,      /* I = 45 */
+(PID.TID 0000.0001)                 1.036222871661027E+11,      /* I = 46 */
+(PID.TID 0000.0001)                 1.042733173971964E+11,      /* I = 47 */
+(PID.TID 0000.0001)                 1.046742473574501E+11       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rAw =  /* rAw(1,:,1,:) ( units: m^2 ) */
 (PID.TID 0000.0001)                 1.216690346714270E+10,      /* J =  1 */
@@ -4084,7 +4585,38 @@
 (PID.TID 0000.0001)                 8.669186205742538E+10,      /* I = 13 */
 (PID.TID 0000.0001)                 8.869393350723613E+10,      /* I = 14 */
 (PID.TID 0000.0001)                 9.003884657168852E+10,      /* I = 15 */
-(PID.TID 0000.0001)                 9.071447638299399E+10       /* I = 16 */
+(PID.TID 0000.0001)     2 @  9.071447638299399E+10,             /* I = 16: 17 */
+(PID.TID 0000.0001)                 9.003884657168852E+10,      /* I = 18 */
+(PID.TID 0000.0001)                 8.869393350723613E+10,      /* I = 19 */
+(PID.TID 0000.0001)                 8.669186205742538E+10,      /* I = 20 */
+(PID.TID 0000.0001)                 8.404959656062837E+10,      /* I = 21 */
+(PID.TID 0000.0001)                 8.078743937057304E+10,      /* I = 22 */
+(PID.TID 0000.0001)                 7.692702995909871E+10,      /* I = 23 */
+(PID.TID 0000.0001)                 7.248875782324815E+10,      /* I = 24 */
+(PID.TID 0000.0001)                 6.748840226738273E+10,      /* I = 25 */
+(PID.TID 0000.0001)                 6.193257577506788E+10,      /* I = 26 */
+(PID.TID 0000.0001)                 5.581203765722643E+10,      /* I = 27 */
+(PID.TID 0000.0001)                 4.909074590409593E+10,      /* I = 28 */
+(PID.TID 0000.0001)                 4.168532893152940E+10,      /* I = 29 */
+(PID.TID 0000.0001)                 3.341968103208270E+10,      /* I = 30 */
+(PID.TID 0000.0001)                 2.390126200743558E+10,      /* I = 31 */
+(PID.TID 0000.0001)                 1.216690346714270E+10,      /* I = 32 */
+(PID.TID 0000.0001)                 9.083293515008307E+10,      /* I = 33 */
+(PID.TID 0000.0001)                 9.110170898494536E+10,      /* I = 34 */
+(PID.TID 0000.0001)                 9.162886297688426E+10,      /* I = 35 */
+(PID.TID 0000.0001)                 9.239403136821951E+10,      /* I = 36 */
+(PID.TID 0000.0001)                 9.336769520564153E+10,      /* I = 37 */
+(PID.TID 0000.0001)                 9.451235404855287E+10,      /* I = 38 */
+(PID.TID 0000.0001)                 9.578399259392229E+10,      /* I = 39 */
+(PID.TID 0000.0001)                 9.713377776174072E+10,      /* I = 40 */
+(PID.TID 0000.0001)                 9.850992024629108E+10,      /* I = 41 */
+(PID.TID 0000.0001)                 9.985963523714983E+10,      /* I = 42 */
+(PID.TID 0000.0001)                 1.011311375396738E+11,      /* I = 43 */
+(PID.TID 0000.0001)                 1.022756055022041E+11,      /* I = 44 */
+(PID.TID 0000.0001)                 1.032490462723345E+11,      /* I = 45 */
+(PID.TID 0000.0001)                 1.040139933533592E+11,      /* I = 46 */
+(PID.TID 0000.0001)                 1.045409681097387E+11,      /* I = 47 */
+(PID.TID 0000.0001)                 1.048096527455915E+11       /* I = 48 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rAs =  /* rAs(1,:,1,:) ( units: m^2 ) */
 (PID.TID 0000.0001)                 1.216690346714270E+10,      /* J =  1 */
@@ -4117,6 +4649,7 @@
 (PID.TID 0000.0001) == Packages configuration : Check & print summary ==
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) GGL90_CHECK: #define ALLOW_GGL90
+(PID.TID 0000.0001) GGL90_CHECK: Some form of convection has been enabled
 (PID.TID 0000.0001) GMREDI_CHECK: #define GMREDI
 (PID.TID 0000.0001) GM_AdvForm =     /* if FALSE => use SkewFlux Form */
 (PID.TID 0000.0001)                   T
@@ -4190,10 +4723,16 @@
 (PID.TID 0000.0001) subMeso_Lmax = /* maximum grid-scale length [m] */
 (PID.TID 0000.0001)                 1.100000000000000E+05
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
-(PID.TID 0000.0001) CTRL_CHECK: ctrl package
-(PID.TID 0000.0001) COST_CHECK: cost package
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) etaday defined by gencost   1
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
@@ -4243,16 +4782,6 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722419321245E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8391653551178E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2578120593863E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0250358581543E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8722832202911E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8121662761594E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8897924720658E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1468365592914E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9848896026611E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7946683883667E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4687031141411E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3866310191807E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.3205451473116E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qnet_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =   0.0000000000000E+00
@@ -4388,6 +4917,11 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7523130449950E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7751600143345E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3530220506968E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3038671079334E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.0941414016950E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7351071689545E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5899056584349E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0452209667951E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952020600973E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3486228464102E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682914769879E-08
@@ -4398,11 +4932,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8591177421038E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1419977130857E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4907766955980E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3038671079334E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.0941414016950E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7351071689545E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5899056584349E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0452209667951E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.2974890878624E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9904900879056E+02
@@ -4422,10 +4951,10 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   7.73551084252212E-01  1.13894701264837E+00
+ cg2d: Sum(rhs),rhsMax =   7.73551084252148E-01  3.29048622472776E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.39239266274991E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.54858862360435E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.54858862360437E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4460,17 +4989,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7946594769665E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722420084324E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8383872101944E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2611859113629E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0155255532808E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8777439320738E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8118152515723E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8870131574401E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1480682595089E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9850725836796E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7946594769665E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4681212296123E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3856459838320E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.3121542290490E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2611859113630E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.7132940640078E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.7158733727438E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5698524557069E+01
@@ -4513,8 +5032,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194584184151E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385747453959E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1230100807358E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9528523505145E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.0041790404959E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9528523505172E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.0041790450892E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4606,6 +5125,11 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7503428376374E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7713957207988E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3505226319723E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3059748256849E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.5091218908351E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7327241853639E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5882951922749E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0430587062321E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952111597009E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3384007376693E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682715906932E-08
@@ -4616,11 +5140,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8592007799505E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1396125628412E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4906252752779E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3059748256849E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.5091218908351E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7327241853639E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5882951922749E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0430587062321E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.2987449617849E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9905789935231E+02
@@ -4639,60 +5158,50 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   1.52685375416200E+00  1.46688334644766E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.25400901181289E+01
+ cg2d: Sum(rhs),rhsMax =   1.52685375416199E+00  4.17012873403983E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.25400901104588E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.34462746813205E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.34462746836541E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7198958148757E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4942266735450E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2877968073375E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8095163782264E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2532755889600E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2883237973767E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2913429661004E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.0951581823803E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1133061117676E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4603928285343E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2898021443945E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8453585977693E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9091461681647E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1940738389365E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.6777303458145E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7198958148745E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4942266735452E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2877968073376E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8095163779032E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2532755888599E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2883237969741E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2913429692487E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.0951582050619E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1133061125797E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4603928523620E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2898021450691E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8453585940871E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9091461890488E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1940738394807E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.6777303797521E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2767171614337E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.5092447359007E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.3227372568755E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.5247702358024E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3390000386488E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.5092447359006E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.3227372536427E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.5247702321120E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3390000373208E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0155082310793E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9400643887773E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9400643887779E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950191664623E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461491561528E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6297669689966E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1001975328888E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461491563146E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6297669695163E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1001975328887E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7948509387646E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722420945853E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8381432392323E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2607646719703E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0155077746101E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8814013024089E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8115141280110E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8860285967554E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1485691065011E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9856076517122E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7948509387646E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4681437529842E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3844293783478E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.3040947010574E-03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8381432407183E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2607646729929E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.7341156700845E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8577671924116E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5845158590861E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3375736605751E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2810251048637E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2810251048638E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0810277943071E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8591942754600E+02
@@ -4713,25 +5222,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0968836232115E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1751049372217E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   1.5953914969480E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8655464014368E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2716092700322E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1709323621430E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.2425540496144E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5342365456380E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4294621182702E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7138841223585E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3139884087328E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.7990921983249E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.2285785078163E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8655464014364E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2716092700329E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1709323621428E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.2425540491223E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5342365464461E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4294621182700E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7138841223583E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3139884071917E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.7990921986162E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.2285785092616E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542979625808E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.5294971861614E-06
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.7201035874089E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081600184E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081600179E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746089187E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941921442E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0819364572658E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0057951211813E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941921508E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0819364568103E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0057951208047E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4774,7 +5283,7 @@
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     2
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.3805048379034E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0625480412895E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0625480412896E+00
 (PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.2964571031868E-03
 (PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2365259966313E-01
 (PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0719485243252E-03
@@ -4785,14 +5294,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0422949479753E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.3296871438523E+02
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0211051700061E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -9.7987575638063E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -9.7987575638074E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7050523192905E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9544207219748E+00
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9544207219749E+00
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9629014731938E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1929063375419E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.8275722387084E-09
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.8275722387082E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4755664835588E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9673204269947E-10
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9673204269950E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3362609121512E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0010170945956E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.3546021455717E-01
@@ -4823,6 +5332,11 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7487527163432E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7683670277569E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3484084992428E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3086510007719E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8416861894889E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7510089282694E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6154051422235E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1319025395783E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952202593044E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3281786289283E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682517043986E-08
@@ -4833,11 +5347,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8592838177972E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1374007675622E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4905145237257E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3086510007719E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8416861894602E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7510089282694E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6154051422234E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1319025395781E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.3000008357074E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9906678991405E+02
@@ -4856,60 +5365,50 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27562176959989E+00  1.58984457467815E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.99965393215799E+00
+ cg2d: Sum(rhs),rhsMax =   2.27562176959984E+00  4.04176142668240E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.99965395716136E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.36249990851643E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.36249989550521E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.6887384398870E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.0100088178497E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.9115061540485E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.5768847517830E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1966748016671E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.9566459885899E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4483426922143E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.1130903859617E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4212509299620E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.7989307318158E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.4459206275538E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5601878568338E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.3467203473108E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5724235253398E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.1019159510537E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.6887384398168E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.0100088188579E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.9115061540482E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.5768847477280E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1966748006528E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.9566459823624E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4483425237462E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.1130904178356E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4212509411585E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.7989309518415E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.4459206275530E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5601878212814E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -8.3467203171012E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5724234232797E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.1019161645962E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8770768721842E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2738087419435E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6485981587177E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.7084741324308E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8227763289863E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6485980881533E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   4.7084740717556E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.8227763096093E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154846040912E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9383199850516E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950245540826E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461436018123E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6293682938569E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0999818924727E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9383199850766E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950245540827E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461436041163E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6293683006908E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0999580560323E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7950889327666E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722422103960E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8379836967998E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2587794916874E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0154841383088E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8827577247036E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8112087557814E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8852577326763E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1485074501132E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9862897038735E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7950889327666E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4682654132711E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3831501121676E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.2952088762810E-03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8379837177617E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2587794931274E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.7551299792817E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0211051700061E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5419653419681E+01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5419653419682E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3441475856869E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3017859720643E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3017859720644E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0822007805507E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8592667495143E+02
@@ -4917,12 +5416,12 @@
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.6879750963578E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.4629658008063E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2108312852892E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.6411025493479E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.6411025493478E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.6387377562221E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.4993153878902E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.4993153878903E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.3003983241792E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.9266610510696E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -6.7441411987374E-03
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.9266610510695E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -6.7441411987373E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2019145024761E-01
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   1.6430307838167E-03
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.8840323540474E+00
@@ -4930,25 +5429,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.1205371752368E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2127440141894E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   1.6493706760294E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.2670428858113E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3906344523937E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.0178655684022E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.6193773490802E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5928027959279E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.3964912843704E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.8115705109022E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7481952188642E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.5351564459954E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.0774212736907E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.2670428858030E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3906344523898E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.0178655684008E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.6193773491120E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5928027959270E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   9.3964912843691E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.8115705109008E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7481951913301E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.5351564519482E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.0774211400814E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542979031231E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1680692019965E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.4067438621205E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1680692019959E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.4067438621500E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193516606777E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193516606707E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385742338320E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229760090349E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1667189270828E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1949448147596E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229760090533E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1667189197556E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1949448073594E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4959,19 +5458,19 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.3955006796129E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3573153024512E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.3955006796294E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3573153024572E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   1.6990885381092E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.7305607019283E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.2953428746310E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.7010754745362E-03
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.7305607019552E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.2953428746301E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.7010754745583E-03
 (PID.TID 0000.0001) %MON seaice_area_max              =   6.3494842216730E-02
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   1.2700474956808E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   6.8002723991274E-03
-(PID.TID 0000.0001) %MON seaice_area_del2             =   6.3708158250027E-05
+(PID.TID 0000.0001) %MON seaice_area_sd               =   6.8002723991273E-03
+(PID.TID 0000.0001) %MON seaice_area_del2             =   6.3708158250026E-05
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.9458665430723E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   5.5534339024697E-04
@@ -4980,8 +5479,8 @@
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.1483975313059E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   9.5448869105497E-08
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.0465277760488E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.5710008561784E-09
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   6.0465277760487E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.5710008561780E-09
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4990,26 +5489,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     3
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.6162075029052E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.2556198847447E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.4353875942215E-03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.6162075029053E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.2556198847449E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.4353875942207E-03
 (PID.TID 0000.0001) %MON exf_ustress_sd               =   1.3200322286668E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.3038596165939E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.2899698925685E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.0931233143465E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.1014674837076E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.3038596165941E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.2899698925687E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.0931233143463E+00
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.1014674837075E-02
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3293402416695E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.3010089767694E-03
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.3010089767695E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.2036666667684E+02
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -3.1705016819846E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -8.7348820732394E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7181826101047E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   2.0083604025530E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9702206084403E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -8.7348820732518E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7181826101048E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   2.0083604025544E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9702206084404E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1726442740945E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.1746321559499E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.5050100461895E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.1712580736189E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.1746321559475E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.5050100461905E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.1712580736238E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4613544517488E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.1952037265985E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.3452369519708E-01
@@ -5037,9 +5536,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2908714857002E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3981693342144E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1376140692775E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7471512003578E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7655016703366E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3465511713767E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7471512003577E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7655016703367E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3465511713762E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3159990145482E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.7202347721051E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7856950336986E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6723515232462E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.3488140384207E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952293589079E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3179565201873E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682318181039E-08
@@ -5050,11 +5554,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8593668556439E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1353624686411E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4904444500075E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3159990145481E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.7202347715562E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7856950336989E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6723515232450E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.3488140384158E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.3012567096299E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9907568047579E+02
@@ -5073,99 +5572,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.02084135214349E+00  1.67395845773659E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.85364696045878E+00
+ cg2d: Sum(rhs),rhsMax =   3.02084135214375E+00  3.85943572236572E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.85364692571300E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.20046372563163E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.20046364383687E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890141179038E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303214802331E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5299326792708E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1484885204139E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1609504960388E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532847276176E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.9605703423701E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.7204333950451E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6624412784407E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0701617561022E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3503511585510E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5767447969928E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3547417887844E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8535229712642E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.4441911979597E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4489510249232E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6899290507845E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.3627610001828E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.6064673548115E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2362801452526E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154379937691E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890141177600E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303215008824E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5299326792706E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1484885079155E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1609505095972E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532847319196E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.9605697321819E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.7204334841556E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6624413167608E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0701622294237E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3503511585485E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5767446318233E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3547417050539E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8535231871927E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.4441916072094E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4489510249271E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6899290507842E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.3627607294953E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.6064672893917E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2362800917911E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154379937690E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9037055914447E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950347113164E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461438690657E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6274789743943E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0986120921569E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7953302242997E+01
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950347113166E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461438718961E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6274789799778E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0986207498925E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7953302242996E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722423538603E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8378437120933E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2563165731350E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0154374827473E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8841118227930E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8109769532303E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8843146906641E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1469973839160E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9871518366747E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7953302242997E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4683919402329E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3819487585011E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.2840797456310E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.7927666962252E+02
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8378437397565E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2563165607361E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.7927666962255E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.1705016819846E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4511939627704E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3578261280452E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3631048137061E+00
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.4511939627716E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3578261280454E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3631048137090E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0833737667944E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8593389466258E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1359312337159E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.6607400490628E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3818566803160E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.1938486075214E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.6260024845948E-05
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.1938486075213E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.6260024845946E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.6248084001287E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.4790231146649E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.4790231146653E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4933638411043E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0758166539787E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -6.8841685694123E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2822508806639E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.8422077978101E-03
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0758166539784E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -6.8841685694115E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2822508806638E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.8422077978103E-03
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.4913085280133E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.1650867891517E-02
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.4913085280116E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.1650867891516E-02
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2734428573772E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   1.7868720792073E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4402921797233E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1300896099104E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1661769472076E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4559241420745E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8360766889689E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2158775308326E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2695851051528E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3058716763928E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.7887300122927E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.8765802886958E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4402921796338E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1300896100538E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1661769472098E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4559241431030E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8360766889660E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2158775308350E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2695851051553E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3058716660326E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.7887300409642E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.8765807176843E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542978440385E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7538641288044E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7127092840615E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7538641288007E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7127092840607E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096914203E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096914368E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737849075E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623693752E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7362235775562E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0933593439050E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623696127E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7362235527993E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0933593027827E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5176,29 +5665,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6280649436814E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6327086092621E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0464438617513E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6280649449062E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6327086094081E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0464438615397E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -4.5189645845076E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5863511941270E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.0924163454859E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.3966246057893E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -4.5189645852314E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5863511939699E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.0924163443747E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.3966246057894E-02
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   1.7182944162889E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   9.1421294096810E-03
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.5364118363698E-05
+(PID.TID 0000.0001) %MON seaice_area_sd               =   9.1421294096812E-03
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.5364118363662E-05
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8634142572678E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.3831597967984E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.3831597967983E-04
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   4.0687137622177E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8037006958483E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2771831203384E-05
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8037006958465E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2771831203385E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.8948844941216E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.1989704531389E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0079726155966E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0079726155957E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5207,26 +5696,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3844357549145E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0417749660154E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.6395880992557E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2478560956338E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0842021423469E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0853818031534E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.4278292094989E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0461142914125E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2540884617246E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0118670371684E-03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3844357549149E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0417749660155E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.6395880992532E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2478560956335E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0842021423479E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0853818031546E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.4278292094905E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0461142914122E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2540884617247E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0118670371691E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.1688862898748E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0470511721052E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0198766120100E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7003472081516E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9628785389059E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8896923119955E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0470511721041E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0198766120194E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7003472081511E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9628785389127E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8896923119951E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1884179312026E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.7315357032604E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4714534330607E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.0139492422763E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.7315357032413E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4714534330630E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.0139492422946E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3182695081118E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0198948751322E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.5593456160356E-01
@@ -5253,10 +5742,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7762631202966E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2739950111696E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3923605941503E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1295255201088E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7459534843417E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627658215063E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3450104063733E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1295255201095E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7459534843405E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627658215050E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3450104063736E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2354995966327E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8339424689847E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7413655021333E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6216180501786E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1869515430308E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952384585115E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3077344114464E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682119318092E-08
@@ -5267,11 +5761,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8594498934906E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1334977965151E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4904150598609E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2354995966331E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8339424672903E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7413655021353E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6216180501746E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1869515430081E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.3025125835525E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9908457103754E+02
@@ -5290,99 +5779,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.74471613139104E+00  1.71426919639224E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.57930395557637E+00
+ cg2d: Sum(rhs),rhsMax =   3.74471613139090E+00  3.61217726753160E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.57930382167635E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.42219165652661E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.42219155120608E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1404016654823E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0741590617800E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1073283312612E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.5178792929066E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1507794952190E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2868838251016E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2510245560916E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1597325575305E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8724321606515E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2378122608554E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0125580490841E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4524984031356E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.8149385394273E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0808803713786E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6774431125225E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9979697065203E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0982429405416E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.1874214205613E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.3150705388773E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6000667091332E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153625517002E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9033148932727E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950470873950E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461493177556E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6248871038918E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0978943169124E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7955690137089E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1404016647630E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0741590726092E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1073283312607E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.5178792679493E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1507794768372E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2868838254637E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2510245559001E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1597326597302E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8724322514635E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2378130657168E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0125580490831E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4524984031454E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.8149383435249E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0808806205211E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6774436857260E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9979697065429E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0982429405399E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.1874190720086E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.3150704094188E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6000666245471E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153625517001E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9033148932728E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950470873949E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461493204458E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6248871048108E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0979059389165E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7955690137084E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722425129955E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8377145787778E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2541867356396E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0153619688705E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8853590586225E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8107976403363E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8832093635506E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1455076843337E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9884478956129E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7955690137089E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4685133690271E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3807480996823E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.2731394267709E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.5192196398720E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0470511721052E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5782874237878E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3430418209739E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3153527476153E+00
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8377146041077E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2541867143791E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.5192196398706E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0470511721041E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5782874237971E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3430418209733E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.3153527476269E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0845467530380E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594106416725E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1342972846379E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.6361537773250E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3296738550022E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2050142726671E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.5087225719391E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.5611935266864E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.3869864290164E-06
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.2717686593130E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.7085063354010E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.1062825596827E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2138647180802E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.6554056975810E-03
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.8555222885635E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.0831919573189E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0976268123354E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2162872766294E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.6042261274905E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5214616802333E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8020886079164E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4157930739627E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.9187119537607E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1927161425571E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.4772712379673E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5428309527796E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.6300988645263E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.5794281234485E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.6447881180770E-04
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2050142726669E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.5087225719389E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.5611935266867E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.3869864290202E-06
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.2717686593132E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.7085063353985E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.1062825596808E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2138647180799E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.6554056975816E-03
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.8555222885636E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.0831919573086E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0976268123351E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2162872766295E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.6042261274910E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5214616796354E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.8020886077965E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4157930739743E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.9187119602262E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1927161425559E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.4772712379804E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.5428309527944E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.6300988414257E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.5794281234433E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.6447887521771E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542977851461E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2790698099040E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2894133051984E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2790698098860E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2894133051951E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192845751847E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734926270E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229530520378E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1072181516221E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.9851618111754E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192845752149E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734926271E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229530526531E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1072181554295E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.9851622506218E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5393,29 +5872,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8071370727068E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8046386666084E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1992734595556E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8071370781309E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8046386672224E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1992734591140E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.1394836129542E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7746327003688E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.2662767550685E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.0394248740461E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.1394836154339E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7746326998879E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.2662767473825E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.0394248740462E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   2.1569652786043E-03
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.1428560407251E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.0657581135220E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   4.7614458591920E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.0657581135104E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   4.7614458591921E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   9.1663735925279E-04
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0464357003188E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.6602645611411E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.7607270534075E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   9.1663735925278E-04
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   5.0464357003196E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   4.6602645610939E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   3.7607270534058E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.1541929310118E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.9974310465881E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   3.2772584199201E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   3.1541929310114E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.9974310465880E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   3.2772584199165E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5424,26 +5903,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     5
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1820120500735E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -8.5568085609903E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.9194368756627E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2086017878389E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9625098023976E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9019596448530E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.7888483116596E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0073921980588E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2161130254103E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8668320025578E-03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1820120500743E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -8.5568085609894E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.9194368756607E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2086017878383E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9625098023997E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9019596448561E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.7888483116476E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0073921980581E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2161130254108E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8668320025599E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.1335080159617E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9403315582923E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1063932350334E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6891155065503E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9333595506639E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8146966690217E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9403315582875E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1063932350541E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6891155065478E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9333595506779E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8146966690210E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2111979058679E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4693485231797E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4517965014702E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9099201729354E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4693485231393E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4517965014738E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9099201729684E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.1751845644748E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8986961658619E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.7734542801004E-01
@@ -5470,10 +5949,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7721141078998E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2627130200620E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3868512530888E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1222752070434E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7450417941139E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7602021679141E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3438081304359E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1222752070460E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7450417941111E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7602021679097E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3438081304387E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.1605328321883E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1555238194036E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7151268978285E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5927525541574E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0843683273467E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952475581150E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.2975123027054E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5681920455145E-08
@@ -5484,11 +5968,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8595329313373E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1318068706254E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4904263556925E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.1605328321891E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1555238168353E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7151268978325E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5927525541500E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0843683272954E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.3037684574750E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9909346159928E+02
@@ -5507,99 +5986,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.45564259744859E+00  1.71597785448804E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96839340170699E+00
+ cg2d: Sum(rhs),rhsMax =   4.45564259744722E+00  3.33482048706553E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96839324707069E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.34356939540013E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.34356910327846E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390913763152E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266642151678E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6505717773706E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7120982043648E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1446751639589E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7250482887492E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7645074463528E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3506722368200E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0437270536152E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2970838414334E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1752922406203E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4880216891566E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1369144215232E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2636074222422E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8143042313935E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5245371770202E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.4966678399777E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3594449480070E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8838557984413E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9215123913946E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390913767014E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266642171440E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6505717773675E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7120981713726E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1446751212565E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7250482909508E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7645074455239E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3506722402532E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0437272193302E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2970851259478E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1752922406147E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4880216892096E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1369141594297E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2636076797336E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8143049637635E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5245371770836E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.4966678399809E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3594420526951E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8838556287460E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9215122660405E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152883307839E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028871503291E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950597964382E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461587547326E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6214251886927E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0972929258755E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7958049641128E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028871503290E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950597964379E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461587571603E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6214251907377E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0973032229424E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7958049641115E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722426768931E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8375934573960E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2512704188869E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0152877554588E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8864947502575E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8106515867999E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8821528976948E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1441942938292E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9896411618226E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7958049641128E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4686271071255E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3795752781903E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.2624919584822E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.2903601642937E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.9403315582923E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6512646285608E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3344732096444E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2843744636550E+00
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8375934789584E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2512703954201E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.2903601642870E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.9403315582875E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6512646285787E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3344732096420E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2843744636820E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0857197392816E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8594824204673E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1328351578473E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.6143361414878E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2781448204106E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2250016097919E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.4111041834628E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.5101693918843E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.3271197382290E-06
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0766943671707E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.6437933143553E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.4116565916970E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1770266377551E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5576635995747E-03
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6531386670462E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.8049645167300E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0518284662829E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1858753555175E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.5104572406221E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6557169994953E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.4483072922625E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6549213244519E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0351943153636E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3844046066079E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7269803801289E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8048363555288E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8148100550577E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.4751770808154E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3289831835552E-04
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2250016097915E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.4111041834542E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.5101693918858E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.3271197382591E-06
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0766943671708E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.6437933143391E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.4116565916986E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1770266377544E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5576635995755E-03
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6531386670481E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.8049645167215E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0518284662824E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1858753555180E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.5104572406240E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6557169969986E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.4483072922495E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6549213244742E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0351943180690E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3844046066013E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7269803801520E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8048363555574E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8148100228463E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.4751770807823E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3289840278415E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542977277467E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7386700322359E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.8180743684670E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7386700319353E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.8180743684488E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771603532E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734543748E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484392547E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4609499436259E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2467115525581E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771603816E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734543749E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484402108E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4609499696439E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2467121221304E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5610,29 +6079,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8903652797406E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8856185431864E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2808998518529E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8903652861827E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8856185441551E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2808998488468E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4646692550219E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8657270708885E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3476660232156E-03
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4646692511830E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8657270702442E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3476660124600E-03
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.2343536618429E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5879394443194E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3666304901725E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.2732397450321E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.6402736751969E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5879394443181E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3666304901720E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.2732397449740E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.6402736751972E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0910856344991E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.0031615021351E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4775820269786E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   5.5933107546946E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0910856344988E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.0031615021386E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4775820267844E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   5.5933107547016E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.7244999160519E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.9988996312315E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9172105117296E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.7244999160464E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   2.9988996312304E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9172105117297E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5641,26 +6110,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1037137616768E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.9088011732770E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.2786172241573E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1985729346596E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9239427726811E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.7385465374428E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.8631690423605E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9822587863608E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2112393309242E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8347572230494E-03
-(PID.TID 0000.0001) %MON exf_hflux_max                =   9.2886135449747E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8488656388599E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1286408660088E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6840816352969E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9182914494108E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7457695395730E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1037137616696E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.9088011733977E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.2786172241739E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1985729346591E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9239427726844E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.7385465374482E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.8631690423339E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9822587863602E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2112393309255E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8347572230533E-03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   9.2886135449750E+02
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8488656388529E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1286408660250E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6840816352926E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9182914494362E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7457695395741E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342840136601E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4037188934400E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4422435758500E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8568336763046E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4037188934142E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4422435758543E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8568336763528E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.0472183881203E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8892726999294E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.9875629441651E-01
@@ -5687,10 +6156,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7693447327525E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2570459671690E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3817508881300E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1151716150149E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7443198409221E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7577814582282E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431695554191E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1151716150208E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7443198409197E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7577814582197E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431695554325E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0916345812712E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7177657060958E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7085440485613E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5822245611208E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0408473972077E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952566577185E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.2872901939645E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5681721592199E-08
@@ -5701,11 +6175,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8596159691840E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1302897993783E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4904783365774E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0916345812701E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7177657037754E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7085440485639E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5822245611103E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0408473971118E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.3050243313975E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9910235216103E+02
@@ -5724,99 +6193,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.15648389870105E+00  1.68406044704176E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.59442350079027E+00
+ cg2d: Sum(rhs),rhsMax =   5.15648389869520E+00  3.10565393023254E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.59442350333145E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.24156010455605E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.24155965095467E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2376456008858E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0712498424120E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1168332880213E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7864228124294E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1352739096310E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.9177595706759E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.2677618528585E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3096043287982E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1685916308889E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2451669333640E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3221942876630E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4959898593611E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.2578124613697E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4060771263394E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8630466932611E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.0276761273279E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.8836706652511E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6127182429180E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.3738261957043E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2080098516539E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152099889403E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9024377350054E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950711090252E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461702965807E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6174122474180E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0968271377779E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7960396726836E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2376456016473E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0712498349062E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.1168332880199E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7864227870049E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1352738869235E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.9177595761293E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.2677618501874E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3096041671156E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1685918702797E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2451684475458E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.3221942874728E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.4959898595650E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.2578121995838E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4060774366215E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8630475671750E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.0276761274430E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.8836706652722E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6127172145548E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.3738259804615E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2080096927832E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152099889404E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9024377350043E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950711090246E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461702985543E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6174122508789E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0968381382763E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7960396726812E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722428356058E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8374756277473E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2480745610856E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0152094083549E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8873318852344E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8105297522047E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8811854300596E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1435683160325E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9904201376271E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7960396726836E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4687361235598E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3784616944229E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.2535514628252E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.6160974222324E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8488656388599E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6678133577876E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3313529647775E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2702238261800E+00
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8374756440932E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2480745383639E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.6160974222223E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8488656388529E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6678133577939E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3313529647758E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2702238262293E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0868927255252E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595543006364E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1315450081912E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.5953958792214E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2984739448912E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2472629445291E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.3382671522927E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4704740677195E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.2691495577205E-06
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.5279112838113E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.8176610094566E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.8019484216378E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1682910989451E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5353565306652E-03
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5449303301422E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.3725300707854E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0220190368207E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1827691187978E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.4986296749943E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4432734167490E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9647494354226E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8846110255775E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.3917267457729E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5574440121422E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9667700556258E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.0564586897476E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8878688703871E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.3982230223667E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8791334893757E-04
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.5953958792213E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2984739448817E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2472629445288E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.3382671522620E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4704740677235E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.2691495578114E-06
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.5279112837015E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.8176610094127E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.8019484216668E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1682910989443E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5353565306655E-03
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5449303301498E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.3725300707669E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0220190368210E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1827691187990E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.4986296749975E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4432734164580E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9647494340109E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8846110255658E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.3917267450252E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5574440119181E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.9667700556131E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.0564586897481E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8878688450632E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.3982230211011E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8791346466047E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542976715902E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.1300672404118E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.2953028577769E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.1300672388322E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.2953028571590E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192859817671E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192859817795E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385736586875E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229489795633E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.6257531674849E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.1830770993076E-08
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229489807718E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.6257538645406E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.1830839046716E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5827,29 +6286,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.9539654102536E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9203130136579E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3396440200877E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.9539654133701E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9203130151586E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3396440142773E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.5762536359654E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9105827660231E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3992341242861E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.4244077559230E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.5762536209226E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9105827653229E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3992341240835E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.4244077559221E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.0124072893822E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.5864008958869E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.4756233538041E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   6.4995297239915E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.0124072893760E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.5864008958839E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.4756233536629E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   6.4995297239871E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.2626412468077E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9431121170375E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   6.2547439718924E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7693352121966E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.2626412468061E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9431121170489E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   6.2547439716130E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7693352123003E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.6035993617722E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.1995485944649E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   6.8818071281144E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.6035993617453E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.1995485944651E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   6.8818071282329E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5858,26 +6317,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1534412081747E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -8.2044689187741E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.7174398196833E-03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1534412081627E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -8.2044689187743E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.7174398197392E-03
 (PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2164383621342E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9634431580786E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.8857918690471E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.0718559629575E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9685649013338E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2396530630263E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.9058444760808E-03
-(PID.TID 0000.0001) %MON exf_hflux_max                =   9.5448996490147E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8005205413552E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0836859654422E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6850973489953E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9136183196972E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.6825327701724E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2583722231701E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.5438453546039E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4406076848920E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8545458422725E-10
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9634431580819E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.8857918690372E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.0718559629441E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9685649013330E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2396530630288E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.9058444760857E-03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   9.5448996490151E+02
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8005205413571E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0836859654224E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6850973489905E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9136183197248E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.6825327701776E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2583722231700E-07
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.5438453546541E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4406076848912E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8545458423057E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.1417681338615E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8798492339970E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -6.2016716082299E-01
@@ -5904,10 +6363,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7679569820750E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2570041647371E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3789105723580E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1079845446923E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7437390194825E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7555637398911E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431385023775E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1079845447023E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7437390194850E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7555637398794E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431385024112E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.1790880052829E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5605511829966E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7225368083906E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5887078830193E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0616985024984E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952657573221E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.2770680852235E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5681522729252E-08
@@ -5918,11 +6382,6 @@
 (PID.TID 0000.0001) %MON exf_swflux_mean              =  -1.8596990070307E+02
 (PID.TID 0000.0001) %MON exf_swflux_sd                =   8.1289466801112E+01
 (PID.TID 0000.0001) %MON exf_swflux_del2              =   1.4905709982590E+00
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.1790880052817E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5605511825644E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7225368083856E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5887078830116E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0616985023694E-10
 (PID.TID 0000.0001) %MON exf_swdown_max               =   3.3062802053200E+02
 (PID.TID 0000.0001) %MON exf_swdown_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_swdown_mean              =   1.9911124272277E+02
@@ -5941,99 +6400,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.85005068090487E+00  1.63578567905662E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.22912086467014E+00
+ cg2d: Sum(rhs),rhsMax =   5.85005068088557E+00  2.96119649638921E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.22912098901427E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   1.67541096904534E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.67541046565554E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517253152562E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5713544304955E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2669383356950E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7979374034441E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1340252638362E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3041032755038E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7962180660995E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1084779749372E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2498102827247E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0087979484532E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4527404464999E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.4759661135862E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1683659022899E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5142757768743E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0834807956736E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5065482389445E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2580568113930E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9066966585135E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8368066279546E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4656476877289E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0151241178731E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9019775955214E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801967321E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461810835133E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6130362278056E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0964496243403E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7962840901035E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517253173759E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5713512815971E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2669383356907E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7979374130950E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1340252834053E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3041032731176E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7962180591953E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1084776836385E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2498105851853E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0087981125950E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4527404461303E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.4759661141420E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1683657141346E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5142761450968E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0834808886090E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5065482390902E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2580568114540E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9066949941390E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8368063333290E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4656475101109E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0151241178733E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9019775955186E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801967305E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461810850892E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6130362322289E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0964611279777E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7962840901038E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722429830554E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8373591592942E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2446338559709E-04
-(PID.TID 0000.0001) %MON dynstat_sst_max              =   3.0151235245416E+01
-(PID.TID 0000.0001) %MON dynstat_sst_min              =  -1.8880012985342E+00
-(PID.TID 0000.0001) %MON dynstat_sst_mean             =   1.8104135841062E+01
-(PID.TID 0000.0001) %MON dynstat_sst_sd               =   9.8803397482702E+00
-(PID.TID 0000.0001) %MON dynstat_sst_del2             =   1.1424012985916E-02
-(PID.TID 0000.0001) %MON dynstat_sss_max              =   3.9914817497846E+01
-(PID.TID 0000.0001) %MON dynstat_sss_min              =   1.7962840901035E+01
-(PID.TID 0000.0001) %MON dynstat_sss_mean             =   3.4688384958176E+01
-(PID.TID 0000.0001) %MON dynstat_sss_sd               =   1.3773962029177E+00
-(PID.TID 0000.0001) %MON dynstat_sss_del2             =   5.2431832699831E-03
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9492876201794E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8005205413552E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6254021762215E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3334247682780E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2730613401461E+00
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8373591711667E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2446338350359E-04
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9492876201845E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8005205413571E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6254021761750E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3334247682812E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2730613402122E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0880657117689E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8596262755385E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1304269927980E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.5794372463370E-01
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3219048372841E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2725834611738E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.2905026126727E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4411660007919E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.1865506245425E-06
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0826407904969E+00
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.5794372463368E-01
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3219048372661E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2725834611742E-04
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.2905026125904E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4411660007973E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.1865506247634E-06
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0826407904782E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -7.0252593856887E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =  -8.2778201500746E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1863113757765E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5808055837004E-03
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.7003859478464E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -8.0212615780921E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0036727052074E-02
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2106620792767E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.5680953255639E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4792132565817E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5471530441161E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1055333377445E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8811151056683E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7112174290188E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1974778397439E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.2984174396055E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8989275245550E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3096309578512E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2838086237557E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =  -8.2778201501586E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1863113757761E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5808055836984E-03
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.7003859478583E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -8.0212615780629E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -2.0036727052082E-02
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2106620792792E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.5680953255676E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4792132558596E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5471530443595E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1055333375727E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8811151026852E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7112174285834E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1974778395630E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.2984174394513E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8989275341349E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.3096309551490E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2838100940719E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542976163609E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.4526587770703E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7193973303943E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.4526587738248E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.7193973291934E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193060004366E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740359617E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538931322E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8351270448471E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.5959349985457E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193060004194E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740359616E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538945466E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8351287290418E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.5959338906509E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6044,29 +6493,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0133998900419E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9405456037619E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4063504939495E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0133998878801E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9405456069014E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4063504974745E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6014828709465E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9403888467014E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4458061939049E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.6094595211645E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6014828457706E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9403888440048E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4458061834070E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.6094595211572E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.4321607367228E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8029545216694E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.6698556099871E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3384652253066E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.4321607367103E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8029545216619E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.6698556097789E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3384652252725E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4322943817552E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8701497629674E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   6.9802249761469E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0283212821807E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4322943817504E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8701497629906E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   6.9802249762397E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0283212822379E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8381828159460E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6018675632811E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2325513809196E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8381828158227E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6018675632909E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2325513813528E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6077,249 +6526,249 @@
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.10995D+04 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
- --> f_profiles = 0.135013607365659D+04 1 1
- --> f_profiles = 0.109947398264241D+04 1 2
- --> f_gencost = 0.403901854218941D+05 1
- --> f_gencost = 0.418277523078413D+05 2
- --> f_genarr3d = 0.000000000000000D+00 1
- --> f_genarr3d = 0.000000000000000D+00 2
- --> f_genarr3d = 0.000000000000000D+00 3
- --> fc               = 0.846675477860344D+05
-  early fc =  0.000000000000000D+00
-  local fc =  0.440927002563683D+04
- global fc =  0.846675477860344D+05
+(PID.TID 0000.0001)  --> f_profiles = 0.135012753328356D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.109945066105183D+04 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.404002220976427D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.418277523185974D+05 2
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
+(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
+(PID.TID 0000.0001)  --> fc               = 0.846775526105755D+05
+(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
+(PID.TID 0000.0001)   local fc =  0.108467522039521D+05
+(PID.TID 0000.0001)  global fc =  0.846775526105755D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   7.0209329649806023
-(PID.TID 0000.0001)         System time:  0.53291898220777512
-(PID.TID 0000.0001)     Wall clock time:   14.246925115585327
+(PID.TID 0000.0001)           User time:   16.570025399327278
+(PID.TID 0000.0001)         System time:   1.6135089695453644
+(PID.TID 0000.0001)     Wall clock time:   19.495706796646118
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.59790902584791183
-(PID.TID 0000.0001)         System time:  0.13098000735044479
-(PID.TID 0000.0001)     Wall clock time:   3.4088819026947021
+(PID.TID 0000.0001)           User time:  0.63043401390314102
+(PID.TID 0000.0001)         System time:  0.49438602104783058
+(PID.TID 0000.0001)     Wall clock time:   1.2275180816650391
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   6.4230239391326904
-(PID.TID 0000.0001)         System time:  0.40193897485733032
-(PID.TID 0000.0001)     Wall clock time:   10.837816953659058
+(PID.TID 0000.0001)           User time:   15.939538836479187
+(PID.TID 0000.0001)         System time:   1.1190940141677856
+(PID.TID 0000.0001)     Wall clock time:   18.268112897872925
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.73788797855377197
-(PID.TID 0000.0001)         System time:  5.49919903278350830E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4237749576568604
+(PID.TID 0000.0001)           User time:   1.0135470032691956
+(PID.TID 0000.0001)         System time:  0.64651101827621460
+(PID.TID 0000.0001)     Wall clock time:   2.6918640136718750
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.6851359605789185
-(PID.TID 0000.0001)         System time:  0.34694698452949524
-(PID.TID 0000.0001)     Wall clock time:   9.4139869213104248
+(PID.TID 0000.0001)           User time:   14.925962448120117
+(PID.TID 0000.0001)         System time:  0.47257089614868164
+(PID.TID 0000.0001)     Wall clock time:   15.576209068298340
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  8.19886922836303711E-002
-(PID.TID 0000.0001)         System time:  5.99998235702514648E-003
-(PID.TID 0000.0001)     Wall clock time:  0.52909183502197266
+(PID.TID 0000.0001)           User time:   8.6557626724243164E-002
+(PID.TID 0000.0001)         System time:   6.9149732589721680E-003
+(PID.TID 0000.0001)     Wall clock time:  0.10581326484680176
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  4.29937839508056641E-002
-(PID.TID 0000.0001)         System time:  1.00001692771911621E-003
-(PID.TID 0000.0001)     Wall clock time:  4.76298332214355469E-002
+(PID.TID 0000.0001)           User time:   8.4171295166015625E-002
+(PID.TID 0000.0001)         System time:   7.1361064910888672E-003
+(PID.TID 0000.0001)     Wall clock time:  0.13107419013977051
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.2881945371627808
-(PID.TID 0000.0001)         System time:  0.27495703101158142
-(PID.TID 0000.0001)     Wall clock time:   8.0509107112884521
+(PID.TID 0000.0001)           User time:   14.359805107116699
+(PID.TID 0000.0001)         System time:  0.31129503250122070
+(PID.TID 0000.0001)     Wall clock time:   14.782106161117554
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.2881945371627808
-(PID.TID 0000.0001)         System time:  0.27495703101158142
-(PID.TID 0000.0001)     Wall clock time:   8.0506267547607422
+(PID.TID 0000.0001)           User time:   14.359663724899292
+(PID.TID 0000.0001)         System time:  0.31128680706024170
+(PID.TID 0000.0001)     Wall clock time:   14.781951665878296
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  7.69854784011840820E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  7.79938697814941406E-002
+(PID.TID 0000.0001)           User time:  0.21557235717773438
+(PID.TID 0000.0001)         System time:   2.2053718566894531E-005
+(PID.TID 0000.0001)     Wall clock time:  0.21585679054260254
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.09954977035522461E-002
-(PID.TID 0000.0001)         System time:  2.99900770187377930E-003
-(PID.TID 0000.0001)     Wall clock time:  2.39849090576171875E-002
+(PID.TID 0000.0001)           User time:   5.9613704681396484E-002
+(PID.TID 0000.0001)         System time:   8.8279247283935547E-003
+(PID.TID 0000.0001)     Wall clock time:   6.8524360656738281E-002
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  9.59863662719726563E-002
-(PID.TID 0000.0001)         System time:  6.99901580810546875E-003
-(PID.TID 0000.0001)     Wall clock time:  0.12350296974182129
+(PID.TID 0000.0001)           User time:  0.18710112571716309
+(PID.TID 0000.0001)         System time:   6.7831277847290039E-003
+(PID.TID 0000.0001)     Wall clock time:  0.19403362274169922
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  9.39865112304687500E-002
-(PID.TID 0000.0001)         System time:  6.99901580810546875E-003
-(PID.TID 0000.0001)     Wall clock time:  0.12210106849670410
+(PID.TID 0000.0001)           User time:  0.18669748306274414
+(PID.TID 0000.0001)         System time:   6.7209005355834961E-003
+(PID.TID 0000.0001)     Wall clock time:  0.19358801841735840
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.57833099365234375E-004
+(PID.TID 0000.0001)           User time:   9.7393989562988281E-005
+(PID.TID 0000.0001)         System time:   3.2901763916015625E-005
+(PID.TID 0000.0001)     Wall clock time:   1.3303756713867188E-004
+(PID.TID 0000.0001)          No. starts:           8
+(PID.TID 0000.0001)           No. stops:           8
+(PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   2.2139787673950195E-002
+(PID.TID 0000.0001)         System time:   1.3411045074462891E-003
+(PID.TID 0000.0001)     Wall clock time:   2.3489236831665039E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  2.99894809722900391E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  3.04269790649414063E-003
+(PID.TID 0000.0001)           User time:   7.4082612991333008E-003
+(PID.TID 0000.0001)         System time:   3.7586688995361328E-004
+(PID.TID 0000.0001)     Wall clock time:   7.7917575836181641E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1888184547424316
-(PID.TID 0000.0001)         System time:  1.79980099201202393E-002
-(PID.TID 0000.0001)     Wall clock time:   1.3018682003021240
+(PID.TID 0000.0001)           User time:   2.7878596782684326
+(PID.TID 0000.0001)         System time:   2.5455117225646973E-002
+(PID.TID 0000.0001)     Wall clock time:   2.8245861530303955
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  8.79851579666137695E-002
-(PID.TID 0000.0001)         System time:  2.00003385543823242E-003
-(PID.TID 0000.0001)     Wall clock time:  8.94203186035156250E-002
+(PID.TID 0000.0001)           User time:  0.45202660560607910
+(PID.TID 0000.0001)         System time:   4.4448375701904297E-003
+(PID.TID 0000.0001)     Wall clock time:  0.45948123931884766
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:  6.19906187057495117E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  6.30860328674316406E-002
+(PID.TID 0000.0001)           User time:  0.28657865524291992
+(PID.TID 0000.0001)         System time:   3.4878253936767578E-003
+(PID.TID 0000.0001)     Wall clock time:  0.29294681549072266
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  0.28995490074157715
-(PID.TID 0000.0001)         System time:  2.99900770187377930E-003
-(PID.TID 0000.0001)     Wall clock time:  0.32384562492370605
-(PID.TID 0000.0001)          No. starts:           8
-(PID.TID 0000.0001)           No. stops:           8
+(PID.TID 0000.0001)           User time:  0.58916532993316650
+(PID.TID 0000.0001)         System time:   1.2796998023986816E-002
+(PID.TID 0000.0001)     Wall clock time:  0.60203099250793457
+(PID.TID 0000.0001)          No. starts:          24
+(PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.97385263442993164
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.97128987312316895
+(PID.TID 0000.0001)           User time:   2.6633291244506836
+(PID.TID 0000.0001)         System time:   9.7110271453857422E-003
+(PID.TID 0000.0001)     Wall clock time:   2.7570247650146484
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10098576545715332
-(PID.TID 0000.0001)         System time:  5.79919815063476563E-002
-(PID.TID 0000.0001)     Wall clock time:  0.15547537803649902
+(PID.TID 0000.0001)           User time:  0.30183410644531250
+(PID.TID 0000.0001)         System time:   6.2000751495361328E-004
+(PID.TID 0000.0001)     Wall clock time:  0.30269312858581543
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  7.59888887405395508E-002
-(PID.TID 0000.0001)         System time:  9.99996066093444824E-003
-(PID.TID 0000.0001)     Wall clock time:  8.75577926635742188E-002
+(PID.TID 0000.0001)           User time:  0.16972041130065918
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.17400908470153809
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.49971246719360352E-002
+(PID.TID 0000.0001)           User time:   6.6720724105834961E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.75337791442871094E-002
+(PID.TID 0000.0001)     Wall clock time:   6.6951990127563477E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  4.09944057464599609E-002
-(PID.TID 0000.0001)         System time:  2.99900770187377930E-003
-(PID.TID 0000.0001)     Wall clock time:  4.06436920166015625E-002
+(PID.TID 0000.0001)           User time:  0.15086340904235840
+(PID.TID 0000.0001)         System time:   3.9690732955932617E-003
+(PID.TID 0000.0001)     Wall clock time:  0.15486836433410645
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  1.99997425079345703E-003
-(PID.TID 0000.0001)         System time:  1.00001692771911621E-003
-(PID.TID 0000.0001)     Wall clock time:  4.34279441833496094E-003
+(PID.TID 0000.0001)           User time:   1.0886430740356445E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.0897397994995117E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  7.09873437881469727E-002
-(PID.TID 0000.0001)         System time:  5.99896907806396484E-003
-(PID.TID 0000.0001)     Wall clock time:  8.00652503967285156E-002
+(PID.TID 0000.0001)           User time:  0.16826820373535156
+(PID.TID 0000.0001)         System time:   1.5094876289367676E-002
+(PID.TID 0000.0001)     Wall clock time:  0.18354487419128418
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2818078994750977
-(PID.TID 0000.0001)         System time:  6.39879703521728516E-002
-(PID.TID 0000.0001)     Wall clock time:   1.3445818424224854
+(PID.TID 0000.0001)           User time:   3.6263103485107422
+(PID.TID 0000.0001)         System time:   1.1201977729797363E-002
+(PID.TID 0000.0001)     Wall clock time:   3.6451230049133301
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.53541564941406250E-004
-(PID.TID 0000.0001)          No. starts:           8
-(PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_TAVE   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.48057937622070313E-004
+(PID.TID 0000.0001)           User time:   7.8439712524414062E-005
+(PID.TID 0000.0001)         System time:   3.0994415283203125E-006
+(PID.TID 0000.0001)     Wall clock time:   9.0122222900390625E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21996808052062988
-(PID.TID 0000.0001)         System time:  7.99804925918579102E-003
-(PID.TID 0000.0001)     Wall clock time:  0.22563481330871582
+(PID.TID 0000.0001)           User time:  0.68308138847351074
+(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
+(PID.TID 0000.0001)     Wall clock time:  0.68428158760070801
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.43289566040039063E-004
+(PID.TID 0000.0001)           User time:   6.9141387939453125E-005
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   7.0095062255859375E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.79987668991088867
-(PID.TID 0000.0001)         System time:  4.59930300712585449E-002
-(PID.TID 0000.0001)     Wall clock time:   2.3667280673980713
+(PID.TID 0000.0001)           User time:  0.93296074867248535
+(PID.TID 0000.0001)         System time:  0.15568602085113525
+(PID.TID 0000.0001)     Wall clock time:   1.0893309116363525
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32095098495483398
-(PID.TID 0000.0001)         System time:  5.09920120239257813E-002
-(PID.TID 0000.0001)     Wall clock time:   1.2223176956176758
+(PID.TID 0000.0001)           User time:  0.18527793884277344
+(PID.TID 0000.0001)         System time:   7.2070002555847168E-002
+(PID.TID 0000.0001)     Wall clock time:  0.25739121437072754
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  9.99879837036132813E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  9.07371044158935547E-002
+(PID.TID 0000.0001)           User time:   1.1495590209960938E-002
+(PID.TID 0000.0001)         System time:   3.9520263671875000E-003
+(PID.TID 0000.0001)     Wall clock time:   1.5450954437255859E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.03950500488281250E-004
+(PID.TID 0000.0001)           User time:   5.3405761718750000E-004
+(PID.TID 0000.0001)         System time:   4.8995018005371094E-005
+(PID.TID 0000.0001)     Wall clock time:   5.8484077453613281E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.22096586227416992
-(PID.TID 0000.0001)         System time:  5.29919862747192383E-002
-(PID.TID 0000.0001)     Wall clock time:  0.63420200347900391
+(PID.TID 0000.0001)           User time:  0.27046585083007812
+(PID.TID 0000.0001)         System time:  0.11914789676666260
+(PID.TID 0000.0001)     Wall clock time:  0.40362691879272461
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.13397884368896484
-(PID.TID 0000.0001)         System time:  5.19919991493225098E-002
-(PID.TID 0000.0001)     Wall clock time:  0.51992416381835938
+(PID.TID 0000.0001)           User time:  0.18062973022460938
+(PID.TID 0000.0001)         System time:   8.7460994720458984E-002
+(PID.TID 0000.0001)     Wall clock time:  0.28121805191040039
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  8.69870185852050781E-002
-(PID.TID 0000.0001)         System time:  9.99987125396728516E-004
-(PID.TID 0000.0001)     Wall clock time:  0.11421108245849609
+(PID.TID 0000.0001)           User time:   8.9786529541015625E-002
+(PID.TID 0000.0001)         System time:   3.1682968139648438E-002
+(PID.TID 0000.0001)     Wall clock time:  0.12236404418945312
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  4.00018692016601563E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  1.26659870147705078E-002
+(PID.TID 0000.0001)           User time:   1.6365051269531250E-003
+(PID.TID 0000.0001)         System time:   1.6295909881591797E-004
+(PID.TID 0000.0001)     Wall clock time:   1.8019676208496094E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6336,10 +6785,32 @@
 (PID.TID 0000.0001) //            Min. Y spins =     1000000000
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000002
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
+(PID.TID 0000.0001) // o Tile number: 000003
+(PID.TID 0000.0001) //         No. X exchanges =              0
+(PID.TID 0000.0001) //            Max. X spins =              0
+(PID.TID 0000.0001) //            Min. X spins =     1000000000
+(PID.TID 0000.0001) //          Total. X spins =              0
+(PID.TID 0000.0001) //            Avg. X spins =       0.00E+00
+(PID.TID 0000.0001) //         No. Y exchanges =              0
+(PID.TID 0000.0001) //            Max. Y spins =              0
+(PID.TID 0000.0001) //            Min. Y spins =     1000000000
+(PID.TID 0000.0001) //          Total. Y spins =              0
+(PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          18536
+(PID.TID 0000.0001) //            No. barriers =          18588
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          18536
+(PID.TID 0000.0001) //     Total barrier spins =          18588
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_cs32/results/output_adm.sens.txt
+++ b/global_oce_cs32/results/output_adm.sens.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67y
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri May  7 10:13:10 EDT 2021
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 12:37:18 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -158,7 +158,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -628,58 +628,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -835,6 +835,9 @@
 (PID.TID 0000.0001) useApproxAdvectionInAdMode = /* approximate AD-advection */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cg2dFullAdjoint = /* use full hand written cg2d adjoint (no approximation) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useKPPinAdMode = /* use KPP in adjoint mode */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -902,8 +905,6 @@
 (PID.TID 0000.0001) ># **********************
 (PID.TID 0000.0001) > &ctrl_nml
 (PID.TID 0000.0001) > doSinglePrecTapelev=.TRUE.,
-(PID.TID 0000.0001) > ctrlSmoothCorrel2D=.TRUE.,
-(PID.TID 0000.0001) > ctrlSmoothCorrel3D=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># *********************
@@ -968,9 +969,9 @@
 (PID.TID 0000.0001) > mult_genarr3d(3) = 0.,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -1046,8 +1047,8 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // pkg/smooth configuration
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) smooth 2D parameters:  1    30    0.    0.
-(PID.TID 0000.0001) smooth 3D parameters:  1    30    0.    0.    0.
+(PID.TID 0000.0001) smooth 2D parameters:  1    30    0.    0.maskC
+(PID.TID 0000.0001) smooth 3D parameters:  1    30    0.    0.    0.maskC
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of pkg/smooth config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -1329,6 +1330,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 7.200000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 3.153600000000000E+07
 (PID.TID 0000.0001)     ;
@@ -1389,22 +1393,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -1583,6 +1596,7 @@
 (PID.TID 0000.0001)  error file =
 (PID.TID 0000.0001)  gencost_flag = -3
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = north10_flux_vol
 (PID.TID 0000.0001) -------------
@@ -1594,6 +1608,7 @@
 (PID.TID 0000.0001)  error file =
 (PID.TID 0000.0001)  gencost_flag = -3
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 3) = moc_north10
 (PID.TID 0000.0001) -------------
@@ -1605,6 +1620,7 @@
 (PID.TID 0000.0001)  error file =
 (PID.TID 0000.0001)  gencost_flag = -5
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -2558,7 +2574,6 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
 (PID.TID 0000.0001)       weight     = wt_theta.data
@@ -2683,6 +2698,93 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -2877,17 +2979,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -2895,10 +3000,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3090,8 +3195,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3108,7 +3213,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3145,8 +3250,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3161,6 +3266,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -3612,47 +3720,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -4706,64 +4773,64 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252148E-01  3.29048622472776E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357776815E+00  4.17022503399561E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.25378323349447E+01
+ cg2d: Sum(rhs),rhsMax =   1.52697357776813E+00  4.17022503399561E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.25378323272703E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.34478286540845E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.34478286563935E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7220831576543E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7220831576530E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4941568763539E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874426E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8092937288782E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2533467112719E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2884748068859E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2920099392758E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1022151678322E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1132333109074E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4603773629505E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2938616379794E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8459289745200E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.8963804221756E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1940013971882E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.6784833267699E-05
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874423E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8092937285550E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2533467111718E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2884748064833E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2920099424240E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1022151905139E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1132333117177E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4603773867797E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2938616386540E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8459289708378E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.8963804430597E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1940013977162E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.6784833608242E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2769957202630E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.5132840060569E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.3215985062292E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.5248723091532E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3390630503530E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.5132840060568E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.3215985029965E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.5248723054680E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3390630490141E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0155011860623E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9415803792981E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950191627401E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461504099366E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6298206545448E-03
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461504100979E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6298206552320E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1000610213798E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8994047407183E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726327878017E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0073441842617E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3826907209947E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8507032606353E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2027997798659E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1449686832679E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.2427386614934E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5390992081229E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4309484766697E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7154362332682E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3129344554273E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.8017215012337E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.2284241604668E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0073441860540E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3826907219707E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8507032601435E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2027997806804E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1449686832678E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.2427386610013E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5390992089309E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4309484766695E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7154362332681E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3129344538862E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.8017215015252E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.2284241618924E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542979625808E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5299161171875E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5299161171874E-06
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.7209700118146E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081320227E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081320223E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746079984E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854182E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823557794451E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328656636688E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854213E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823557789890E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328656632395E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4817,14 +4884,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0422854006221E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.3296438538218E+02
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0209634519797E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -9.7950490305809E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -9.7950490305817E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7048015364063E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9540816099778E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9623201658926E-07
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9540816099779E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9623201658927E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1928804646881E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.8286605260290E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4752807499852E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9664847413216E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.8286605260288E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4752807499853E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9664847413219E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3362609121512E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0010170945956E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.3546021455717E-01
@@ -4855,11 +4922,11 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7488730803800E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7682145855982E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3484485085363E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3080696934706E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8416655458345E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7511177570015E-08
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3080696934707E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8416655458628E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7511177570014E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6148510918363E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1311523361460E-10
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1311523361462E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952202593044E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3281786289283E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682517043986E-08
@@ -4888,65 +4955,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27601764070118E+00  4.04197234578125E+00
- cg2d: Sum(rhs),rhsMax =   3.02165606792590E+00  3.85995024094910E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.85288555420924E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601764070111E+00  4.04197234578123E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165606792568E+00  3.85995024091529E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.85288551069115E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.19969225614463E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.19969217256200E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890402609337E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303080877747E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890402607898E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303081084345E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5316966869643E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1483050963958E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1622406931771E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6559727969236E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.9607182210955E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.7209208064453E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6623668342836E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0707193055075E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3668913447194E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5770786952745E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3543047738333E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8535213368072E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.4450931334760E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4517272087328E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6939945423771E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.3620787268120E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.6089420748317E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2375218327954E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154466181268E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9396257620812E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950347075523E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461507162227E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6271652524937E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0987216603846E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1483050842561E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1622407086058E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6559728012181E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.9607176111030E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.7209208922449E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6623668752978E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0707198196333E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3668913447169E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5770785300923E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3543046954937E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8535215527749E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.4450935949876E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4517272087367E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6939945423768E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.3620784421645E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.6089420089471E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2375217794694E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154466181270E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9396257621077E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950347075526E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461507190544E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6271652593949E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0987305399351E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8987645798192E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726330465244E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0070201124175E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3772567102723E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.1338171955773E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5802353972834E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240918396E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4564503243546E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8555597665680E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2173753954000E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2711488268550E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3057232510802E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.7930398928779E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.8764665408403E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0070201458281E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3772566990703E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.1338171955404E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5802354768392E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240918418E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4564503253829E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8555597665651E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2173753954024E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2711488268575E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3057232410202E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.7930399215715E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.8764669740102E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542978440074E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7575486619909E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7180825570805E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7575486619873E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7180825570797E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096777492E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096777661E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737833613E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623568954E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959395214E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276264456381E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623570976E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959060763E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276264031325E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4957,29 +5024,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6266137978488E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6328426404148E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0463181888385E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6266137990315E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6328426405664E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0463181886299E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -4.5201857214911E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5861474370869E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.0924955873822E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.4037768357354E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -4.5201857222343E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5861474369281E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.0924955862715E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.4037768357355E-02
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   1.7185050080772E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   9.1432894603469E-03
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.5498880902109E-05
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8672995801018E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   9.1432894603470E-03
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.5498880902070E-05
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8672995801019E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.3851543123594E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.3851543123593E-04
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   4.0696195559937E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8091517955238E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2787068334910E-05
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8091517955219E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2787068334912E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.8953534523236E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.8953534523237E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.1994419297762E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0121073030672E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0121073030663E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4988,26 +5055,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3844270228197E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0417589747856E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.6384275529612E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2478616714219E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0841802031589E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0853724252863E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.4277893213240E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0460748762173E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2540791040531E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0118677110526E-03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3844270228201E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0417589747857E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.6384275529589E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2478616714216E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0841802031599E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0853724252875E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.4277893213152E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0460748762170E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2540791040532E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0118677110533E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.1688174316804E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0463291109667E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0187055236536E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7000241603295E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9628274369863E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8894177711191E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0463291109660E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0187055236599E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7000241603302E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9628274369936E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8894177711193E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1883687342004E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.7343418043392E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4711017202821E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.0142891545143E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.7343418043255E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4711017202852E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.0142891545321E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3182695081118E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0198948751322E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.5593456160356E-01
@@ -5034,15 +5101,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7762631202966E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2739950111696E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3923613550083E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1258430936334E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7462505392776E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7625796830366E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3452027264093E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2352250557566E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8337592321048E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7416461122431E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6208879767472E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1871791513469E-10
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1258430936342E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7462505392768E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7625796830364E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3452027264097E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2352250557569E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8337592337783E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7416461122418E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6208879767517E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1871791513695E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952384585115E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3077344114464E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682119318092E-08
@@ -5071,65 +5138,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.74608559882526E+00  3.61302462958173E+00
- cg2d: Sum(rhs),rhsMax =   4.45761416646582E+00  3.33597383815632E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96706438341623E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608559882506E+00  3.61302462788831E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761416646442E+00  3.33597382979536E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96706422336150E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.33728065529280E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.33728053683239E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390576244349E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266696127647E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206967E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527726446E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463462334811E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901373520E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680595857E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510304108570E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436489969945E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2992862163873E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1805123309400E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5077157119703E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1367240502271E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2642421910301E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188712516393E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487250441E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840631151E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673465280513E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943371109096E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264809234533E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706920E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9029464932251E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950597931844E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461718897577E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6209151530762E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0976385713245E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981819416445E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390576248213E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266696147292E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206937E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527400515E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463461837854E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901395485E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680587560E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510304160454E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436491544268E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2992873918663E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1805123307335E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5077157120234E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1367237930748E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2642424460278E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188719904930E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487251075E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840631183E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673437629994E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943369377548E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264807997633E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706922E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9029464932257E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950597931841E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461718921796E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6209151621133E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0976493325984E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981819416225E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726333694657E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067566945383E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721089059710E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576028930E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681588203E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550013018900E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686252443E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534748090E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209622396E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925432102E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8146742470790E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5061127776329E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3301712453258E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067567206878E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088838815E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576018928E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681589277E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550013019122E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686279435E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534745658E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209622627E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925432387E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8146742152694E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.5061127764065E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3301720691637E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542977276382E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7495794275164E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.8350324426902E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7495794265678E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.8350324420195E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771505953E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771506257E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734511743E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484254881E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614783284991E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210425026915E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484263712E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614783656195E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210431185563E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5140,29 +5207,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8883545198230E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8855865594377E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2806532047810E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8883545239500E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8855865603565E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2806532015867E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4666809335036E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8652100759787E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3474458701495E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.2360203961632E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4666809295620E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8652100753562E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3474458591345E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.2360203961631E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5886239340013E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3669682798324E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.2765191169403E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.6496045389344E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5886239340002E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3669682798321E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.2765191168852E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.6496045389339E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0915727150087E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.0053130762430E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4907322292164E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   5.5987949556495E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0915727150083E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.0053130762462E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4907322290236E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   5.5987949556619E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.7314491461883E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.0012147480166E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9367759686496E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.7314491461830E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.0012147480163E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9367759686534E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5171,26 +5238,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1037075319256E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.9086473786258E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.2757391525213E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1986047778936E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9240206332203E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.7385360531521E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.8631232392511E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9823714102123E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2112287882203E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8347808452520E-03
-(PID.TID 0000.0001) %MON exf_hflux_max                =   9.2886219769115E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8476995926066E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891370058E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909458951E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387149869E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539012757E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1037075319182E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.9086473787371E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.2757391525519E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1986047778928E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9240206332231E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.7385360531575E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.8631232392249E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9823714102116E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2112287882216E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8347808452557E-03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   9.2886219769108E+02
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8476995926017E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891370115E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909458983E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387150137E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539012778E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342284317824E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796250E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781331E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8574493068619E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796058E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781434E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8574493069014E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.0472183881203E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8892726999294E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.9875629441651E-01
@@ -5217,15 +5284,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7693447327525E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2570459671690E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3816578923415E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1104555773288E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046688E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104767E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172316E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594668E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197723056E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371824E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764311E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0412193075587E-10
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1104555773410E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046680E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104757E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172466E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594654E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197745416E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371804E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764488E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0412193076481E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952566577185E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.2872901939645E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5681721592199E-08
@@ -5254,65 +5321,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.15911012251587E+00  3.10707882939577E+00
- cg2d: Sum(rhs),rhsMax =   5.85339071336659E+00  2.96283946876159E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.22708931409487E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911012251061E+00  3.10707881036238E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339071335443E+00  2.96283944234202E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.22708940360578E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   1.64667855614881E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.64667853807229E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517419384524E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5711956584156E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993142E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977402846405E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361003503855E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754865445E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152032886353E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089661483879E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499026990133E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0094318696491E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4625188160682E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5209188736415E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1681990306254E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5165808152818E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0848780047927E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5278920800505E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786515826E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072414649075E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644193035970E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783248630797E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185557E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458179313E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892071E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4462020475466E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6126513004355E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0970628945425E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439283718E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517419404721E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5711930106822E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993114E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977402895537E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361003544257E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754838937E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152032817386E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089658240092E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499029849931E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0094320183165E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4625188154784E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5209188741999E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1681988972544E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5165811824946E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0848780978523E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5278920802009E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786516316E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072398658095E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644189707293E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246506920E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185563E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458180838E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892054E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4462020491081E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6126513103439E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0970750017350E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439292380E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726336750298E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222840572E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976506241E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502676345E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601909948E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633110668E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753296456467E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356024633E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446459594E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745417620E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8987366426987E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3813407904197E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2893710680428E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222985486E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976415238E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502668246E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601912161E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633108971E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753296423327E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356017686E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446457806E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745416100E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8987366475372E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.3813407860789E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2893725033246E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542976161516E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.4706133493088E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7511635081360E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.4706133455102E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.7511635062198E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943451E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316416E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538633636E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441808963920E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326287630433E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943291E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316415E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538645643E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826506008E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326275857834E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5323,29 +5390,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015806102E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425161491E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935359904E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015724911E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425194518E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935396000E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032168262122E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9397438222301E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4451765225315E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.6121956407390E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032168007281E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9397438194209E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4451765112350E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.6121956407290E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.4332297665808E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8035737713302E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.6753780942461E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283717676E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.4332297665705E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8035737713248E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.6753780940915E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283717223E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4331232104475E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8738037374520E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   7.0030891660313E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657522492E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4331232104444E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8738037374746E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   7.0030891661955E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657523121E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147588823E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146556E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095013061E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587878E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146931E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095021031E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5358,22 +5425,22 @@
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899021225E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899009584E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899021225E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899009584E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222846954753E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707154405382E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748585496962E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186023741319E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604627083333E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866659818793E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845024957E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707148229167E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748572443576E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186133289931E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604625729167E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866628704970E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -5381,23 +5448,23 @@
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963234923E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963615524E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068387265E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067895084E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846316134E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843759134E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153613288E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707147176420E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748586224791E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748575159857E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428644979553E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899021225D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866659818793D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428644979553D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428624466631E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736899009584D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866628704970D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428624466631D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -5406,151 +5473,65 @@
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888418199D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889477125D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157164295470D+08
-(PID.TID 0000.0001)  global fc =  0.139129888418199D+09
+(PID.TID 0000.0001)   local fc =  0.792157147949215D+08
+(PID.TID 0000.0001)  global fc =  0.139129889477125D+09
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
- cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
- cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697357776815E+00  4.17022503399603E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601764070135E+00  4.04197234578102E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165606792570E+00  3.85995024091507E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.74608559882543E+00  3.61302462958151E+00
- cg2d: Sum(rhs),rhsMax =   4.45761416646636E+00  3.33597383815620E+00
- cg2d: Sum(rhs),rhsMax =   5.15911012251672E+00  3.10707882939607E+00
- cg2d: Sum(rhs),rhsMax =   5.85339071336745E+00  2.96283946876190E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608559882535E+00  3.61302462788807E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761416646482E+00  3.33597382979533E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911012251146E+00  3.10707881036115E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339071335491E+00  2.96283944234280E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.74608577798608E+00  3.61303114709574E+00
- cg2d: Sum(rhs),rhsMax =   4.45761761974450E+00  3.33597889011480E+00
- cg2d: Sum(rhs),rhsMax =   5.15911604137395E+00  3.10708255938939E+00
- cg2d: Sum(rhs),rhsMax =   5.85339734146226E+00  2.96284271209768E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608598826450E+00  3.61303115221832E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761783002212E+00  3.33597887930389E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911625164870E+00  3.10708253803197E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339755173015E+00  2.96284268389013E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
- Calling cg2d from S/R CG2D_SAD
+ Calling cg2d from S/R CG2D_MAD
  cg2d: Sum(rhs),rhsMax =   2.09610107049230E-13  3.55600724767241E+02
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -7.61002372229314E-13  4.69523172580516E+01
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -2.41195952099815E-13  4.69523172524602E+01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.5145494433157E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3452513542556E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.6109088003514E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   9.2404149409377E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3457244456146E+02
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.9679167113987E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -9.6224527739913E+04
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6446440206801E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.7650699328340E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6017271459245E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.4962098470329E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.2749272084468E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.6268247740818E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7869483124789E-02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.2961682819523E-03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.3138440257720E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.7619086767024E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.8935906348104E+04
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8136678033917E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.4413928054436E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.5145494433965E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.3452513538334E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.6109087984306E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   9.2404149382786E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3457244446677E+02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.9679167114157E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -9.6224527743703E+04
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.6446440215536E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.7650699301057E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6017271461410E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.4962098470242E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.2749272084588E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   2.6268247727116E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7869483103019E-02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.2961682811291E-03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.3138440262750E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.7619086769641E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -4.8935906885135E+04
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8136678033407E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.4413928053055E+04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.0226039289177E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.3321394424103E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =  -7.9081972834875E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   7.8395253854129E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.3481005383210E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   5.0199711769474E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -7.5025272702551E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -2.9612463675083E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   7.0512795207290E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   1.0121927098566E+02
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.0847521493574E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -2.1381616743861E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.4241656857560E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   6.9853572768922E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   1.1270624433590E+02
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   7.2647830513296E-03
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -3.4653933453044E-03
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   3.9120205697561E-06
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.7212853954630E-04
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   7.1324001385493E-06
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   1.3428259211578E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -1.3062306777374E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -4.3598467655418E+01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   1.3321420055538E+02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   2.6532466520543E+00
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   2.5083847476873E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -6.0693523240321E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   2.4881983945991E+01
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   1.2047844507404E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   2.2986637984010E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   3.3966676639220E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -1.2448599502913E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =   2.3724970746980E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   1.3918811456935E+01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   3.4316948721896E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.2911043896075E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.0922956467174E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =   2.6743109969198E+02
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   2.1184100677542E+04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   4.4556630142240E+02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   7.7621746959061E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -8.3135438418588E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   4.9187554305766E+07
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   1.8136741820338E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.4414102029447E+07
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   3.9364227498831E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -4.1840518921754E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.3777365817340E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   8.1527961517105E-02
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.1293097740634E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   4.2749272084468E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -4.4962098470329E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.6238780167236E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   8.7869597178718E-02
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   2.2961690634373E-03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   1.2801867346511E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -1.3468846177718E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   6.8096394806865E+07
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   2.9128003198036E+09
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   6.3454248455049E+07
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5562,31 +5543,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.1929066249773E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.7365822744469E+07
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -3.2508475892784E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2749869863230E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2683889379808E+03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6907139015706E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.3587927699422E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   7.5199673082262E+04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   8.3113082640954E+05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2165129047059E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.7733142925937E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.8946677464941E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   4.4226345163447E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.1215859051434E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.5291050385489E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.6095565791134E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.6231868480848E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.7340077627649E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.6676428511760E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1959004572187E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.7050550026517E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.6553537771185E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.1967825374301E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.1663023073865E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0432643070873E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.1929066248386E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.7365822744681E+07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -3.2508475872056E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2749869876526E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2683889376691E+03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6907139016702E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.3587927699439E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   7.5199673439692E+04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   8.3113082850804E+05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2165129102435E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.7733138297393E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.8946677466811E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   4.4225649820659E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.1215865693200E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.5291050929682E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.6095565795962E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.6231868482346E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.7340077753504E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.6676429484395E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1959004967666E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.7050550031729E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.6553537786995E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   9.1967825850674E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.1663023422933E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0432643217617E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5595,163 +5576,77 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     6
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.5961311760355E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -1.7354228063548E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -2.5730459688184E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   4.9021658065453E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   5.8228412641908E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   2.5104705946450E+01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -1.0811053290351E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -6.2729650151873E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.2319278202536E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   5.1385986822320E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.7381647314273E+03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -4.8468870350048E+03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -7.0019239931977E+01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   3.3935907949890E+02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   6.7701889384166E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.0085088665526E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.1469737492258E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   1.2787632870433E+04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.6844483382587E+05
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   8.9546830941435E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.2710117810993E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -7.7719724839396E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   4.6322896398028E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6958571893997E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.2396135461900E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.5961311965270E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -1.7354228081865E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -2.5730459429523E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   4.9021657730292E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   5.8228412225888E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   2.5104705361075E+01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -1.0811053335428E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -6.2729649586260E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.2319278289574E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   5.1385986924431E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.7381647319716E+03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -4.8468870352700E+03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =  -7.0019240232944E+01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   3.3935908019526E+02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   6.7701889349518E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.0085088666187E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.1469737490262E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   1.2787633005943E+04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.6844483380911E+05
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   8.9546830936373E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.2710117813389E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -7.7719724832181E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   4.6322896889473E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6958571893400E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.2396135460106E+03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   6.15951734062037E-13  1.66201895161950E+01
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   2.82440737464640E-13  1.27807736760603E+01
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -1.77191594730175E-13  1.66201895074073E+01
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -2.96651592179842E-13  1.27807736761055E+01
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
- cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
- cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.88293824976427E-12  7.60802552502461E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697357776815E+00  4.17022503399603E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601764070135E+00  4.04197234578102E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165606792570E+00  3.85995024091507E+00
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -1.85806925401266E-12  7.60802552533996E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9116145509372E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.5874693441658E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.3387785957164E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.7332661378668E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.7319667836126E+02
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9860598224318E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.1525901730451E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.1530867721364E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8803800418902E+04
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6652834046497E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   7.3211221455949E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.3023761774421E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6847009156259E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1114657853209E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0050728398053E-03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1683704663874E+07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.2420025805017E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2263878270316E+05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8836938356584E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.6934288126837E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9116145484226E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.5874693434770E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.3387785846735E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.7332661334051E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.7319667410372E+02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9860598232631E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.1525901729932E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.1530867794796E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8803800402114E+04
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.6652833904995E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   7.3211221457511E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.3023761602646E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6847010002289E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.1114657859681E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0050728369803E-03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1683704650796E+07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.2420025802668E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2263878356554E+05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.8836938370948E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.6934288021053E+04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.1648894467779E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -5.8505411380134E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =  -3.6635701249679E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.3401632165228E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   9.2963619272749E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.2818296403334E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -1.5956587426296E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.6258175628593E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.2357185536737E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.1388088164005E+02
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   1.9492364281447E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -3.6089581249606E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.6017209063621E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.2998195640060E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.3260188244340E+02
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   5.5775071934294E-02
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =  -2.1306446216713E-02
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   2.7742166294854E-05
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   1.2171405163518E-03
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   4.1611985313928E-05
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.5083793876542E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -4.0225306536383E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.8865314942858E+01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   2.6281963856840E+02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   5.4957061748790E+00
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.3827678932443E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -1.2078553124315E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =   7.3219620200896E-01
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   2.1100989766193E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   4.8280868642959E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.8928349415756E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -3.6462502230805E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.2902256413079E-01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   2.9974846585144E+01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.3181677429128E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.8081640684991E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -1.9804642119037E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -1.2015664725014E+03
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   3.4033598349999E+04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   5.2846795387421E+02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   8.2428273206095E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.1682798301334E+10
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2342400764050E+08
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   2.8837241171898E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.6935125232715E+07
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   7.6769692095921E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -6.7554649308757E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =   3.0255761449620E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   1.9569865600979E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.7904129115607E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   8.3023761774421E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -7.3211221455949E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =   2.9337193771500E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.1120456297623E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.0078916246142E-03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   3.3680366114867E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -4.0626461205639E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   3.8008947316238E+08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.0414598175779E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   1.6972339540132E+08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
@@ -5763,31 +5658,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.9555201724775E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.6852719823444E+07
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.3947372662345E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2555467887631E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2621388993019E+03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6273590138907E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5297290529054E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   4.2490450296010E+04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   9.2251280441407E+05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2190589880193E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.3099597778358E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5522776760174E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.5573836712185E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4023224999451E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.8397719210227E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   9.7023942974312E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -8.5530978548047E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6078063886169E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.3076536979993E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.6394667024924E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0061878963398E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.4090254711565E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.4341365047198E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.0368765158974E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.9219068893970E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.9555201730198E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.6852719812034E+07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.3947372467111E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.2555467879523E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.2621389097942E+03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.6273590128911E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.5297290532348E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =   4.2490457833717E+04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   9.2251281753250E+05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2190590378174E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.3099597787044E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5522776827822E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.5577674795906E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4023230934775E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.8397720046302E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   9.7023943031813E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -8.5530978611129E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6078065219934E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.3076537112246E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   6.6394668077360E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0061878984715E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.4090254728573E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.4341365807729E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.0368765159239E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.9219069045687E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5796,158 +5691,72 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     3
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   2.5726490519020E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.7523751582069E+03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -3.3314762217941E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   6.9059200014528E+01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.0368511585557E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.3586603875516E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.9179060253515E+03
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.4493860874175E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   6.1525960145447E+01
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   1.5642035820894E+00
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.4119768819130E+03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.0573898122894E+04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   7.0398666220427E+00
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   7.0436157143963E+02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.4120517202867E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1645938599057E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.0532049234524E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1398554576486E+04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.5320935178677E+05
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.6773211629436E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8290808580566E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.1043243624068E+06
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1358544729886E+04
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.7242954791113E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.4993798802280E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   2.5726490588904E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.7523751949028E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -3.3314762023821E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   6.9059200013506E+01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.0368512177227E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.3586602862069E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.9179060100624E+03
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.4493860965368E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   6.1525960474596E+01
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   1.5642035759887E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.4119768908744E+03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.0573898123995E+04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   7.0398668719394E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   7.0436157073318E+02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.4120517242463E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1645938598440E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.0532049199405E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1398554760293E+04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.5320935218596E+05
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.6773211366778E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8290808578335E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.1043243611391E+06
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1358544797093E+04
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.7242954805530E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.4993798707145E+03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =   3.33955085807247E-13  7.08138196317667E+00
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.27897692436818E-13  8.06165949210180E+00
- Calling cg2d from S/R CG2D_SAD
- cg2d: Sum(rhs),rhsMax =  -1.05160324892495E-12  6.51439354482620E+00
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =  -1.84741111297626E-13  7.08138196373899E+00
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   7.53175299905706E-13  8.06165949625343E+00
+ Calling cg2d from S/R CG2D_MAD
+ cg2d: Sum(rhs),rhsMax =   1.70530256582424E-13  6.51439355202331E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3277685362078E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.9100830018624E+05
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.7187422858628E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0470746422046E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.5411767546154E+02
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.0595210895523E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.4380776955633E+05
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9874027818979E+03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3363770019095E+04
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388689651496E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.0328575985349E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -9.9174900178528E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.1794203847667E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.5583928606055E-01
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0807315644178E-03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.3410719083372E+07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.1075826654060E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2043464008160E+05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.4619884847998E+06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7776402028973E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3277685290327E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.9100829993478E+05
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -5.7187422849456E+03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0470746334326E+04
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.5411767285585E+02
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   4.0595210824270E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.4380776990387E+05
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9874027612730E+03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3363770029913E+04
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388689201693E+02
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.0328575967751E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -9.9174899910723E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.1794202363531E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.5583928599500E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0807315599265E-03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.3410719056917E+07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.1075826634073E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2043464244209E+05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.4619884723012E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7776401938208E+04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.2716620603010E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.1383140403025E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =  -6.6219295155678E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   7.2732234533896E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.2706237762097E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adustress_max         =   1.5800651698072E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_min         =  -2.9022622387545E+05
-(PID.TID 0000.0001) %MON ad_exf_adustress_mean        =  -5.7853828635183E+03
-(PID.TID 0000.0001) %MON ad_exf_adustress_sd          =   1.4570575150899E+04
-(PID.TID 0000.0001) %MON ad_exf_adustress_del2        =   2.5901123330823E+02
-(PID.TID 0000.0001) %MON ad_exf_advstress_max         =   2.1748644068618E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_min         =  -1.2763662120428E+05
-(PID.TID 0000.0001) %MON ad_exf_advstress_mean        =   1.3281930526807E+03
-(PID.TID 0000.0001) %MON ad_exf_advstress_sd          =   1.6791124548332E+04
-(PID.TID 0000.0001) %MON ad_exf_advstress_del2        =   2.6964262857248E+02
-(PID.TID 0000.0001) %MON ad_exf_adhflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adhflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_max           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_min           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_mean          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_sd            =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adsflux_del2          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adwspeed_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  1
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  2
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
-(PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_aduwind_max           =   2.9827582740944E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_min           =  -7.4000803160522E+03
-(PID.TID 0000.0001) %MON ad_exf_aduwind_mean          =  -9.6579312242783E+01
-(PID.TID 0000.0001) %MON ad_exf_aduwind_sd            =   3.4675132737780E+02
-(PID.TID 0000.0001) %MON ad_exf_aduwind_del2          =   7.1358836087243E+00
-(PID.TID 0000.0001) %MON ad_exf_advwind_max           =   3.2677694226355E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_min           =  -3.2132879679653E+03
-(PID.TID 0000.0001) %MON ad_exf_advwind_mean          =  -2.0873346770295E+01
-(PID.TID 0000.0001) %MON ad_exf_advwind_sd            =   3.0399810767558E+02
-(PID.TID 0000.0001) %MON ad_exf_advwind_del2          =   6.0321411573837E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_max           =   6.1668140569326E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_min           =  -4.5894372382557E+02
-(PID.TID 0000.0001) %MON ad_exf_adatemp_mean          =  -2.9799973354503E+00
-(PID.TID 0000.0001) %MON ad_exf_adatemp_sd            =   3.6246784780121E+01
-(PID.TID 0000.0001) %MON ad_exf_adatemp_del2          =   7.9396560201698E-01
-(PID.TID 0000.0001) %MON ad_exf_adaqh_max             =   1.6299228119002E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_min             =  -2.7025276801591E+05
-(PID.TID 0000.0001) %MON ad_exf_adaqh_mean            =  -3.1913685477707E+03
-(PID.TID 0000.0001) %MON ad_exf_adaqh_sd              =   4.3224037351225E+04
-(PID.TID 0000.0001) %MON ad_exf_adaqh_del2            =   6.0925473856002E+02
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adprecip_max          =   9.1088969933317E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_min          =  -1.3409272870603E+10
-(PID.TID 0000.0001) %MON ad_exf_adprecip_mean         =   1.2167339244547E+08
-(PID.TID 0000.0001) %MON ad_exf_adprecip_sd           =   3.4620275415247E+09
-(PID.TID 0000.0001) %MON ad_exf_adprecip_del2         =   3.7777517901133E+07
-(PID.TID 0000.0001) %MON ad_exf_adswflux_max          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_min          =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_mean         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_sd           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswflux_del2         =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adswdown_max          =   9.7411697745047E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_min          =  -6.8968925807195E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_mean         =  -2.0329542240221E-03
-(PID.TID 0000.0001) %MON ad_exf_adswdown_sd           =   2.3732718530167E-01
-(PID.TID 0000.0001) %MON ad_exf_adswdown_del2         =   2.9126786419497E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_max          =   1.0966533713883E+00
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_min          =  -8.0328575985349E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_mean         =  -2.4372696240152E-03
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_sd           =   2.5773394422505E-01
-(PID.TID 0000.0001) %MON ad_exf_adlwdown_del2         =   3.1756967657705E-03
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_max          =   4.6883447741070E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_min          =  -7.3250410151930E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_mean         =   7.5820126583633E+08
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_sd           =   1.9679733992781E+10
-(PID.TID 0000.0001) %MON ad_exf_adrunoff_del2         =   2.7792203053380E+08
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  2
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5962,31 +5771,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.6756924643375E+07
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -5.7668277228159E+06
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.8005847287813E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   4.7800816628186E+05
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.5335211713560E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.4315209509915E+06
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.7564265104221E+07
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0938014263543E+04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9190651320566E+05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.8773041611887E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.6756924646349E+07
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -5.7668277225568E+06
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -2.8005847431783E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   4.7800815795065E+05
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   4.5335201557524E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.4315209501007E+06
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.7564265112237E+07
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0938008992502E+04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9190651241061E+05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   4.8773035305044E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.4720424482754E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.9965580373459E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.7397673270763E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.3169386441564E+04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3804414894416E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174175682755E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.6856861430831E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.6298374800870E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8587589807232E+05
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.8911181915524E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.4720424495263E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.9965580389014E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.7397676281428E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.3169385138438E+04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.3804414699639E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0174175734950E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.6856861470646E+06
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   2.6298376388344E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8587589242940E+05
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.8911180624474E+02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5995,31 +5804,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     0
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.4285527364125E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7598732784887E+03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -8.0542178166050E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.7650263294679E+02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   1.4664536420846E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.4409360996524E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.6140875659262E+03
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3785169154619E+00
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5928434159719E+02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   4.2615703299700E+00
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   1.1657183153831E+04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.6655107980829E+04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   8.4571454626853E+01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   9.4467119349184E+02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.7166932314326E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.3976191547745E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.4883571918284E+06
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1645113706304E+04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   9.0404255377532E+05
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.8952717651856E+03
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   8.6732803963657E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.2622131150510E+06
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1443641700796E+04
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2693931446716E+05
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.5782116279118E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   7.4285527776723E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7598734434590E+03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =  -8.0542178453588E+00
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.7650263429755E+02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   1.4664535950817E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.4409357707765E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.6140878225111E+03
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3785170281116E+00
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5928434358619E+02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   4.2615703438060E+00
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   1.1657183175456E+04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.6655107970962E+04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   8.4571448878478E+01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   9.4467118810419E+02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.7166932302607E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.3976191542482E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.4883571849515E+06
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =   3.1645114286147E+04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   9.0404255062641E+05
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.8952717415998E+03
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   8.6732803944620E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.2622131125624E+06
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =   1.1443641910857E+04
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2693931332725E+05
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.5782116194162E+03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6031,7 +5840,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  1.39129888418199E+08
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  1.39129889477125E+08
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -6050,12 +5859,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252098E-01  3.29048622472429E+00
  cg2d: Sum(rhs),rhsMax =   1.52697358431249E+00  4.17022503398205E+00
- cg2d: Sum(rhs),rhsMax =   2.27601765314465E+00  4.04197234571436E+00
- cg2d: Sum(rhs),rhsMax =   3.02165608578957E+00  3.85995024071302E+00
- cg2d: Sum(rhs),rhsMax =   3.74608562165758E+00  3.61302462901035E+00
- cg2d: Sum(rhs),rhsMax =   4.45761419363021E+00  3.33597383712085E+00
- cg2d: Sum(rhs),rhsMax =   5.15911015353674E+00  3.10707882794718E+00
- cg2d: Sum(rhs),rhsMax =   5.85339074759958E+00  2.96283946716953E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601765314462E+00  4.04197234571435E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165608578966E+00  3.85995024067977E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608562165702E+00  3.61302462731545E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761419362887E+00  3.33597382875963E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911015353132E+00  3.10707880891282E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339074758716E+00  2.96283944075196E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6065,22 +5874,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899254056E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899242414E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899254056E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899242414E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222846952582E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707153849826E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748584802517E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186029644097E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604628715278E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866656344401E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845022786E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707148229167E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748572165799E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186144053820E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626979167E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866626098633E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6088,23 +5897,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963169819E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963550420E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068320804E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067824826E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846174092E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843634758E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153230182E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707146803489E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748585656537E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748574645924E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428643813180E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899254056D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866656344401D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428643813180D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428623378622E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736899242414D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866626098633D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428623378622D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6113,11 +5922,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888672283D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889652240D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157166555562D+08
-(PID.TID 0000.0001)  global fc =  0.139129888672283D+09
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129888672283E+08
+(PID.TID 0000.0001)   local fc =  0.792157149141838D+08
+(PID.TID 0000.0001)  global fc =  0.139129889652240D+09
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889652240E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6127,13 +5936,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252190E-01  3.29048622473124E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357122355E+00  4.17022503400893E+00
- cg2d: Sum(rhs),rhsMax =   2.27601762825762E+00  4.04197234584808E+00
- cg2d: Sum(rhs),rhsMax =   3.02165605006121E+00  3.85995024118329E+00
- cg2d: Sum(rhs),rhsMax =   3.74608557599240E+00  3.61302463015362E+00
- cg2d: Sum(rhs),rhsMax =   4.45761413930140E+00  3.33597383919068E+00
- cg2d: Sum(rhs),rhsMax =   5.15911009149499E+00  3.10707883084526E+00
- cg2d: Sum(rhs),rhsMax =   5.85339067913355E+00  2.96283947034793E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697357122359E+00  4.17022503400893E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601762825738E+00  4.04197234584808E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165605006115E+00  3.85995024114960E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608557599223E+00  3.61302462845989E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761413929961E+00  3.33597383083021E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911009148988E+00  3.10707881181027E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339067912145E+00  2.96283944393041E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6143,22 +5952,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898741829E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898730187E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898741829E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898730187E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222847234701E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707154960937E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748585635851E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186015755208E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626145833E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866662529297E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845304905E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707149340278E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748573138021E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186123914931E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604624652778E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866632804362E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6166,23 +5975,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963234923E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963615524E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068405372E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067922414E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846456032E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843924904E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153881037E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707147453088E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748586785314E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748575746184E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428645965831E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898741829D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866662529297D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428645965831D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428625522726E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736898730187D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866632804362D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428625522726D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6191,17 +6000,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888217836D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889144855D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157162595888D+08
-(PID.TID 0000.0001)  global fc =  0.139129888217836D+09
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129888217836E+08
+(PID.TID 0000.0001)   local fc =  0.792157145069450D+08
+(PID.TID 0000.0001)  global fc =  0.139129889144855D+09
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889144855E+08
 grad-res -------------------------------
- grad-res     0    1    1    1    1    1    1    1   1.39129888418E+08  1.39129888672E+08  1.39129888218E+08
- grad-res     0    1    1    1    0    1    1    1   3.40075531006E+01  2.27223619819E+01  3.31843666768E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129888418199E+08
+ grad-res     0    1    1    1    1    1    1    1   1.39129889477E+08  1.39129889652E+08  1.39129889145E+08
+ grad-res     0    1    1    1    0    1    1    1   3.40075531006E+01  2.53692656755E+01  2.54010848693E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129889477125E+08
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  3.40075531005859E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.27223619818687E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.53692656755447E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2         594           2
@@ -6217,13 +6026,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252176E-01  3.29048622472274E+00
- cg2d: Sum(rhs),rhsMax =   1.52697358722564E+00  4.17022503397201E+00
- cg2d: Sum(rhs),rhsMax =   2.27601765888514E+00  4.04197234565430E+00
- cg2d: Sum(rhs),rhsMax =   3.02165609423517E+00  3.85995024050694E+00
- cg2d: Sum(rhs),rhsMax =   3.74608563265483E+00  3.61302462852283E+00
- cg2d: Sum(rhs),rhsMax =   4.45761420686100E+00  3.33597383627754E+00
- cg2d: Sum(rhs),rhsMax =   5.15911016859178E+00  3.10707882679623E+00
- cg2d: Sum(rhs),rhsMax =   5.85339076415704E+00  2.96283946589900E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697358722563E+00  4.17022503397201E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601765888521E+00  4.04197234565432E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165609423523E+00  3.85995024047286E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608563265508E+00  3.61302462682799E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761420685903E+00  3.33597382791545E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911016858638E+00  3.10707880776196E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339076414485E+00  2.96283943948324E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6233,22 +6042,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899254056E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899242414E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899254056E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899242414E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222846952582E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707153849826E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748584802517E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186029730902E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604628715278E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866656335720E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845022786E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707148229167E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748572165799E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186145529514E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604627013889E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866625916341E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6256,23 +6065,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268962996208E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963376808E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068316464E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067820350E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846168014E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843624653E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153161757E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707146727704E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748585601894E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748574535298E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428643662332E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899254056D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866656335721D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428643662332D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428623160269E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736899242414D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866625916341D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428623160269D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6281,11 +6090,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888658067D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889648634D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157166459961D+08
-(PID.TID 0000.0001)  global fc =  0.139129888658067D+09
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129888658067E+08
+(PID.TID 0000.0001)   local fc =  0.792157149013454D+08
+(PID.TID 0000.0001)  global fc =  0.139129889648634D+09
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889648634E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6295,13 +6104,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252148E-01  3.29048622473278E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356831069E+00  4.17022503401875E+00
- cg2d: Sum(rhs),rhsMax =   2.27601762251653E+00  4.04197234590783E+00
- cg2d: Sum(rhs),rhsMax =   3.02165604161519E+00  3.85995024139163E+00
- cg2d: Sum(rhs),rhsMax =   3.74608556499425E+00  3.61302463064138E+00
- cg2d: Sum(rhs),rhsMax =   4.45761412607030E+00  3.33597384003777E+00
- cg2d: Sum(rhs),rhsMax =   5.15911007644007E+00  3.10707883199502E+00
- cg2d: Sum(rhs),rhsMax =   5.85339066257538E+00  2.96283947161528E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697356831072E+00  4.17022503401875E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601762251645E+00  4.04197234590785E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165604161553E+00  3.85995024135716E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608556499379E+00  3.61302462894661E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761412606839E+00  3.33597383167363E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911007643473E+00  3.10707881295762E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339066256324E+00  2.96283944520235E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6311,22 +6120,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898765112E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898753470E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898765112E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898753470E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222847234701E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707155099826E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748585635851E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186015321180E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626145833E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866662711589E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845304905E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707149340278E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748573138021E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186122439236E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604624618056E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866632986654E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6334,23 +6143,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963327154E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963707755E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068427073E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067935435E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846477954E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843942918E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153913148E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707147478587E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748586885666E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748575835262E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428646151140E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898765112D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866662711589D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428646151140D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428625677560E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736898753470D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866632986654D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428625677560D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6359,17 +6168,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888220466D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889144438D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157162737795D+08
-(PID.TID 0000.0001)  global fc =  0.139129888220466D+09
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129888220466E+08
+(PID.TID 0000.0001)   local fc =  0.792157145041993D+08
+(PID.TID 0000.0001)  global fc =  0.139129889144438D+09
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889144438E+08
 grad-res -------------------------------
- grad-res     0    2    2    1    1    1    1    1   1.39129888418E+08  1.39129888658E+08  1.39129888220E+08
- grad-res     0    2    2    2    0    1    1    1   3.87030792236E+01  2.18800202012E+01  4.34669782350E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129888418199E+08
+ grad-res     0    2    2    1    1    1    1    1   1.39129889477E+08  1.39129889649E+08  1.39129889144E+08
+ grad-res     0    2    2    2    0    1    1    1   3.87030792236E+01  2.52098292112E+01  3.48635051346E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129889477125E+08
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  3.87030792236328E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.18800202012062E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.52098292112350E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3         594           3
@@ -6386,12 +6195,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252198E-01  3.29048622472200E+00
  cg2d: Sum(rhs),rhsMax =   1.52697358863699E+00  4.17022503395985E+00
- cg2d: Sum(rhs),rhsMax =   2.27601766174621E+00  4.04197234556664E+00
- cg2d: Sum(rhs),rhsMax =   3.02165609849880E+00  3.85995024020678E+00
- cg2d: Sum(rhs),rhsMax =   3.74608563824549E+00  3.61302462783527E+00
- cg2d: Sum(rhs),rhsMax =   4.45761421368439E+00  3.33597383511050E+00
- cg2d: Sum(rhs),rhsMax =   5.15911017650012E+00  3.10707882521312E+00
- cg2d: Sum(rhs),rhsMax =   5.85339077305372E+00  2.96283946410433E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601766174617E+00  4.04197234556664E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165609849848E+00  3.85995024017247E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608563824586E+00  3.61302462614041E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761421368269E+00  3.33597382674684E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911017649455E+00  3.10707880617652E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339077304124E+00  2.96283943768413E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6401,22 +6210,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899440320E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899428679E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899440320E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899428679E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222846952582E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707153849826E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748584802517E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186029210069E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604628125000E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866656978082E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845022786E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707148229167E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748572165799E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186143532986E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626909722E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866626220161E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6424,23 +6233,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268962996208E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963376808E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068318634E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067822520E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846168463E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843629027E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153235541E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707146780737E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748585661505E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748574655232E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428643798347E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899440320D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866656978082D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428643798347D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428623339780E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736899428679D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866626220161D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428623339780D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6449,11 +6258,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888626059D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889654830D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157166139880D+08
-(PID.TID 0000.0001)  global fc =  0.139129888626059D+09
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129888626059E+08
+(PID.TID 0000.0001)   local fc =  0.792157149214299D+08
+(PID.TID 0000.0001)  global fc =  0.139129889654830D+09
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889654830E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6464,12 +6273,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252126E-01  3.29048622473353E+00
  cg2d: Sum(rhs),rhsMax =   1.52697356689907E+00  4.17022503403125E+00
- cg2d: Sum(rhs),rhsMax =   2.27601761965553E+00  4.04197234599471E+00
- cg2d: Sum(rhs),rhsMax =   3.02165603735179E+00  3.85995024169212E+00
- cg2d: Sum(rhs),rhsMax =   3.74608555940367E+00  3.61302463132785E+00
- cg2d: Sum(rhs),rhsMax =   4.45761411924661E+00  3.33597384120507E+00
- cg2d: Sum(rhs),rhsMax =   5.15911006853139E+00  3.10707883357847E+00
- cg2d: Sum(rhs),rhsMax =   5.85339065367907E+00  2.96283947341552E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601761965573E+00  4.04197234599469E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165603735193E+00  3.85995024165796E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608555940364E+00  3.61302462963196E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761411924485E+00  3.33597383284438E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911006852613E+00  3.10707881454381E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339065366657E+00  2.96283944699830E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6479,22 +6288,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898718545E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898706904E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898718545E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898706904E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222847234701E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707154960937E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748585635851E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186015842014E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626145833E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866662520616E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845304905E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707149340278E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748573138021E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186124001736E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604624652778E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866632795682E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6502,23 +6311,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963240348E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963620949E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068422733E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067935435E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846473427E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843921174E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153862353E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707147459666E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748586808559E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748575742997E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428646005690E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898718545D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866662520616D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428646005690D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428625535950E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736898706904D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866632795682D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428625535950D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6527,17 +6336,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888220362D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889144717D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157162551295D+08
-(PID.TID 0000.0001)  global fc =  0.139129888220362D+09
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129888220362E+08
+(PID.TID 0000.0001)   local fc =  0.792157144998222D+08
+(PID.TID 0000.0001)  global fc =  0.139129889144717D+09
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889144717E+08
 grad-res -------------------------------
- grad-res     0    3    3    1    1    1    1    1   1.39129888418E+08  1.39129888626E+08  1.39129888220E+08
- grad-res     0    3    3    3    0    1    1    1   3.31904220581E+01  2.02848345041E+01  3.88834692472E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129888418199E+08
+ grad-res     0    3    3    1    1    1    1    1   1.39129889477E+08  1.39129889655E+08  1.39129889145E+08
+ grad-res     0    3    3    3    0    1    1    1   3.31904220581E+01  2.55056306720E+01  2.31536416520E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129889477125E+08
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  3.31904220581055E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.02848345041275E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  2.55056306719780E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4         594           4
@@ -6553,13 +6362,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252183E-01  3.29048622472130E+00
- cg2d: Sum(rhs),rhsMax =   1.52697358994743E+00  4.17022503394058E+00
- cg2d: Sum(rhs),rhsMax =   2.27601766444567E+00  4.04197234543381E+00
- cg2d: Sum(rhs),rhsMax =   3.02165610263884E+00  3.85995023976384E+00
- cg2d: Sum(rhs),rhsMax =   3.74608564382629E+00  3.61302462687043E+00
- cg2d: Sum(rhs),rhsMax =   4.45761422084880E+00  3.33597383353500E+00
- cg2d: Sum(rhs),rhsMax =   5.15911018537207E+00  3.10707882314534E+00
- cg2d: Sum(rhs),rhsMax =   5.85339078379516E+00  2.96283946179787E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697358994746E+00  4.17022503394058E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601766444549E+00  4.04197234543340E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165610263890E+00  3.85995023972966E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608564382626E+00  3.61302462517581E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761422084720E+00  3.33597382517461E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911018536681E+00  3.10707880411102E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339078378311E+00  2.96283943538017E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6569,22 +6378,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899440320E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736899428679E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899440320E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736899428679E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222846952582E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707153849826E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748584941406E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186026258680E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604627812500E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866657724609E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845022786E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707148229167E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748572443576E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186139973959E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626180556E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866627583008E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6592,23 +6401,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963083013E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963463614E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068320804E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067824690E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846187748E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843664428E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153311462E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707146906232E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748585944792E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748574830844E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428644187692E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899440320D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866657724609D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428644187692D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428623687138E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736899428679D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866627583008D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428623687138D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6617,11 +6426,11 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888590340D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889553281D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157165828454D+08
-(PID.TID 0000.0001)  global fc =  0.139129888590340D+09
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129888590340E+08
+(PID.TID 0000.0001)   local fc =  0.792157148383455D+08
+(PID.TID 0000.0001)  global fc =  0.139129889553281D+09
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889553281E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6631,13 +6440,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252190E-01  3.29048622473423E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356558878E+00  4.17022503405074E+00
- cg2d: Sum(rhs),rhsMax =   2.27601761695649E+00  4.04197234612793E+00
- cg2d: Sum(rhs),rhsMax =   3.02165603321211E+00  3.85995024213286E+00
- cg2d: Sum(rhs),rhsMax =   3.74608555382292E+00  3.61302463229192E+00
- cg2d: Sum(rhs),rhsMax =   4.45761411208255E+00  3.33597384277527E+00
- cg2d: Sum(rhs),rhsMax =   5.15911005966026E+00  3.10707883564385E+00
- cg2d: Sum(rhs),rhsMax =   5.85339064293876E+00  2.96283947572090E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697356558873E+00  4.17022503405074E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601761695644E+00  4.04197234612790E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165603321197E+00  3.85995024210011E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608555382272E+00  3.61302463059753E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761411208156E+00  3.33597383441723E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911005965469E+00  3.10707881661085E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339064292646E+00  2.96283944930159E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6647,22 +6456,22 @@ grad-res -------------------------------
 (PID.TID 0000.0001) boxmean/horflux :  2  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  3  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  4  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898718545E+00
+(PID.TID 0000.0001) boxmean/horflux :  5  8.91736898706904E+00
 (PID.TID 0000.0001) boxmean/horflux :  6  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  7  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  8  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  9  0.00000000000000E+00
-(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898718545E+00
+(PID.TID 0000.0001) boxmean/horflux fc : 8.91736898706904E+00
 (PID.TID 0000.0001) boxmean/horflux :  1  0.00000000000000E+00
 (PID.TID 0000.0001) boxmean/horflux :  2  6.61126619742839E+06
 (PID.TID 0000.0001) boxmean/horflux :  3 -2.69268961979167E+06
-(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597068195530E+07
-(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222847234701E+07
-(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707154960937E+07
-(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748585635851E+07
-(PID.TID 0000.0001) boxmean/horflux :  8  9.16186021571180E+06
-(PID.TID 0000.0001) boxmean/horflux :  9  3.41604626597222E+07
-(PID.TID 0000.0001) boxmean/horflux fc :-3.47866661496311E+07
+(PID.TID 0000.0001) boxmean/horflux :  4 -1.68597067841797E+07
+(PID.TID 0000.0001) boxmean/horflux :  5 -2.66222845304905E+07
+(PID.TID 0000.0001) boxmean/horflux :  6 -2.57707148784722E+07
+(PID.TID 0000.0001) boxmean/horflux :  7 -1.27748572721354E+07
+(PID.TID 0000.0001) boxmean/horflux :  8  9.16186129036458E+06
+(PID.TID 0000.0001) boxmean/horflux :  9  3.41604625381944E+07
+(PID.TID 0000.0001) boxmean/horflux fc :-3.47866630590820E+07
 (PID.TID 0000.0001) Inside cost_gencost_moc ...
 (PID.TID 0000.0001) Cost    3: m_trVol_step
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
@@ -6670,23 +6479,23 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  2 -3.35248229166667E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963234923E+06kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  3  2.69268963615524E+06kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597068405372E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  4  1.68597067904917E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222846424336E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222843871642E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707153751982E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707147347260E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748586532171E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748575494020E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664357638889E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83677986111111E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428645551936E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898718545D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866661496311D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428645551936D+08 3
+(PID.TID 0000.0001) moc fc:  8.47428625093975E+07
+(PID.TID 0000.0001)  --> f_gencost = 0.891736898706904D+01 1
+(PID.TID 0000.0001)  --> f_gencost =-0.347866630590820D+08 2
+(PID.TID 0000.0001)  --> f_gencost = 0.847428625093975D+08 3
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
@@ -6695,17 +6504,17 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129888277417D+09
+(PID.TID 0000.0001)  --> fc               = 0.139129889321006D+09
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157163121847D+08
-(PID.TID 0000.0001)  global fc =  0.139129888277417D+09
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129888277417E+08
+(PID.TID 0000.0001)   local fc =  0.792157146761108D+08
+(PID.TID 0000.0001)  global fc =  0.139129889321006D+09
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889321006E+08
 grad-res -------------------------------
- grad-res     0    4    4    1    1    1    1    1   1.39129888418E+08  1.39129888590E+08  1.39129888277E+08
- grad-res     0    4    4    4    0    1    1    1   2.02525329590E+01  1.56461626291E+01  2.27446627994E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129888418199E+08
+ grad-res     0    4    4    1    1    1    1    1   1.39129889477E+08  1.39129889553E+08  1.39129889321E+08
+ grad-res     0    4    4    4    0    1    1    1   2.02525329590E+01  1.16137534380E+01  4.26553040969E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129889477125E+08
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.02525329589844E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.56461626291275E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.16137534379959E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6719,271 +6528,271 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   1  1.3912988841820E+08  1.3912988867228E+08  1.3912988821784E+08
-(PID.TID 0000.0001) grdchk output (g):   1     2.2722361981869E+01  3.4007553100586E+01  3.3184366676833E-01
+(PID.TID 0000.0001) grdchk output (c):   1  1.3912988947712E+08  1.3912988965224E+08  1.3912988914486E+08
+(PID.TID 0000.0001) grdchk output (g):   1     2.5369265675545E+01  3.4007553100586E+01  2.5401084869268E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   2  1.3912988841820E+08  1.3912988865807E+08  1.3912988822047E+08
-(PID.TID 0000.0001) grdchk output (g):   2     2.1880020201206E+01  3.8703079223633E+01  4.3466978235040E-01
+(PID.TID 0000.0001) grdchk output (c):   2  1.3912988947712E+08  1.3912988964863E+08  1.3912988914444E+08
+(PID.TID 0000.0001) grdchk output (g):   2     2.5209829211235E+01  3.8703079223633E+01  3.4863505134647E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   3  1.3912988841820E+08  1.3912988862606E+08  1.3912988822036E+08
-(PID.TID 0000.0001) grdchk output (g):   3     2.0284834504128E+01  3.3190422058105E+01  3.8883469247196E-01
+(PID.TID 0000.0001) grdchk output (c):   3  1.3912988947712E+08  1.3912988965483E+08  1.3912988914472E+08
+(PID.TID 0000.0001) grdchk output (g):   3     2.5505630671978E+01  3.3190422058105E+01  2.3153641652022E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   4  1.3912988841820E+08  1.3912988859034E+08  1.3912988827742E+08
-(PID.TID 0000.0001) grdchk output (g):   4     1.5646162629128E+01  2.0252532958984E+01  2.2744662799393E-01
+(PID.TID 0000.0001) grdchk output (c):   4  1.3912988947712E+08  1.3912988955328E+08  1.3912988932101E+08
+(PID.TID 0000.0001) grdchk output (g):   4     1.1613753437996E+01  2.0252532958984E+01  4.2655304096943E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.5425359049640E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.2466310200584E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   228.19628123193979
-(PID.TID 0000.0001)         System time:   3.5964660830795765
-(PID.TID 0000.0001)     Wall clock time:   235.94089007377625
+(PID.TID 0000.0001)           User time:   181.01406209543347
+(PID.TID 0000.0001)         System time:   3.7856418937444687
+(PID.TID 0000.0001)     Wall clock time:   186.07646203041077
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   1.3586829416453838
-(PID.TID 0000.0001)         System time:  0.42246999219059944
-(PID.TID 0000.0001)     Wall clock time:   1.8293609619140625
+(PID.TID 0000.0001)           User time:  0.98372395709156990
+(PID.TID 0000.0001)         System time:  0.41121998429298401
+(PID.TID 0000.0001)     Wall clock time:   1.5202059745788574
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   101.35235714912415
-(PID.TID 0000.0001)         System time:   2.1101629734039307
-(PID.TID 0000.0001)     Wall clock time:   105.84134006500244
+(PID.TID 0000.0001)           User time:   90.582457900047302
+(PID.TID 0000.0001)         System time:   2.4952551126480103
+(PID.TID 0000.0001)     Wall clock time:   93.794975996017456
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   135.30474925041199
-(PID.TID 0000.0001)         System time:  0.51635193824768066
-(PID.TID 0000.0001)     Wall clock time:   137.71519136428833
+(PID.TID 0000.0001)           User time:   98.353852272033691
+(PID.TID 0000.0001)         System time:  0.44531953334808350
+(PID.TID 0000.0001)     Wall clock time:   99.364600419998169
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5268390178680420
-(PID.TID 0000.0001)         System time:   5.1395893096923828E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5483751296997070
+(PID.TID 0000.0001)           User time:   1.9114682674407959
+(PID.TID 0000.0001)         System time:   1.0722875595092773E-003
+(PID.TID 0000.0001)     Wall clock time:   1.9201118946075439
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0989239215850830
-(PID.TID 0000.0001)         System time:   5.5115222930908203E-002
-(PID.TID 0000.0001)     Wall clock time:   2.2264001369476318
+(PID.TID 0000.0001)           User time:   1.0833761692047119
+(PID.TID 0000.0001)         System time:   8.7345123291015625E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1714797019958496
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.9681203365325928
-(PID.TID 0000.0001)         System time:   3.5613477230072021E-002
-(PID.TID 0000.0001)     Wall clock time:   2.0751488208770752
+(PID.TID 0000.0001)           User time:  0.97471261024475098
+(PID.TID 0000.0001)         System time:   6.7807197570800781E-002
+(PID.TID 0000.0001)     Wall clock time:   1.0433831214904785
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   7.8248977661132812E-004
-(PID.TID 0000.0001)         System time:   1.4662742614746094E-005
-(PID.TID 0000.0001)     Wall clock time:   7.9989433288574219E-004
+(PID.TID 0000.0001)           User time:   6.3896179199218750E-004
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-005
+(PID.TID 0000.0001)     Wall clock time:   7.2097778320312500E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.24381017684936523
-(PID.TID 0000.0001)         System time:   6.0701370239257812E-004
-(PID.TID 0000.0001)     Wall clock time:  0.25334858894348145
+(PID.TID 0000.0001)           User time:  0.18079710006713867
+(PID.TID 0000.0001)         System time:   1.1649131774902344E-003
+(PID.TID 0000.0001)     Wall clock time:  0.18212914466857910
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0383300781250000E-002
-(PID.TID 0000.0001)         System time:   2.0849704742431641E-004
-(PID.TID 0000.0001)     Wall clock time:   8.0661296844482422E-002
+(PID.TID 0000.0001)           User time:   5.9410333633422852E-002
+(PID.TID 0000.0001)         System time:   6.2215328216552734E-004
+(PID.TID 0000.0001)     Wall clock time:   6.0098409652709961E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   29.761304140090942
-(PID.TID 0000.0001)         System time:  0.13488996028900146
-(PID.TID 0000.0001)     Wall clock time:   30.256855249404907
+(PID.TID 0000.0001)           User time:   19.943119764328003
+(PID.TID 0000.0001)         System time:  0.10597181320190430
+(PID.TID 0000.0001)     Wall clock time:   20.362575292587280
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.8205854892730713
-(PID.TID 0000.0001)         System time:   4.1437149047851562E-003
-(PID.TID 0000.0001)     Wall clock time:   2.8647637367248535
+(PID.TID 0000.0001)           User time:   1.8709557056427002
+(PID.TID 0000.0001)         System time:   1.6600251197814941E-002
+(PID.TID 0000.0001)     Wall clock time:   1.9339921474456787
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   2.1075403690338135
-(PID.TID 0000.0001)         System time:   3.7422180175781250E-003
-(PID.TID 0000.0001)     Wall clock time:   2.1440460681915283
+(PID.TID 0000.0001)           User time:   1.3825235366821289
+(PID.TID 0000.0001)         System time:   1.6002774238586426E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4308562278747559
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   8.0095713138580322
-(PID.TID 0000.0001)         System time:   5.7150721549987793E-003
-(PID.TID 0000.0001)     Wall clock time:   8.0943641662597656
+(PID.TID 0000.0001)           User time:   4.8937087059020996
+(PID.TID 0000.0001)         System time:   1.5978813171386719E-002
+(PID.TID 0000.0001)     Wall clock time:   4.9326794147491455
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   26.810731887817383
-(PID.TID 0000.0001)         System time:   2.5723397731781006E-002
-(PID.TID 0000.0001)     Wall clock time:   27.329919576644897
+(PID.TID 0000.0001)           User time:   21.338966846466064
+(PID.TID 0000.0001)         System time:   1.7092466354370117E-002
+(PID.TID 0000.0001)     Wall clock time:   21.395030260086060
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5812497138977051
-(PID.TID 0000.0001)         System time:   7.4007511138916016E-003
-(PID.TID 0000.0001)     Wall clock time:   6.6568093299865723
+(PID.TID 0000.0001)           User time:   2.9070119857788086
+(PID.TID 0000.0001)         System time:   1.9061565399169922E-004
+(PID.TID 0000.0001)     Wall clock time:   2.9104361534118652
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9831995964050293
-(PID.TID 0000.0001)         System time:   5.1239132881164551E-003
-(PID.TID 0000.0001)     Wall clock time:   2.0390982627868652
+(PID.TID 0000.0001)           User time:   1.3136289119720459
+(PID.TID 0000.0001)         System time:   4.0382146835327148E-003
+(PID.TID 0000.0001)     Wall clock time:   1.3235979080200195
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.69218206405639648
-(PID.TID 0000.0001)         System time:   3.5852193832397461E-004
-(PID.TID 0000.0001)     Wall clock time:  0.69824337959289551
+(PID.TID 0000.0001)           User time:  0.50389456748962402
+(PID.TID 0000.0001)         System time:   1.8346309661865234E-004
+(PID.TID 0000.0001)     Wall clock time:  0.50617241859436035
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6173372268676758
-(PID.TID 0000.0001)         System time:   2.2882223129272461E-004
-(PID.TID 0000.0001)     Wall clock time:   1.6411135196685791
+(PID.TID 0000.0001)           User time:  0.99775099754333496
+(PID.TID 0000.0001)         System time:   8.8214874267578125E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0109291076660156
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10819911956787109
-(PID.TID 0000.0001)         System time:   2.4926662445068359E-004
-(PID.TID 0000.0001)     Wall clock time:  0.10915565490722656
+(PID.TID 0000.0001)           User time:   7.9594850540161133E-002
+(PID.TID 0000.0001)         System time:   2.6284456253051758E-003
+(PID.TID 0000.0001)     Wall clock time:   8.5256814956665039E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.4175655841827393
-(PID.TID 0000.0001)         System time:  0.10619288682937622
-(PID.TID 0000.0001)     Wall clock time:   8.6039631366729736
+(PID.TID 0000.0001)           User time:   4.8231937885284424
+(PID.TID 0000.0001)         System time:   7.9882025718688965E-002
+(PID.TID 0000.0001)     Wall clock time:   4.9272401332855225
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   29.118278741836548
-(PID.TID 0000.0001)         System time:   1.8272936344146729E-002
-(PID.TID 0000.0001)     Wall clock time:   29.532597780227661
+(PID.TID 0000.0001)           User time:   22.867475986480713
+(PID.TID 0000.0001)         System time:   2.4863958358764648E-002
+(PID.TID 0000.0001)     Wall clock time:   22.971421003341675
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.8453292846679688E-004
-(PID.TID 0000.0001)         System time:   1.3589859008789062E-005
-(PID.TID 0000.0001)     Wall clock time:   7.9607963562011719E-004
+(PID.TID 0000.0001)           User time:   6.6351890563964844E-004
+(PID.TID 0000.0001)         System time:   2.0861625671386719E-005
+(PID.TID 0000.0001)     Wall clock time:   6.9069862365722656E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.39191961288452148
-(PID.TID 0000.0001)         System time:   7.1704387664794922E-005
-(PID.TID 0000.0001)     Wall clock time:  0.41156005859375000
+(PID.TID 0000.0001)           User time:  0.22779512405395508
+(PID.TID 0000.0001)         System time:   3.2771825790405273E-003
+(PID.TID 0000.0001)     Wall clock time:  0.24085402488708496
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.3385238647460938E-004
-(PID.TID 0000.0001)         System time:   1.1801719665527344E-005
-(PID.TID 0000.0001)     Wall clock time:   7.9131126403808594E-004
+(PID.TID 0000.0001)           User time:   6.6113471984863281E-004
+(PID.TID 0000.0001)         System time:   4.2915344238281250E-006
+(PID.TID 0000.0001)     Wall clock time:   6.7353248596191406E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31568765640258789
-(PID.TID 0000.0001)         System time:   4.7413110733032227E-002
-(PID.TID 0000.0001)     Wall clock time:  0.36538052558898926
+(PID.TID 0000.0001)           User time:  0.11876964569091797
+(PID.TID 0000.0001)         System time:   4.7617793083190918E-002
+(PID.TID 0000.0001)     Wall clock time:  0.16235828399658203
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12798309326171875
-(PID.TID 0000.0001)         System time:   9.7720861434936523E-002
-(PID.TID 0000.0001)     Wall clock time:  0.22750043869018555
+(PID.TID 0000.0001)           User time:  0.13495850563049316
+(PID.TID 0000.0001)         System time:   6.8140983581542969E-002
+(PID.TID 0000.0001)     Wall clock time:  0.20310425758361816
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.3773002624511719
-(PID.TID 0000.0001)         System time:  0.14633631706237793
-(PID.TID 0000.0001)     Wall clock time:   1.5533316135406494
+(PID.TID 0000.0001)           User time:  0.99574756622314453
+(PID.TID 0000.0001)         System time:  0.16719281673431396
+(PID.TID 0000.0001)     Wall clock time:   1.1740550994873047
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.45797538757324219
-(PID.TID 0000.0001)         System time:   9.9092125892639160E-002
-(PID.TID 0000.0001)     Wall clock time:  0.56317710876464844
+(PID.TID 0000.0001)           User time:  0.50950050354003906
+(PID.TID 0000.0001)         System time:  0.10774743556976318
+(PID.TID 0000.0001)     Wall clock time:  0.62246417999267578
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.20928192138671875
-(PID.TID 0000.0001)         System time:   5.1732063293457031E-002
-(PID.TID 0000.0001)     Wall clock time:  0.26587486267089844
+(PID.TID 0000.0001)           User time:  0.20938110351562500
+(PID.TID 0000.0001)         System time:   3.9726018905639648E-002
+(PID.TID 0000.0001)     Wall clock time:  0.31754398345947266
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.22371673583984375
-(PID.TID 0000.0001)         System time:   2.3772954940795898E-002
-(PID.TID 0000.0001)     Wall clock time:  0.25164389610290527
+(PID.TID 0000.0001)           User time:  0.26718902587890625
+(PID.TID 0000.0001)         System time:   3.1946897506713867E-002
+(PID.TID 0000.0001)     Wall clock time:  0.30005979537963867
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   125.05207824707031
-(PID.TID 0000.0001)         System time:  0.98829317092895508
-(PID.TID 0000.0001)     Wall clock time:   127.75250601768494
+(PID.TID 0000.0001)           User time:   88.971176147460938
+(PID.TID 0000.0001)         System time:  0.80744099617004395
+(PID.TID 0000.0001)     Wall clock time:   90.143529891967773
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   9.0157775878906250
-(PID.TID 0000.0001)         System time:  0.32218289375305176
-(PID.TID 0000.0001)     Wall clock time:   9.4925725460052490
+(PID.TID 0000.0001)           User time:   6.5457534790039062
+(PID.TID 0000.0001)         System time:  0.22502183914184570
+(PID.TID 0000.0001)     Wall clock time:   6.7813711166381836
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   115.97778320312500
-(PID.TID 0000.0001)         System time:  0.65823912620544434
-(PID.TID 0000.0001)     Wall clock time:   118.18579530715942
+(PID.TID 0000.0001)           User time:   82.410995483398438
+(PID.TID 0000.0001)         System time:  0.57227134704589844
+(PID.TID 0000.0001)     Wall clock time:   83.279945850372314
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.4202194213867188
-(PID.TID 0000.0001)         System time:  0.21080636978149414
-(PID.TID 0000.0001)     Wall clock time:   6.1479525566101074
+(PID.TID 0000.0001)           User time:   3.5133514404296875
+(PID.TID 0000.0001)         System time:  0.12320137023925781
+(PID.TID 0000.0001)     Wall clock time:   3.6672799587249756
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2145996093750000E-002
-(PID.TID 0000.0001)         System time:   1.8334388732910156E-004
-(PID.TID 0000.0001)     Wall clock time:   1.2368917465209961E-002
+(PID.TID 0000.0001)           User time:   1.1116027832031250E-002
+(PID.TID 0000.0001)         System time:   1.7237663269042969E-004
+(PID.TID 0000.0001)     Wall clock time:   1.1417627334594727E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   107.64271545410156
-(PID.TID 0000.0001)         System time:  0.23007917404174805
-(PID.TID 0000.0001)     Wall clock time:   108.88632392883301
+(PID.TID 0000.0001)           User time:   77.127807617187500
+(PID.TID 0000.0001)         System time:  0.20930743217468262
+(PID.TID 0000.0001)     Wall clock time:   77.572846174240112
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0776138305664062
-(PID.TID 0000.0001)         System time:   1.7944097518920898E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1068415641784668
+(PID.TID 0000.0001)           User time:  0.37200927734375000
+(PID.TID 0000.0001)         System time:   2.7730941772460938E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42127180099487305
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.4724731445312500E-003
-(PID.TID 0000.0001)         System time:   1.5974044799804688E-005
-(PID.TID 0000.0001)     Wall clock time:   1.4917850494384766E-003
+(PID.TID 0000.0001)           User time:   1.3732910156250000E-003
+(PID.TID 0000.0001)         System time:   2.7179718017578125E-005
+(PID.TID 0000.0001)     Wall clock time:   1.4121532440185547E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.6078491210937500
-(PID.TID 0000.0001)         System time:  0.19501471519470215
-(PID.TID 0000.0001)     Wall clock time:   1.8106923103332520
+(PID.TID 0000.0001)           User time:   1.3504104614257812
+(PID.TID 0000.0001)         System time:  0.21149206161499023
+(PID.TID 0000.0001)     Wall clock time:   1.5629010200500488
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.8409729003906250E-002
-(PID.TID 0000.0001)         System time:   9.0599060058593750E-005
-(PID.TID 0000.0001)     Wall clock time:   1.8500566482543945E-002
+(PID.TID 0000.0001)           User time:   1.8898010253906250E-002
+(PID.TID 0000.0001)         System time:   1.2397766113281250E-004
+(PID.TID 0000.0001)     Wall clock time:   2.6863098144531250E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -7023,9 +6832,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         229046
+(PID.TID 0000.0001) //            No. barriers =         225080
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         229046
+(PID.TID 0000.0001) //     Total barrier spins =         225080
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_cs32/results/output_adm.txt
+++ b/global_oce_cs32/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68f
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Mar 15 13:47:34 EDT 2022
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 12:37:18 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -158,7 +158,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -905,8 +905,6 @@
 (PID.TID 0000.0001) ># **********************
 (PID.TID 0000.0001) > &ctrl_nml
 (PID.TID 0000.0001) > doSinglePrecTapelev=.TRUE.,
-(PID.TID 0000.0001) > ctrlSmoothCorrel2D=.TRUE.,
-(PID.TID 0000.0001) > ctrlSmoothCorrel3D=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># *********************
@@ -964,6 +962,7 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -1399,22 +1398,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -2584,7 +2592,6 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
 (PID.TID 0000.0001)       weight     = wt_theta.data
@@ -2697,6 +2704,93 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3107,8 +3201,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3125,7 +3219,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3632,47 +3726,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -4720,64 +4773,64 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252148E-01  3.29048622472776E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357776815E+00  4.17022503399561E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.25378323349447E+01
+ cg2d: Sum(rhs),rhsMax =   1.52697357776813E+00  4.17022503399561E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.25378323272703E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.34478286540845E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.34478286563935E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7220831576543E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7220831576530E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4941568763539E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874426E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8092937288782E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2533467112719E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2884748068859E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2920099392758E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1022151678322E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1132333109074E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4603773629505E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2938616379794E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8459289745200E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.8963804221756E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1940013971882E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.6784833267699E-05
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874423E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8092937285550E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2533467111718E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2884748064833E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2920099424240E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1022151905139E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1132333117177E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.4603773867797E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2938616386540E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8459289708378E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.8963804430597E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1940013977162E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   3.6784833608242E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2769957202630E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.5132840060569E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.3215985062292E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.5248723091532E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3390630503530E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -8.5132840060568E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.3215985029965E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.5248723054680E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.3390630490141E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0155011860623E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9415803792981E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950191627401E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461504099366E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6298206545448E-03
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461504100979E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6298206552320E-03
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.1000610213798E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8994047407183E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726327878017E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0073441842617E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3826907209947E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8507032606353E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2027997798659E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1449686832679E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.2427386614934E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5390992081229E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4309484766697E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7154362332682E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3129344554273E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.8017215012337E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.2284241604668E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0073441860540E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3826907219707E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8507032601435E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2027997806804E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1449686832678E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.2427386610013E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.5390992089309E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4309484766695E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.7154362332681E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3129344538862E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.8017215015252E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.2284241618924E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542979625808E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5299161171875E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5299161171874E-06
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.7209700118146E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081320227E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081320223E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746079984E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854182E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823557794451E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328656636688E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854213E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823557789890E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328656632395E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4831,14 +4884,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0422854006221E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.3296438538218E+02
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0209634519797E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -9.7950490305809E+00
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -9.7950490305817E+00
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7048015364063E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9540816099778E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9623201658926E-07
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9540816099779E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9623201658927E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1928804646881E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.8286605260290E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4752807499852E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9664847413216E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.8286605260288E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4752807499853E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.9664847413219E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3362609121512E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0010170945956E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.3546021455717E-01
@@ -4869,11 +4922,11 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7488730803800E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7682145855982E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3484485085363E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3080696934706E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8416655458345E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7511177570015E-08
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3080696934707E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8416655458628E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7511177570014E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6148510918363E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1311523361460E-10
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1311523361462E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952202593044E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3281786289283E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682517043986E-08
@@ -4902,65 +4955,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27601764070118E+00  4.04197234578125E+00
- cg2d: Sum(rhs),rhsMax =   3.02165606792590E+00  3.85995024094910E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.85288555420924E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601764070111E+00  4.04197234578123E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165606792568E+00  3.85995024091529E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.85288551069115E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
-(PID.TID 0000.0001)      cg2d_last_res =   1.19969225614463E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.19969217256200E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890402609337E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303080877747E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890402607898E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303081084345E-01
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5316966869643E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1483050963958E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1622406931771E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6559727969236E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.9607182210955E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.7209208064453E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6623668342836E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0707193055075E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3668913447194E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5770786952745E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3543047738333E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8535213368072E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.4450931334760E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4517272087328E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6939945423771E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.3620787268120E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.6089420748317E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2375218327954E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154466181268E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9396257620812E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950347075523E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461507162227E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6271652524937E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0987216603846E+01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1483050842561E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1622407086058E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6559728012181E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.9607176111030E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -1.7209208922449E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6623668752978E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0707198196333E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3668913447169E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5770785300923E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.3543046954937E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8535215527749E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.4450935949876E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4517272087367E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6939945423768E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.3620784421645E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   5.6089420089471E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2375217794694E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0154466181270E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9396257621077E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950347075526E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461507190544E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6271652593949E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0987305399351E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8987645798192E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726330465244E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0070201124175E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3772567102723E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.1338171955773E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5802353972834E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240918396E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4564503243546E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8555597665680E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2173753954000E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2711488268550E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3057232510802E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.7930398928779E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.8764665408403E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0070201458281E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3772566990703E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.1338171955404E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5802354768392E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240918418E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4564503253829E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8555597665651E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2173753954024E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.2711488268575E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3057232410202E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.7930399215715E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.8764669740102E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542978440074E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7575486619909E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7180825570805E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.7575486619873E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7180825570797E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096777492E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096777661E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737833613E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623568954E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959395214E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276264456381E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623570976E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959060763E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276264031325E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4971,29 +5024,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6266137978488E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6328426404148E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0463181888385E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6266137990315E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6328426405664E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0463181886299E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -4.5201857214911E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5861474370869E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.0924955873822E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   8.4037768357354E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -4.5201857222343E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5861474369281E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.0924955862715E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   8.4037768357355E-02
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   1.7185050080772E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   9.1432894603469E-03
-(PID.TID 0000.0001) %MON seaice_area_del2             =   8.5498880902109E-05
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8672995801018E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   9.1432894603470E-03
+(PID.TID 0000.0001) %MON seaice_area_del2             =   8.5498880902070E-05
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8672995801019E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.3851543123594E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   7.3851543123593E-04
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   4.0696195559937E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8091517955238E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2787068334910E-05
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   3.8091517955219E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   2.2787068334912E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.8953534523236E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   1.8953534523237E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   1.1994419297762E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0121073030672E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   2.0121073030663E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5002,26 +5055,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3844270228197E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0417589747856E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.6384275529612E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2478616714219E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0841802031589E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0853724252863E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.4277893213240E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0460748762173E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2540791040531E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0118677110526E-03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3844270228201E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0417589747857E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -6.6384275529589E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2478616714216E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   2.0841802031599E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0853724252875E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -8.4277893213152E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -2.0460748762170E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2540791040532E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   2.0118677110533E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.1688174316804E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0463291109667E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0187055236536E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7000241603295E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9628274369863E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8894177711191E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0463291109660E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0187055236599E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7000241603302E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9628274369936E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8894177711193E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.1883687342004E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.7343418043392E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4711017202821E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.0142891545143E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.7343418043255E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4711017202852E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.0142891545321E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3182695081118E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0198948751322E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.5593456160356E-01
@@ -5048,15 +5101,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7762631202966E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2739950111696E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3923613550083E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1258430936334E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7462505392776E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7625796830366E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3452027264093E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2352250557566E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8337592321048E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7416461122431E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6208879767472E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1871791513469E-10
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1258430936342E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7462505392768E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7625796830364E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3452027264097E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2352250557569E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8337592337783E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7416461122418E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6208879767517E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.1871791513695E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952384585115E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.3077344114464E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5682119318092E-08
@@ -5085,65 +5138,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.74608559882526E+00  3.61302462958173E+00
- cg2d: Sum(rhs),rhsMax =   4.45761416646582E+00  3.33597383815632E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96706438341623E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608559882506E+00  3.61302462788831E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761416646442E+00  3.33597382979536E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96706422336150E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.33728065529280E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.33728053683239E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390576244349E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266696127647E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206967E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527726446E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463462334811E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901373520E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680595857E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510304108570E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436489969945E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2992862163873E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1805123309400E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5077157119703E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1367240502271E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2642421910301E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188712516393E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487250441E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840631151E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673465280513E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943371109096E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264809234533E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706920E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9029464932251E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950597931844E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461718897577E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6209151530762E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0976385713245E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981819416445E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390576248213E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266696147292E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206937E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527400515E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463461837854E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901395485E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680587560E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510304160454E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436491544268E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2992873918663E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.1805123307335E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5077157120234E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1367237930748E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2642424460278E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188719904930E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487251075E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840631183E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673437629994E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943369377548E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264807997633E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706922E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9029464932257E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950597931841E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4461718921796E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6209151621133E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0976493325984E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981819416225E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726333694657E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067566945383E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721089059710E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576028930E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681588203E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550013018900E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686252443E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534748090E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209622396E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925432102E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8146742470790E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5061127776329E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3301712453258E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067567206878E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088838815E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576018928E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681589277E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550013019122E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686279435E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534745658E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209622627E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925432387E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8146742152694E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.5061127764065E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3301720691637E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542977276382E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7495794275164E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.8350324426902E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7495794265678E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.8350324420195E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771505953E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771506257E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734511743E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484254881E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614783284991E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210425026915E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484263712E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614783656195E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210431185563E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5154,29 +5207,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8883545198230E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8855865594377E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2806532047810E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8883545239500E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8855865603565E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2806532015867E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4666809335036E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8652100759787E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3474458701495E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.2360203961632E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4666809295620E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8652100753562E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3474458591345E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.2360203961631E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5886239340013E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3669682798324E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.2765191169403E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   5.6496045389344E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   2.5886239340002E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.3669682798321E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.2765191168852E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   5.6496045389339E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0915727150087E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.0053130762430E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4907322292164E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   5.5987949556495E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.0915727150083E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   6.0053130762462E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   5.4907322290236E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   5.5987949556619E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.7314491461883E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.0012147480166E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9367759686496E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   4.7314491461830E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.0012147480163E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9367759686534E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5185,26 +5238,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1037075319256E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.9086473786258E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.2757391525213E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1986047778936E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9240206332203E-03
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.7385360531521E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.8631232392511E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9823714102123E-02
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2112287882203E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8347808452520E-03
-(PID.TID 0000.0001) %MON exf_hflux_max                =   9.2886219769115E+02
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8476995926066E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891370058E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909458951E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387149869E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539012757E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1037075319182E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.9086473787371E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =  -7.2757391525519E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1986047778928E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   1.9240206332231E-03
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.7385360531575E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -7.8631232392249E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -1.9823714102116E-02
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.2112287882216E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.8347808452557E-03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   9.2886219769108E+02
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8476995926017E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891370115E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909458983E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387150137E+00
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539012778E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342284317824E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796250E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781331E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8574493068619E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796058E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781434E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8574493069014E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.0472183881203E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8892726999294E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.9875629441651E-01
@@ -5231,15 +5284,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7693447327525E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2570459671690E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3816578923415E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1104555773288E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046688E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104767E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172316E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594668E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197723056E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371824E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764311E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0412193075587E-10
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1104555773410E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046680E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104757E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172466E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594654E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197745416E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371804E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764488E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.0412193076481E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952566577185E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.2872901939645E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5681721592199E-08
@@ -5268,65 +5321,65 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.15911012251587E+00  3.10707882939577E+00
- cg2d: Sum(rhs),rhsMax =   5.85339071336659E+00  2.96283946876159E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.22708931409487E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911012251061E+00  3.10707881036238E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339071335443E+00  2.96283944234202E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.22708940360578E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   1.64667855614881E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.64667853807229E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517419384524E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5711956584156E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993142E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977402846405E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361003503855E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754865445E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152032886353E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089661483879E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499026990133E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0094318696491E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4625188160682E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5209188736415E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1681990306254E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5165808152818E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0848780047927E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5278920800505E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786515826E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072414649075E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644193035970E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783248630797E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185557E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458179313E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892071E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4462020475466E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6126513004355E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0970628945425E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439283718E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517419404721E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5711930106822E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993114E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977402895537E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361003544257E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754838937E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152032817386E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089658240092E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499029849931E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0094320183165E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4625188154784E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5209188741999E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1681988972544E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5165811824946E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0848780978523E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5278920802009E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786516316E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072398658095E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644189707293E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246506920E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185563E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458180838E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892054E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4462020491081E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.6126513103439E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0970750017350E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439292380E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726336750298E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222840572E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976506241E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502676345E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601909948E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633110668E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753296456467E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356024633E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446459594E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745417620E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8987366426987E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3813407904197E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2893710680428E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222985486E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976415238E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502668246E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601912161E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633108971E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753296423327E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356017686E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446457806E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745416100E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.8987366475372E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.3813407860789E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2893725033246E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542976161516E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.4706133493088E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7511635081360E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.4706133455102E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.7511635062198E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9720793743754E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943451E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316416E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538633636E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441808963920E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326287630433E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943291E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316415E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538645643E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826506008E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326275857834E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5337,29 +5390,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015806102E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425161491E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935359904E-03
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015724911E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425194518E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935396000E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032168262122E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9397438222301E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4451765225315E-03
-(PID.TID 0000.0001) %MON seaice_area_max              =   1.6121956407390E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032168007281E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9397438194209E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4451765112350E-03
+(PID.TID 0000.0001) %MON seaice_area_max              =   1.6121956407290E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.4332297665808E-03
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8035737713302E-02
-(PID.TID 0000.0001) %MON seaice_area_del2             =   1.6753780942461E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283717676E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.4332297665705E-03
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8035737713248E-02
+(PID.TID 0000.0001) %MON seaice_area_del2             =   1.6753780940915E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283717223E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4331232104475E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8738037374520E-03
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   7.0030891660313E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657522492E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4331232104444E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8738037374746E-03
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   7.0030891661955E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657523121E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147588823E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146556E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095013061E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587878E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146931E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095021031E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5370,73 +5423,73 @@
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974313852075D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624875249D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644067409975D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722019373161D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973460976730D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391966711D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644073930355D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448722019043189D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894664938770D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894347361738D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473231505990D+04
-(PID.TID 0000.0001)  global fc =  0.331894664938770D+05
+(PID.TID 0000.0001)   local fc =  0.142473229858032D+04
+(PID.TID 0000.0001)  global fc =  0.331894347361738D+05
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
- cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
- cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697357776815E+00  4.17022503399603E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601764070135E+00  4.04197234578102E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165606792570E+00  3.85995024091507E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.74608559882543E+00  3.61302462958151E+00
- cg2d: Sum(rhs),rhsMax =   4.45761416646636E+00  3.33597383815620E+00
- cg2d: Sum(rhs),rhsMax =   5.15911012251672E+00  3.10707882939607E+00
- cg2d: Sum(rhs),rhsMax =   5.85339071336745E+00  2.96283946876190E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608559882535E+00  3.61302462788807E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761416646482E+00  3.33597382979533E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911012251146E+00  3.10707881036115E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339071335491E+00  2.96283944234280E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.74608577798608E+00  3.61303114709574E+00
- cg2d: Sum(rhs),rhsMax =   4.45761761974450E+00  3.33597889011480E+00
- cg2d: Sum(rhs),rhsMax =   5.15911604137395E+00  3.10708255938939E+00
- cg2d: Sum(rhs),rhsMax =   5.85339734146226E+00  2.96284271209768E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608598826450E+00  3.61303115221832E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761783002212E+00  3.33597887930389E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911625164870E+00  3.10708253803197E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339755173015E+00  2.96284268389013E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  2.59263162023582E-03
+ cg2d: Sum(rhs),rhsMax =  -9.54097911787244E-18  2.59263157440081E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   1.99493199737333E-17  2.28707906627996E-03
+ cg2d: Sum(rhs),rhsMax =  -9.54097911787244E-18  2.28707913782461E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7044832355171E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2118582829951E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6547383902750E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8170085027526E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3149953857108E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1210024444293E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2256888427286E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4586815785172E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0733228841403E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5364509294721E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196594861287E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875432885064E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1269091962144E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.3544552257591E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7882058126039E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.1607532697540E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.1192571990263E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   7.6913584704888E-01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1858728633943E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.0677904981727E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.6946736141657E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.3345664867200E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6228172252363E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584309330E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.3311872089491E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7044831728323E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2118615160905E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6547952695167E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8170080819658E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3149952655918E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1210022623170E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2256888349387E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4586901644957E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0733231467555E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5364510544790E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196594858746E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875432883245E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1269092748691E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.3544552221450E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.7882057863699E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   7.1607540022599E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -7.1192521741120E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   7.6913620125568E-01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.1858729986966E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.0677905982809E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.6946736140874E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.3345664865901E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6228172352248E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584210684E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.3311872045634E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5446,35 +5499,35 @@
 (PID.TID 0000.0001) %MON ad_time_tsnumber             =                     6
 (PID.TID 0000.0001) %MON ad_time_secondsf             =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   1.9138391494751E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.2043855667114E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -4.7562494213580E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.7437240559581E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8721446814901E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1341095486001E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1397492516459E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.9905251869927E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0506244446408E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0665182148744E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3080432403011E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5158944695913E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.1486765565651E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.9874464065158E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0034180913884E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6097048463388E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5277591619389E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4549716367740E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3554009614010E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0423373263728E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2009895241713E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4401547219330E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.5683437849469E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6738998528160E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691860307461E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1326273453603E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.3166963428279E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.1576138320642E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9308456274746E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3574196626010E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.2043859481812E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =  -4.7562515258993E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.7437242636320E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8721445161193E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1341100463917E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1397491456637E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -4.9916439671626E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0506245332158E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0665188677926E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3080439645600E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.5158930487732E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.1486740262724E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.9874486559704E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0034196853640E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6097081975799E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5277559809608E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4547468059298E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3554191896097E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0423389284669E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2009895276794E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4401547468534E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.5683479375260E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6738980949809E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691860274509E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1325179453088E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.3218133265378E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.1576016989273E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9307302611672E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3574061298040E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5483,75 +5536,75 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     6
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2255912180524E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7310208954596E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7873810211848E-05
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5343092270984E-03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5301417400765E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0581370366637E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0333957200843E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3273873378754E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1518130122099E-03
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0872034202754E-05
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378409220195E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1435016011649E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.8112238579074E-06
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0912014805983E-03
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3910922257339E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1559034700064E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3506250698662E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -6.4546389535943E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.4146182121453E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.0174916650970E-01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8182554998653E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5243150893519E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3481968559688E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015433841762E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879311334983E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2255778364435E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7310102069277E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7873556876896E-05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5343079219496E-03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5301412997357E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0581337529653E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0333933203891E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3274247626750E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1518132899752E-03
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0872066441684E-05
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378410231957E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1435037480282E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.8120760598754E-06
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0912015564711E-03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3910922296201E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1559034889101E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3506250786958E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -6.4546390998514E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   4.4146182014990E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   6.0174916459594E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   7.8182555684881E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5243151214354E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3481969090644E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015433803087E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879311268079E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   7.58941520739853E-19  3.49905873621620E-03
+ cg2d: Sum(rhs),rhsMax =  -1.73472347597681E-17  3.49905857223942E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   1.21430643318376E-17  2.04009942678851E-03
+ cg2d: Sum(rhs),rhsMax =  -5.20417042793042E-18  2.04009937209445E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252226E-01  3.29048622472774E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357776816E+00  4.17022503399603E+00
- cg2d: Sum(rhs),rhsMax =   2.27601764070151E+00  4.04197234578102E+00
- cg2d: Sum(rhs),rhsMax =   3.02165606792587E+00  3.85995024094881E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697357776815E+00  4.17022503399603E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601764070135E+00  4.04197234578102E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165606792570E+00  3.85995024091507E+00
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -4.85722573273506E-17  2.83628801421088E-03
+ cg2d: Sum(rhs),rhsMax =  -8.67361737988404E-18  2.83628841625579E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3102640000804E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8265295500100E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0237748824936E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9721802467114E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2826806470714E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7300262876995E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9069112282952E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6348741748740E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0019419791610E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7393012113036E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0393761935041E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2933731732452E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6167205416842E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459245331703E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615169105904E-06
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5716268955521E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5832842454975E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.9176078900338E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5424800418975E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.4427367137472E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   7.5236624874256E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.6463644354210E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.1264528808496E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.4118155948284E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.0332263471203E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3102627557790E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8265295439611E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0237676304826E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9721797699459E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2826801204972E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7300263080872E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9069113579238E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6348741302644E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0019416650820E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7393016898628E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0393761943577E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2933731739436E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6167205620668E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459245358806E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615169218605E-06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5716276829746E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5832799614489E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.9176097089166E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.5424801293649E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.4427369108922E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   7.5236624877752E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.6463644354494E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.1264528779871E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.4118155949741E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.0332263502506E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5562,34 +5615,34 @@
 (PID.TID 0000.0001) %MON ad_time_secondsf             =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_max         =   2.0466220855713E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_min         =  -2.0763593673706E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   1.9630677226673E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.6093156437125E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.6374326598003E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.4113189451581E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.3839569255260E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4928785442398E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.8725953858454E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.9845427503203E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4607189925323E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4799779328470E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.9898170122889E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6358660125636E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.9331315367514E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.8195346437399E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8116911371072E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.0113237964823E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.2723113156833E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.3931390205821E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.3380419572589E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.2399992228549E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.0193545434904E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.1175542005660E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.0367835365638E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.6664667202304E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.9149849764797E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2069120399685E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.5994701570782E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0275952986677E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   1.9630677969772E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   4.6093156122238E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.6374325900601E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.4113179807742E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.3839554307640E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4928357331078E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.8725957294469E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.9845455764445E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.4607168866502E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4799720992106E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.9898032872916E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.6358673128513E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.9331347924664E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.8195327723823E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8116917078459E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.0113793876666E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.2722874230889E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   6.3931394715316E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.3380422005404E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.2399992226443E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.0193536706187E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.1175594364210E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.0367835747292E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.6664667118849E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.9149914311818E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2069115644380E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   8.5996680345652E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0275944887631E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5598,70 +5651,70 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     3
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1742071259913E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2162651394104E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4514952241469E-04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5199607959207E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9194176121027E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299856020008E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7473260446963E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1535235210124E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5798735267702E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2193963854717E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4304244524037E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3618258869498E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.5022997361647E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4493754748493E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5504654862445E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4087948500214E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7138034109404E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -5.7005491783713E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.0005950968021E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.2012477079381E-01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.2363227949789E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3468270074775E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.0733875571305E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.5386116103963E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.3366537375404E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1742027287202E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2162617760538E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4514846855186E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5199595130411E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9194170840471E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299827127677E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7473267304866E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1535346759490E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5798733310766E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2193985686135E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4304209001504E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3618242862535E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.5023011388787E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4493745770166E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5504649830051E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4087948741797E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7138034588959E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -5.7005492758534E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   7.0005951090859E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   9.2012477464275E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.2363228037088E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3468270248455E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.0733876050851E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   2.5386116147011E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   3.3366537513828E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -1.50704101975485E-17  1.94295766760882E-03
+ cg2d: Sum(rhs),rhsMax =  -1.01915004213637E-17  1.94295768146997E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   4.98732999343332E-18  1.58381888351740E-03
+ cg2d: Sum(rhs),rhsMax =  -2.16840434497101E-18  1.58381886199117E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.46944695195361E-18  2.31109058484344E-03
+ cg2d: Sum(rhs),rhsMax =   2.60208521396521E-18  2.31109058695558E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     0
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7856995508937E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3596153351940E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9996883909553E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7801389565012E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1546289728027E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5235851609192E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0450941004869E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8826105591752E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6410827857225E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5366547897089E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956064643829E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4091388786480E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.6141293280267E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7478179311550E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419842383760E-05
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5363078612157E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5398375291447E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.8377771188866E+00
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8360841130859E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5427552699047E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.0052936384856E-03
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.0513318962825E-03
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3140005491751E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8458700461333E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.6972406212083E-06
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7857019123115E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3596153541755E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9996788890584E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7801376951119E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1546292164202E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5235848081947E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0450933617276E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8826111519875E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6410822855408E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5366516734442E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956064642486E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4091388725872E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.6141293004678E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   8.7478179143937E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419842388971E-05
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5363078831138E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5398336844175E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.8377805439176E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8360830844058E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5427549125630E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.0052936378992E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.0513318962605E-03
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3140005415629E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8458700426434E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.6972406224463E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5678,31 +5731,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9807034093562E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.1270333022907E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.2963838542005E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2821304189064E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.4658711843025E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3452838954058E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.4018915177098E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.3701546314855E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3893779168920E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.6338967877690E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9807021241040E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -3.1270323357643E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.2963484910654E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2821314599476E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.4658731849579E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3452847608704E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.4018923972796E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -5.3701417232785E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.3893790656257E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.6339016553609E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0955157173850E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.4242530737105E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.4525377147399E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4369505464535E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700869890080E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0169434786589E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4797947980258E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.5854306757326E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3392324216324E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6755277330329E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   5.0955157196600E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.4242530737568E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.4525380756107E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4369535352833E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700870857921E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0168990475101E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4797556969293E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.5854304259179E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3392411728327E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6755280055110E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5711,31 +5764,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_seaice_tsnumber           =                     0
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8134713670095E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1836720517881E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0929765992065E-04
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2609087185825E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1070856335372E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890852038234E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5622210090942E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9713238034987E-05
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1005762338646E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9937935295157E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1713203850489E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3352704302588E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6478040243645E-04
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3711869572396E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2631458822373E-04
-(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9825487868929E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7084760777433E+02
-(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -7.3923826785352E+00
-(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   8.9981545849668E+01
-(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.1722186131805E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8073154428099E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3458975563003E+02
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.6860118074680E+00
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2631438735970E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.2507452061718E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8134668364471E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1836681684081E-01
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0929595352455E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2609069945472E-02
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1070844220612E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890820026281E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5622216542202E-01
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9714650576089E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1005757260216E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9937954289720E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1713210272139E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3352704693064E-01
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6478277143216E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3711864946939E-02
+(PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2631448353783E-04
+(PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9825487488790E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -3.7084760350949E+02
+(PID.TID 0000.0001) %MON ad_seaice_adheff_mean        =  -7.3923835031795E+00
+(PID.TID 0000.0001) %MON ad_seaice_adheff_sd          =   8.9981546183932E+01
+(PID.TID 0000.0001) %MON ad_seaice_adheff_del2        =   1.1722186169978E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_max        =   1.8073154290276E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -1.3458975426782E+02
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.6860121072561E+00
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   3.2631438860685E+01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   4.2507452202116E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5747,7 +5800,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  3.31894664938770E+04
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  3.31894347361738E+04
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -5766,12 +5819,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252098E-01  3.29048622472429E+00
  cg2d: Sum(rhs),rhsMax =   1.52697358431249E+00  4.17022503398205E+00
- cg2d: Sum(rhs),rhsMax =   2.27601765314465E+00  4.04197234571436E+00
- cg2d: Sum(rhs),rhsMax =   3.02165608578957E+00  3.85995024071302E+00
- cg2d: Sum(rhs),rhsMax =   3.74608562165758E+00  3.61302462901035E+00
- cg2d: Sum(rhs),rhsMax =   4.45761419363021E+00  3.33597383712085E+00
- cg2d: Sum(rhs),rhsMax =   5.15911015353674E+00  3.10707882794718E+00
- cg2d: Sum(rhs),rhsMax =   5.85339074759958E+00  2.96283946716953E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601765314462E+00  4.04197234571435E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165608578966E+00  3.85995024067977E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608562165702E+00  3.61302462731545E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761419362887E+00  3.33597382875963E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911015353132E+00  3.10707880891282E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339074758716E+00  2.96283944075196E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5779,21 +5832,21 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974314233500D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624872024D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644066489935D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722092846220D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973461358151D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391963488D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644073185345D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448722092495620D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894672228990D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894354667400D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473291578341D+04
-(PID.TID 0000.0001)  global fc =  0.331894672228990D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894672228990E+04
+(PID.TID 0000.0001)   local fc =  0.142473289902552D+04
+(PID.TID 0000.0001)  global fc =  0.331894354667400D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894354667400E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -5803,13 +5856,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252190E-01  3.29048622473124E+00
- cg2d: Sum(rhs),rhsMax =   1.52697357122355E+00  4.17022503400893E+00
- cg2d: Sum(rhs),rhsMax =   2.27601762825762E+00  4.04197234584808E+00
- cg2d: Sum(rhs),rhsMax =   3.02165605006121E+00  3.85995024118329E+00
- cg2d: Sum(rhs),rhsMax =   3.74608557599240E+00  3.61302463015362E+00
- cg2d: Sum(rhs),rhsMax =   4.45761413930140E+00  3.33597383919068E+00
- cg2d: Sum(rhs),rhsMax =   5.15911009149499E+00  3.10707883084526E+00
- cg2d: Sum(rhs),rhsMax =   5.85339067913355E+00  2.96283947034793E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697357122359E+00  4.17022503400893E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601762825738E+00  4.04197234584808E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165605006115E+00  3.85995024114960E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608557599223E+00  3.61302462845989E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761413929961E+00  3.33597383083021E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911009148988E+00  3.10707881181027E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339067912145E+00  2.96283944393041E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5817,27 +5870,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974313470536D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624878488D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644068188824D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448721953015326D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973460595196D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391969946D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644074915378D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448721952686683D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894658345956D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894340789672D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473175566186D+04
-(PID.TID 0000.0001)  global fc =  0.331894658345956D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894658345956E+04
+(PID.TID 0000.0001)   local fc =  0.142473173977104D+04
+(PID.TID 0000.0001)  global fc =  0.331894340789672D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894340789672E+04
 grad-res -------------------------------
- grad-res     0    1    1    1    1    1    1    1   3.31894664939E+04  3.31894672229E+04  3.31894658346E+04
- grad-res     0    1    1    1    0    1    1    1   5.09815104306E-02  6.94151665812E-02 -3.61575323973E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
+ grad-res     0    1    1    1    1    1    1    1   3.31894347362E+04  3.31894354667E+04  3.31894340790E+04
+ grad-res     0    1    1    1    0    1    1    1   5.09815104306E-02  6.93886398949E-02 -3.61055004233E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894347361738E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09815104305744E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.94151665811660E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.93886398948962E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2         594           2
@@ -5853,13 +5906,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252176E-01  3.29048622472274E+00
- cg2d: Sum(rhs),rhsMax =   1.52697358722564E+00  4.17022503397201E+00
- cg2d: Sum(rhs),rhsMax =   2.27601765888514E+00  4.04197234565430E+00
- cg2d: Sum(rhs),rhsMax =   3.02165609423517E+00  3.85995024050694E+00
- cg2d: Sum(rhs),rhsMax =   3.74608563265483E+00  3.61302462852283E+00
- cg2d: Sum(rhs),rhsMax =   4.45761420686100E+00  3.33597383627754E+00
- cg2d: Sum(rhs),rhsMax =   5.15911016859178E+00  3.10707882679623E+00
- cg2d: Sum(rhs),rhsMax =   5.85339076415704E+00  2.96283946589900E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697358722563E+00  4.17022503397201E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601765888521E+00  4.04197234565432E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165609423523E+00  3.85995024047286E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608563265508E+00  3.61302462682799E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761420685903E+00  3.33597382791545E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911016858638E+00  3.10707880776196E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339076414485E+00  2.96283943948324E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5867,21 +5920,21 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974314354079D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624875213D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644065660966D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722083640594D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973461478730D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391966679D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644072414320D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448722083286449D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894671240777D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894353684628D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473302055009D+04
-(PID.TID 0000.0001)  global fc =  0.331894671240777D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894671240777E+04
+(PID.TID 0000.0001)   local fc =  0.142473300512255D+04
+(PID.TID 0000.0001)  global fc =  0.331894353684628D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894353684628E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -5891,13 +5944,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252148E-01  3.29048622473278E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356831069E+00  4.17022503401875E+00
- cg2d: Sum(rhs),rhsMax =   2.27601762251653E+00  4.04197234590783E+00
- cg2d: Sum(rhs),rhsMax =   3.02165604161519E+00  3.85995024139163E+00
- cg2d: Sum(rhs),rhsMax =   3.74608556499425E+00  3.61302463064138E+00
- cg2d: Sum(rhs),rhsMax =   4.45761412607030E+00  3.33597384003777E+00
- cg2d: Sum(rhs),rhsMax =   5.15911007644007E+00  3.10707883199502E+00
- cg2d: Sum(rhs),rhsMax =   5.85339066257538E+00  2.96283947161528E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697356831072E+00  4.17022503401875E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601762251645E+00  4.04197234590785E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165604161553E+00  3.85995024135716E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608556499379E+00  3.61302462894661E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761412606839E+00  3.33597383167363E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911007643473E+00  3.10707881295762E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339066256324E+00  2.96283944520235E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5905,27 +5958,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974313349852D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624875285D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644069502959D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448721950110760D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973460474503D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391966747D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644076464715D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448721949782117D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894658171642D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894340638880D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473159962094D+04
-(PID.TID 0000.0001)  global fc =  0.331894658171642D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894658171642E+04
+(PID.TID 0000.0001)   local fc =  0.142473158409020D+04
+(PID.TID 0000.0001)  global fc =  0.331894340638880D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894340638880E+04
 grad-res -------------------------------
- grad-res     0    2    2    1    1    1    1    1   3.31894664939E+04  3.31894671241E+04  3.31894658172E+04
- grad-res     0    2    2    2    0    1    1    1   4.96699325740E-02  6.53456765576E-02 -3.15598253737E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
+ grad-res     0    2    2    1    1    1    1    1   3.31894347362E+04  3.31894353685E+04  3.31894340639E+04
+ grad-res     0    2    2    2    0    1    1    1   4.96699325740E-02  6.52287402772E-02 -3.13243986792E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894347361738E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.96699325740337E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.53456765576266E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.52287402772345E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3         594           3
@@ -5942,12 +5995,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252198E-01  3.29048622472200E+00
  cg2d: Sum(rhs),rhsMax =   1.52697358863699E+00  4.17022503395985E+00
- cg2d: Sum(rhs),rhsMax =   2.27601766174621E+00  4.04197234556664E+00
- cg2d: Sum(rhs),rhsMax =   3.02165609849880E+00  3.85995024020678E+00
- cg2d: Sum(rhs),rhsMax =   3.74608563824549E+00  3.61302462783527E+00
- cg2d: Sum(rhs),rhsMax =   4.45761421368439E+00  3.33597383511050E+00
- cg2d: Sum(rhs),rhsMax =   5.15911017650012E+00  3.10707882521312E+00
- cg2d: Sum(rhs),rhsMax =   5.85339077305372E+00  2.96283946410433E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601766174617E+00  4.04197234556664E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165609849848E+00  3.85995024017247E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608563824586E+00  3.61302462614041E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761421368269E+00  3.33597382674684E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911017649455E+00  3.10707880617652E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339077304124E+00  2.96283943768413E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5955,21 +6008,21 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974314378885D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624876853D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644064600946D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722054806655D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973461503543D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391968317D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644071085492D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448722054452509D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894668255502D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894350672472D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473290834129D+04
-(PID.TID 0000.0001)  global fc =  0.331894668255502D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894668255502E+04
+(PID.TID 0000.0001)   local fc =  0.142473289304684D+04
+(PID.TID 0000.0001)  global fc =  0.331894350672472D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894350672472E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -5980,12 +6033,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252126E-01  3.29048622473353E+00
  cg2d: Sum(rhs),rhsMax =   1.52697356689907E+00  4.17022503403125E+00
- cg2d: Sum(rhs),rhsMax =   2.27601761965553E+00  4.04197234599471E+00
- cg2d: Sum(rhs),rhsMax =   3.02165603735179E+00  3.85995024169212E+00
- cg2d: Sum(rhs),rhsMax =   3.74608555940367E+00  3.61302463132785E+00
- cg2d: Sum(rhs),rhsMax =   4.45761411924661E+00  3.33597384120507E+00
- cg2d: Sum(rhs),rhsMax =   5.15911006853139E+00  3.10707883357847E+00
- cg2d: Sum(rhs),rhsMax =   5.85339065367907E+00  2.96283947341552E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601761965573E+00  4.04197234599469E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165603735193E+00  3.85995024165796E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608555940364E+00  3.61302462963196E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761411924485E+00  3.33597383284438E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911006852613E+00  3.10707881454381E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339065366657E+00  2.96283944699830E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -5993,27 +6046,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974313325207D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624873647D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644070269005D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448721984700163D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973460449863D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391965112D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644077359472D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448721984709785D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894661703084D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894344217024D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473174626259D+04
-(PID.TID 0000.0001)  global fc =  0.331894661703084D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894661703084E+04
+(PID.TID 0000.0001)   local fc =  0.142473173037044D+04
+(PID.TID 0000.0001)  global fc =  0.331894344217024D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894344217024E+04
 grad-res -------------------------------
- grad-res     0    3    3    1    1    1    1    1   3.31894664939E+04  3.31894668256E+04  3.31894661703E+04
- grad-res     0    3    3    3    0    1    1    1   2.86069530994E-02  3.27620866301E-02 -1.45249076904E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.86069530993700E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27620866301004E-02
+ grad-res     0    3    3    1    1    1    1    1   3.31894347362E+04  3.31894350672E+04  3.31894344217E+04
+ grad-res     0    3    3    3    0    1    1    1   2.86069568247E-02  3.22772375512E-02 -1.28300285452E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894347361738E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.86069568246603E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.22772375511704E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4         594           4
@@ -6029,13 +6082,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252183E-01  3.29048622472130E+00
- cg2d: Sum(rhs),rhsMax =   1.52697358994743E+00  4.17022503394058E+00
- cg2d: Sum(rhs),rhsMax =   2.27601766444567E+00  4.04197234543381E+00
- cg2d: Sum(rhs),rhsMax =   3.02165610263884E+00  3.85995023976384E+00
- cg2d: Sum(rhs),rhsMax =   3.74608564382629E+00  3.61302462687043E+00
- cg2d: Sum(rhs),rhsMax =   4.45761422084880E+00  3.33597383353500E+00
- cg2d: Sum(rhs),rhsMax =   5.15911018537207E+00  3.10707882314534E+00
- cg2d: Sum(rhs),rhsMax =   5.85339078379516E+00  2.96283946179787E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697358994746E+00  4.17022503394058E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601766444549E+00  4.04197234543340E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165610263890E+00  3.85995023972966E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608564382626E+00  3.61302462517581E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761422084720E+00  3.33597382517461E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911018536681E+00  3.10707880411102E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339078378311E+00  2.96283943538017E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6043,21 +6096,21 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974314321325D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624877234D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644063623697D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722023213277D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973461445976D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391968695D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644069595576D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448722023431561D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894664993063D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894347416006D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473266403134D+04
-(PID.TID 0000.0001)  global fc =  0.331894664993063D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894664993063E+04
+(PID.TID 0000.0001)   local fc =  0.142473264866253D+04
+(PID.TID 0000.0001)  global fc =  0.331894347416006D+05
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894347416006E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -6067,13 +6120,13 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   7.73551084252190E-01  3.29048622473423E+00
- cg2d: Sum(rhs),rhsMax =   1.52697356558878E+00  4.17022503405074E+00
- cg2d: Sum(rhs),rhsMax =   2.27601761695649E+00  4.04197234612793E+00
- cg2d: Sum(rhs),rhsMax =   3.02165603321211E+00  3.85995024213286E+00
- cg2d: Sum(rhs),rhsMax =   3.74608555382292E+00  3.61302463229192E+00
- cg2d: Sum(rhs),rhsMax =   4.45761411208255E+00  3.33597384277527E+00
- cg2d: Sum(rhs),rhsMax =   5.15911005966026E+00  3.10707883564385E+00
- cg2d: Sum(rhs),rhsMax =   5.85339064293876E+00  2.96283947572090E+00
+ cg2d: Sum(rhs),rhsMax =   1.52697356558873E+00  4.17022503405074E+00
+ cg2d: Sum(rhs),rhsMax =   2.27601761695644E+00  4.04197234612790E+00
+ cg2d: Sum(rhs),rhsMax =   3.02165603321197E+00  3.85995024210011E+00
+ cg2d: Sum(rhs),rhsMax =   3.74608555382272E+00  3.61302463059753E+00
+ cg2d: Sum(rhs),rhsMax =   4.45761411208156E+00  3.33597383441723E+00
+ cg2d: Sum(rhs),rhsMax =   5.15911005965469E+00  3.10707881661085E+00
+ cg2d: Sum(rhs),rhsMax =   5.85339064292646E+00  2.96283944930159E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
@@ -6081,27 +6134,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.22926D+05 0.18579D+06
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134974313382708D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260624873260D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644071851342D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722009451622D+04 2
+(PID.TID 0000.0001)  --> f_profiles = 0.134973460507357D+04 1 1
+(PID.TID 0000.0001)  --> f_profiles = 0.229260391964717D+05 1 2
+(PID.TID 0000.0001)  --> f_gencost = 0.442644078451561D+04 1
+(PID.TID 0000.0001)  --> f_gencost = 0.448722009122979D+04 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894664341827D+05
+(PID.TID 0000.0001)  --> fc               = 0.331894346772906D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473191782152D+04
-(PID.TID 0000.0001)  global fc =  0.331894664341827D+05
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894664341827E+04
+(PID.TID 0000.0001)   local fc =  0.142473189938900D+04
+(PID.TID 0000.0001)  global fc =  0.331894346772906D+05
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894346772906E+04
 grad-res -------------------------------
- grad-res     0    4    4    1    1    1    1    1   3.31894664939E+04  3.31894664993E+04  3.31894664342E+04
- grad-res     0    4    4    4    0    1    1    1   4.68086265028E-03  3.25618239003E-03  3.04362756758E-01
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894664938770E+04
-(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.68086265027523E-03
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.25618239003234E-03
+ grad-res     0    4    4    1    1    1    1    1   3.31894347362E+04  3.31894347416E+04  3.31894346773E+04
+ grad-res     0    4    4    4    0    1    1    1   4.68086637557E-03  3.21550141962E-03  3.13054216544E-01
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894347361738E+04
+(PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.68086637556553E-03
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.21550141961779E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6115,271 +6168,271 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   1  3.3189466493877E+04  3.3189467222899E+04  3.3189465834596E+04
-(PID.TID 0000.0001) grdchk output (g):   1     6.9415166581166E-02  5.0981510430574E-02 -3.6157532397347E-01
+(PID.TID 0000.0001) grdchk output (c):   1  3.3189434736174E+04  3.3189435466740E+04  3.3189434078967E+04
+(PID.TID 0000.0001) grdchk output (g):   1     6.9388639894896E-02  5.0981510430574E-02 -3.6105500423312E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   2  3.3189466493877E+04  3.3189467124078E+04  3.3189465817164E+04
-(PID.TID 0000.0001) grdchk output (g):   2     6.5345676557627E-02  4.9669932574034E-02 -3.1559825373686E-01
+(PID.TID 0000.0001) grdchk output (c):   2  3.3189434736174E+04  3.3189435368463E+04  3.3189434063888E+04
+(PID.TID 0000.0001) grdchk output (g):   2     6.5228740277234E-02  4.9669932574034E-02 -3.1324398679241E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   3  3.3189466493877E+04  3.3189466825550E+04  3.3189466170308E+04
-(PID.TID 0000.0001) grdchk output (g):   3     3.2762086630100E-02  2.8606953099370E-02 -1.4524907690438E-01
+(PID.TID 0000.0001) grdchk output (c):   3  3.3189434736174E+04  3.3189435067247E+04  3.3189434421702E+04
+(PID.TID 0000.0001) grdchk output (g):   3     3.2277237551170E-02  2.8606956824660E-02 -1.2830028545176E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   4  3.3189466493877E+04  3.3189466499306E+04  3.3189466434183E+04
-(PID.TID 0000.0001) grdchk output (g):   4     3.2561823900323E-03  4.6808626502752E-03  3.0436275675791E-01
+(PID.TID 0000.0001) grdchk output (c):   4  3.3189434736174E+04  3.3189434741601E+04  3.3189434677291E+04
+(PID.TID 0000.0001) grdchk output (g):   4     3.2155014196178E-03  4.6808663755655E-03  3.1305421654355E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9328866101126E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9280813559654E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   174.55678601562977
-(PID.TID 0000.0001)         System time:   2.5830048844218254
-(PID.TID 0000.0001)     Wall clock time:   178.22393393516541
+(PID.TID 0000.0001)           User time:   178.44453713297844
+(PID.TID 0000.0001)         System time:   4.4695480167865753
+(PID.TID 0000.0001)     Wall clock time:   185.67369413375854
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.94894698262214661
-(PID.TID 0000.0001)         System time:  0.24376498907804489
-(PID.TID 0000.0001)     Wall clock time:   1.3828959465026855
+(PID.TID 0000.0001)           User time:  0.85201698169112206
+(PID.TID 0000.0001)         System time:  0.51199299097061157
+(PID.TID 0000.0001)     Wall clock time:   1.5712068080902100
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   83.311727702617645
-(PID.TID 0000.0001)         System time:   1.8113310635089874
-(PID.TID 0000.0001)     Wall clock time:   85.824037075042725
+(PID.TID 0000.0001)           User time:   91.184690356254578
+(PID.TID 0000.0001)         System time:   2.9585370421409607
+(PID.TID 0000.0001)     Wall clock time:   96.466220140457153
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   99.223167896270752
-(PID.TID 0000.0001)         System time:  0.37552225589752197
-(PID.TID 0000.0001)     Wall clock time:   100.12991309165955
+(PID.TID 0000.0001)           User time:   97.291767835617065
+(PID.TID 0000.0001)         System time:  0.45762133598327637
+(PID.TID 0000.0001)     Wall clock time:   98.130225896835327
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9138526916503906
-(PID.TID 0000.0001)         System time:   5.3608417510986328E-004
-(PID.TID 0000.0001)     Wall clock time:   1.9153716564178467
+(PID.TID 0000.0001)           User time:   1.8694834709167480
+(PID.TID 0000.0001)         System time:   5.3584575653076172E-004
+(PID.TID 0000.0001)     Wall clock time:   1.8756022453308105
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.96229171752929688
-(PID.TID 0000.0001)         System time:   4.6961843967437744E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1297271251678467
+(PID.TID 0000.0001)           User time:   1.8597583770751953
+(PID.TID 0000.0001)         System time:   9.3877077102661133E-002
+(PID.TID 0000.0001)     Wall clock time:   2.1500723361968994
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.88628745079040527
-(PID.TID 0000.0001)         System time:   4.6710014343261719E-002
-(PID.TID 0000.0001)     Wall clock time:   1.0535964965820312
+(PID.TID 0000.0001)           User time:   1.7819361686706543
+(PID.TID 0000.0001)         System time:   9.3346357345581055E-002
+(PID.TID 0000.0001)     Wall clock time:   2.0713655948638916
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   7.6031684875488281E-004
-(PID.TID 0000.0001)         System time:   9.0599060058593750E-006
-(PID.TID 0000.0001)     Wall clock time:   7.5268745422363281E-004
+(PID.TID 0000.0001)           User time:   7.5078010559082031E-004
+(PID.TID 0000.0001)         System time:   2.6464462280273438E-005
+(PID.TID 0000.0001)     Wall clock time:   7.8535079956054688E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16671729087829590
-(PID.TID 0000.0001)         System time:   2.9695034027099609E-004
-(PID.TID 0000.0001)     Wall clock time:  0.16712141036987305
+(PID.TID 0000.0001)           User time:  0.17165493965148926
+(PID.TID 0000.0001)         System time:   2.7228593826293945E-003
+(PID.TID 0000.0001)     Wall clock time:  0.17452836036682129
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.1922788619995117E-002
-(PID.TID 0000.0001)         System time:   2.3317337036132812E-004
-(PID.TID 0000.0001)     Wall clock time:   6.2314271926879883E-002
+(PID.TID 0000.0001)           User time:   5.8332920074462891E-002
+(PID.TID 0000.0001)         System time:   8.1253051757812500E-004
+(PID.TID 0000.0001)     Wall clock time:   5.9269428253173828E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   22.515388488769531
-(PID.TID 0000.0001)         System time:   5.2355706691741943E-002
-(PID.TID 0000.0001)     Wall clock time:   22.609428882598877
+(PID.TID 0000.0001)           User time:   19.342762470245361
+(PID.TID 0000.0001)         System time:  0.10408496856689453
+(PID.TID 0000.0001)     Wall clock time:   19.502175331115723
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.0323276519775391
-(PID.TID 0000.0001)         System time:   4.2564272880554199E-003
-(PID.TID 0000.0001)     Wall clock time:   2.0372138023376465
+(PID.TID 0000.0001)           User time:   1.7974803447723389
+(PID.TID 0000.0001)         System time:   9.6051692962646484E-003
+(PID.TID 0000.0001)     Wall clock time:   1.8085312843322754
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.5270893573760986
-(PID.TID 0000.0001)         System time:   4.0290355682373047E-003
-(PID.TID 0000.0001)     Wall clock time:   1.5316410064697266
+(PID.TID 0000.0001)           User time:   1.3370220661163330
+(PID.TID 0000.0001)         System time:   8.3973407745361328E-003
+(PID.TID 0000.0001)     Wall clock time:   1.3465802669525146
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   6.7513849735260010
-(PID.TID 0000.0001)         System time:   1.6428112983703613E-002
-(PID.TID 0000.0001)     Wall clock time:   6.8024644851684570
+(PID.TID 0000.0001)           User time:   4.8324489593505859
+(PID.TID 0000.0001)         System time:   1.6785502433776855E-002
+(PID.TID 0000.0001)     Wall clock time:   4.8831017017364502
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   22.042269229888916
-(PID.TID 0000.0001)         System time:   7.9120993614196777E-003
-(PID.TID 0000.0001)     Wall clock time:   22.089069366455078
+(PID.TID 0000.0001)           User time:   20.729671239852905
+(PID.TID 0000.0001)         System time:   1.8754243850708008E-002
+(PID.TID 0000.0001)     Wall clock time:   20.788431406021118
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3157866001129150
-(PID.TID 0000.0001)         System time:   4.6759843826293945E-004
-(PID.TID 0000.0001)     Wall clock time:   2.3171830177307129
+(PID.TID 0000.0001)           User time:   2.9502911567687988
+(PID.TID 0000.0001)         System time:   2.6881694793701172E-004
+(PID.TID 0000.0001)     Wall clock time:   2.9740490913391113
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2438883781433105
-(PID.TID 0000.0001)         System time:   1.1682510375976562E-004
-(PID.TID 0000.0001)     Wall clock time:   1.2445726394653320
+(PID.TID 0000.0001)           User time:   1.2907841205596924
+(PID.TID 0000.0001)         System time:   2.7430057525634766E-004
+(PID.TID 0000.0001)     Wall clock time:   1.2928600311279297
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.51593875885009766
-(PID.TID 0000.0001)         System time:   3.9716362953186035E-003
-(PID.TID 0000.0001)     Wall clock time:  0.52020168304443359
+(PID.TID 0000.0001)           User time:  0.48852324485778809
+(PID.TID 0000.0001)         System time:   5.1021575927734375E-005
+(PID.TID 0000.0001)     Wall clock time:  0.49064612388610840
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.93417286872863770
-(PID.TID 0000.0001)         System time:   1.7881393432617188E-005
-(PID.TID 0000.0001)     Wall clock time:  0.93725109100341797
+(PID.TID 0000.0001)           User time:  0.97532820701599121
+(PID.TID 0000.0001)         System time:   2.4998188018798828E-004
+(PID.TID 0000.0001)     Wall clock time:  0.98011088371276855
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6619148254394531E-002
-(PID.TID 0000.0001)         System time:   2.5212764739990234E-005
-(PID.TID 0000.0001)     Wall clock time:   7.6673269271850586E-002
+(PID.TID 0000.0001)           User time:   9.2041969299316406E-002
+(PID.TID 0000.0001)         System time:   1.0228157043457031E-004
+(PID.TID 0000.0001)     Wall clock time:   9.2572212219238281E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1334791183471680
-(PID.TID 0000.0001)         System time:  0.11519706249237061
-(PID.TID 0000.0001)     Wall clock time:   4.2663819789886475
+(PID.TID 0000.0001)           User time:   5.5397768020629883
+(PID.TID 0000.0001)         System time:  0.12631213665008545
+(PID.TID 0000.0001)     Wall clock time:   5.6746575832366943
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   23.508372306823730
-(PID.TID 0000.0001)         System time:   1.1636674404144287E-002
-(PID.TID 0000.0001)     Wall clock time:   23.558078765869141
+(PID.TID 0000.0001)           User time:   22.770012140274048
+(PID.TID 0000.0001)         System time:   1.7300248146057129E-002
+(PID.TID 0000.0001)     Wall clock time:   22.814287185668945
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.2121620178222656E-004
-(PID.TID 0000.0001)         System time:   1.4960765838623047E-005
-(PID.TID 0000.0001)     Wall clock time:   7.0810317993164062E-004
+(PID.TID 0000.0001)           User time:   7.1358680725097656E-004
+(PID.TID 0000.0001)         System time:   9.0599060058593750E-006
+(PID.TID 0000.0001)     Wall clock time:   7.0476531982421875E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30049419403076172
-(PID.TID 0000.0001)         System time:   3.2901763916015625E-005
-(PID.TID 0000.0001)     Wall clock time:  0.30106925964355469
+(PID.TID 0000.0001)           User time:  0.36161231994628906
+(PID.TID 0000.0001)         System time:   3.9485692977905273E-003
+(PID.TID 0000.0001)     Wall clock time:  0.36569547653198242
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.4849853515625000E-004
-(PID.TID 0000.0001)         System time:   1.1861324310302734E-005
-(PID.TID 0000.0001)     Wall clock time:   6.4563751220703125E-004
+(PID.TID 0000.0001)           User time:   6.8116188049316406E-004
+(PID.TID 0000.0001)         System time:   7.0333480834960938E-006
+(PID.TID 0000.0001)     Wall clock time:   6.4849853515625000E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.37810039520263672
-(PID.TID 0000.0001)         System time:   2.0011961460113525E-002
-(PID.TID 0000.0001)     Wall clock time:  0.40956854820251465
+(PID.TID 0000.0001)           User time:  0.70366525650024414
+(PID.TID 0000.0001)         System time:   2.7696728706359863E-002
+(PID.TID 0000.0001)     Wall clock time:  0.73268151283264160
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15532779693603516
-(PID.TID 0000.0001)         System time:  0.10785597562789917
-(PID.TID 0000.0001)     Wall clock time:  0.26313352584838867
+(PID.TID 0000.0001)           User time:  0.13311004638671875
+(PID.TID 0000.0001)         System time:   5.6046724319458008E-002
+(PID.TID 0000.0001)     Wall clock time:  0.18922066688537598
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.2100772857666016
-(PID.TID 0000.0001)         System time:   5.9949994087219238E-002
-(PID.TID 0000.0001)     Wall clock time:   2.3064212799072266
+(PID.TID 0000.0001)           User time:   2.0503797531127930
+(PID.TID 0000.0001)         System time:  0.11381387710571289
+(PID.TID 0000.0001)     Wall clock time:   2.2079093456268311
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.49365520477294922
-(PID.TID 0000.0001)         System time:   6.0001909732818604E-002
-(PID.TID 0000.0001)     Wall clock time:  0.55388855934143066
+(PID.TID 0000.0001)           User time:  0.51765251159667969
+(PID.TID 0000.0001)         System time:   8.4208846092224121E-002
+(PID.TID 0000.0001)     Wall clock time:  0.60352420806884766
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.14381408691406250
-(PID.TID 0000.0001)         System time:   3.9890050888061523E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18666410446166992
+(PID.TID 0000.0001)           User time:  0.21717071533203125
+(PID.TID 0000.0001)         System time:   5.6025028228759766E-002
+(PID.TID 0000.0001)     Wall clock time:  0.33960008621215820
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.17381286621093750
-(PID.TID 0000.0001)         System time:   8.0449581146240234E-003
-(PID.TID 0000.0001)     Wall clock time:  0.18190193176269531
+(PID.TID 0000.0001)           User time:  0.14526367187500000
+(PID.TID 0000.0001)         System time:   2.4044990539550781E-002
+(PID.TID 0000.0001)     Wall clock time:  0.16932797431945801
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   89.978340148925781
-(PID.TID 0000.0001)         System time:  0.47994995117187500
-(PID.TID 0000.0001)     Wall clock time:   90.648307085037231
+(PID.TID 0000.0001)           User time:   86.045265197753906
+(PID.TID 0000.0001)         System time:  0.91889691352844238
+(PID.TID 0000.0001)     Wall clock time:   87.127191066741943
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.0911788940429688
-(PID.TID 0000.0001)         System time:  0.17961978912353516
-(PID.TID 0000.0001)     Wall clock time:   6.2722082138061523
+(PID.TID 0000.0001)           User time:   5.9685592651367188
+(PID.TID 0000.0001)         System time:  0.34112906455993652
+(PID.TID 0000.0001)     Wall clock time:   6.3178453445434570
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   83.865112304687500
-(PID.TID 0000.0001)         System time:  0.30023193359375000
-(PID.TID 0000.0001)     Wall clock time:   84.351010322570801
+(PID.TID 0000.0001)           User time:   80.047813415527344
+(PID.TID 0000.0001)         System time:  0.56328129768371582
+(PID.TID 0000.0001)     Wall clock time:   80.752905607223511
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.2147979736328125
-(PID.TID 0000.0001)         System time:   1.5872001647949219E-002
-(PID.TID 0000.0001)     Wall clock time:   2.2594349384307861
+(PID.TID 0000.0001)           User time:   2.6172561645507812
+(PID.TID 0000.0001)         System time:   2.7626752853393555E-002
+(PID.TID 0000.0001)     Wall clock time:   2.6615121364593506
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.56592559814453125
-(PID.TID 0000.0001)         System time:   3.1868457794189453E-002
-(PID.TID 0000.0001)     Wall clock time:  0.59794902801513672
+(PID.TID 0000.0001)           User time:  0.54714202880859375
+(PID.TID 0000.0001)         System time:   1.6291856765747070E-002
+(PID.TID 0000.0001)     Wall clock time:  0.56366896629333496
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   77.691154479980469
-(PID.TID 0000.0001)         System time:  0.13638019561767578
-(PID.TID 0000.0001)     Wall clock time:   77.979200601577759
+(PID.TID 0000.0001)           User time:   73.649604797363281
+(PID.TID 0000.0001)         System time:  0.27567720413208008
+(PID.TID 0000.0001)     Wall clock time:   74.040488243103027
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.23314666748046875
-(PID.TID 0000.0001)         System time:   1.2159347534179688E-005
-(PID.TID 0000.0001)     Wall clock time:  0.23728299140930176
+(PID.TID 0000.0001)           User time:  0.29788208007812500
+(PID.TID 0000.0001)         System time:   5.6266784667968750E-005
+(PID.TID 0000.0001)     Wall clock time:  0.29795360565185547
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.5945434570312500E-003
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.6019344329833984E-003
+(PID.TID 0000.0001)           User time:   1.8539428710937500E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.8243789672851562E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.4043350219726562
-(PID.TID 0000.0001)         System time:   6.3962936401367188E-002
-(PID.TID 0000.0001)     Wall clock time:   2.4692320823669434
+(PID.TID 0000.0001)           User time:   2.2525253295898438
+(PID.TID 0000.0001)         System time:  0.11988854408264160
+(PID.TID 0000.0001)     Wall clock time:   2.3796570301055908
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.5907287597656250E-002
-(PID.TID 0000.0001)         System time:   1.2397766113281250E-004
-(PID.TID 0000.0001)     Wall clock time:   1.6055822372436523E-002
+(PID.TID 0000.0001)           User time:   1.7478942871093750E-002
+(PID.TID 0000.0001)         System time:   2.5391578674316406E-004
+(PID.TID 0000.0001)     Wall clock time:   1.8849134445190430E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6419,9 +6472,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         232022
+(PID.TID 0000.0001) //            No. barriers =         229634
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         232022
+(PID.TID 0000.0001) //     Total barrier spins =         229634
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/code/GGL90_OPTIONS.h
+++ b/global_oce_llc90/code/GGL90_OPTIONS.h
@@ -21,5 +21,14 @@ C     Use horizontal averaging for viscosity and diffusivity as
 C     originally implemented in OPA.
 #define ALLOW_GGL90_SMOOTH
 
+C     allow IDEMIX model
+#undef ALLOW_GGL90_IDEMIX
+
+C     include Langmuir circulation parameterization
+#undef ALLOW_GGL90_LANGMUIR
+
+C     recover old bug prior to Jun 2023
+#undef GGL90_MISSING_HFAC_BUG
+
 #endif /* ALLOW_GGL90 */
 #endif /* GGL90_OPTIONS_H */

--- a/global_oce_llc90/code/mom_calc_visc.F.ref
+++ b/global_oce_llc90/code/mom_calc_visc.F.ref
@@ -516,15 +516,6 @@ C  Harmonic on Div.u points
          viscAh_DMax(i,j)=MIN(viscAhGridMax*L2rdt,viscAhMax)
          viscAh_D(i,j)=MIN(viscAh_DMax(i,j),viscAh_D(i,j))
 
-C- Customized version: Increase Harmonic Viscosity around Gibraltar Strait:
-         IF ( (yC(i,j,bi,bj).GE.33.) .AND.
-     &        (yC(i,j,bi,bj).LE.39.) .AND.
-     &        (xC(i,j,bi,bj).GE.-7.) .AND.
-     &        (xC(i,j,bi,bj).LE.-2.) ) THEN
-           viscAh_D(i,j) = 10. _d 0 * viscAh_D(i,j)
-         ENDIF
-C- Customized code ends here
-
 C  BiHarmonic on Div.u points
          Alin=viscA4D+viscA4Grid*L4rdt
      &         + viscA4_DLth(i,j)+viscA4_DSmg(i,j)
@@ -671,15 +662,6 @@ C  Harmonic on Zeta points
          viscAh_Z(i,j)=MAX(viscAh_ZMin(i,j),Alin)
          viscAh_ZMax(i,j)=MIN(viscAhGridMax*L2rdt,viscAhMax)
          viscAh_Z(i,j)=MIN(viscAh_ZMax(i,j),viscAh_Z(i,j))
-
-C- Customized version: Increase Harmonic Viscosity around Gibraltar Strait:
-         IF ( (yG(i,j,bi,bj).GE.33.) .AND.
-     &        (yG(i,j,bi,bj).LE.39.) .AND.
-     &        (xG(i,j,bi,bj).GE.-7.) .AND.
-     &        (xG(i,j,bi,bj).LE.-2.) ) THEN
-           viscAh_Z(i,j) = 10. _d 0 * viscAh_Z(i,j)
-         ENDIF
-C- Customized code ends here
 
 C  BiHarmonic on Zeta points
          Alin=viscA4Z+viscA4Grid*L4rdt

--- a/global_oce_llc90/results/output.core2.txt
+++ b/global_oce_llc90/results/output.core2.txt
@@ -5,9 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67t
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Dec 15 02:22:54 EST 2020
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -166,9 +167,9 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># Continuous equation parameters
 (PID.TID 0000.0001) > &PARM01
-(PID.TID 0000.0001) > tRef               = 3*23.,3*22.,21.,2*20.,19.,2*18.,17.,2*16.,15.,14.,13.,
-(PID.TID 0000.0001) >                      12.,11.,2*9.,8.,7.,2*6.,2*5.,3*4.,3*3.,4*2.,12*1.,
-(PID.TID 0000.0001) > sRef               = 50*34.5,
+(PID.TID 0000.0001) > tRef = 3*23., 3*22., 21., 2*20., 19., 2*18., 17., 2*16., 15., 14., 13.,
+(PID.TID 0000.0001) >        12., 11., 2*9., 8., 7., 2*6., 2*5., 3*4., 3*3., 4*2., 12*1.,
+(PID.TID 0000.0001) > sRef = 50*34.5,
 (PID.TID 0000.0001) > no_slip_sides  = .TRUE.,
 (PID.TID 0000.0001) > no_slip_bottom = .TRUE.,
 (PID.TID 0000.0001) >#
@@ -193,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -258,8 +259,7 @@
 (PID.TID 0000.0001) ># dumpFreq    =31536000.0,
 (PID.TID 0000.0001) > monitorFreq = 3600.0,
 (PID.TID 0000.0001) > dumpInitAndLast = .TRUE.,
-(PID.TID 0000.0001) > adjMonitorFreq = 864000.0,
-(PID.TID 0000.0001) > pickupStrictlyMatch=.FALSE.,
+(PID.TID 0000.0001) >#pickupStrictlyMatch=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -283,7 +283,6 @@
 (PID.TID 0000.0001) > hydrogSaltFile ='some_S_atlas.bin',
 (PID.TID 0000.0001) > viscA4Dfile    ='viscA4Dfld_eccollc_90x50.bin',
 (PID.TID 0000.0001) > viscA4Zfile    ='viscA4Zfld_eccollc_90x50.bin',
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
@@ -658,58 +657,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -889,6 +888,7 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -971,24 +971,30 @@
 (PID.TID 0000.0001) // Parameter file "data.diagnostics"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Diagnostic Package Choices
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-(PID.TID 0000.0001) >#               > 0 : write time-average output every multiple of frequency (iter)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
 (PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-(PID.TID 0000.0001) >#                 when this entry is missing, select all common levels of this list
-(PID.TID 0000.0001) >#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file
-(PID.TID 0000.0001) >#                 for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#--------------------------------------------------------------------
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &diagnostics_list
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
 (PID.TID 0000.0001) >   dumpatlast = .TRUE.,
 (PID.TID 0000.0001) >   diagMdsDir = 'diags',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(1) = 2635200.0,
-(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 (PID.TID 0000.0001) >#stuff that is not quite state variables (and may not be quite
 (PID.TID 0000.0001) >#synchroneous) but are added here to reduce number of files
 (PID.TID 0000.0001) >                 'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -1121,19 +1127,24 @@
 (PID.TID 0000.0001) >#  filename(17) = 'state_2d_set2',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
 (PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 (PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-(PID.TID 0000.0001) >#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) > &DIAG_STATIS_PARMS
 (PID.TID 0000.0001) ># diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 (PID.TID 0000.0001) ># nSetRegMskFile=1,
@@ -1142,17 +1153,17 @@
 (PID.TID 0000.0001) ># val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 (PID.TID 0000.0001) >#                10.,11.,12.,13.,14.,15.,16.,17.
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-(PID.TID 0000.0001) >#                   'UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >#                   'THETA   ','SALT    ',
+(PID.TID 0000.0001) ># stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+(PID.TID 0000.0001) >#                      'UVEL    ','VVEL    ','WVEL    ',
+(PID.TID 0000.0001) >#                      'THETA   ','SALT    ',
 (PID.TID 0000.0001) >#    stat_fname(1)= 'dynStDiag',
 (PID.TID 0000.0001) >#     stat_freq(1)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 (PID.TID 0000.0001) >#                   10,11,12,13,14,15,16,17
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-(PID.TID 0000.0001) >#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-(PID.TID 0000.0001) >#                   'oceQnet ','oceSflux','oceFWflx',
+(PID.TID 0000.0001) ># stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+(PID.TID 0000.0001) >#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+(PID.TID 0000.0001) >#                      'oceQnet ','oceSflux','oceFWflx',
 (PID.TID 0000.0001) >#    stat_fname(2)= 'surfStDiag',
 (PID.TID 0000.0001) >#     stat_freq(2)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -1455,6 +1466,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1515,22 +1529,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -1707,6 +1730,7 @@
 (PID.TID 0000.0001)  error file = some_T_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = saltatlas
@@ -1716,6 +1740,7 @@
 (PID.TID 0000.0001)  error file = some_S_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -1914,7 +1939,7 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
-(PID.TID 0000.0001)                    1500
+(PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2649,8 +2674,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:         7220976
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2678,16 +2703,21 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2695,74 +2725,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   317
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   236 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   239 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   317 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   261 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   296 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   299 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   253 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   254 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   230 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   123 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   130 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVxHEFF , Parms: UU      M1 , mate:   289
-(PID.TID 0000.0001)   set mate pointer for diag #   289  ADVyHEFF , Parms: VV      M1 , mate:   288
-(PID.TID 0000.0001)   set mate pointer for diag #   290  DFxEHEFF , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  DFyEHEFF , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #   296  ADVxSNOW , Parms: UU      M1 , mate:   297
-(PID.TID 0000.0001)   set mate pointer for diag #   297  ADVySNOW , Parms: VV      M1 , mate:   296
-(PID.TID 0000.0001)   set mate pointer for diag #   298  DFxESNOW , Parms: UU      M1 , mate:   299
-(PID.TID 0000.0001)   set mate pointer for diag #   299  DFyESNOW , Parms: VV      M1 , mate:   298
-(PID.TID 0000.0001)   set mate pointer for diag #   253  SIuice   , Parms: UU      M1 , mate:   254
-(PID.TID 0000.0001)   set mate pointer for diag #   254  SIvice   , Parms: VV      M1 , mate:   253
+(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
+(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
+(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
+(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
+(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
+(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiX  , Parms: UU      LR , mate:   230
-(PID.TID 0000.0001)   set mate pointer for diag #   230  GM_PsiY  , Parms: VV      LR , mate:   229
-(PID.TID 0000.0001)   set mate pointer for diag #   123  DFxE_TH  , Parms: UU      MR , mate:   124
-(PID.TID 0000.0001)   set mate pointer for diag #   124  DFyE_TH  , Parms: VV      MR , mate:   123
-(PID.TID 0000.0001)   set mate pointer for diag #   120  ADVx_TH  , Parms: UU      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   121  ADVy_TH  , Parms: VV      MR , mate:   120
-(PID.TID 0000.0001)   set mate pointer for diag #   130  DFxE_SLT , Parms: UU      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   131  DFyE_SLT , Parms: VV      MR , mate:   130
-(PID.TID 0000.0001)   set mate pointer for diag #   127  ADVx_SLT , Parms: UU      MR , mate:   128
-(PID.TID 0000.0001)   set mate pointer for diag #   128  ADVy_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
+(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
+(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
+(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
+(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
+(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
+(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
+(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2845,8 +2875,95 @@
 (PID.TID 0000.0001)     4 @  2.000000000000000E+00,             /* K = 35: 38 */
 (PID.TID 0000.0001)    12 @  1.000000000000000E+00              /* K = 39: 50 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3041,17 +3158,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -3059,10 +3179,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3084,7 +3204,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -3093,7 +3213,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -3254,8 +3374,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3272,7 +3392,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3309,8 +3429,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3325,6 +3445,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -3376,7 +3499,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
 (PID.TID 0000.0001)                       0
@@ -3770,47 +3893,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -4599,7 +4681,9 @@
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
-(PID.TID 0000.0001) CTRL_CHECK: #define ALLOW_CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) etaday defined by gencost   0
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
@@ -5039,42 +5123,42 @@
  cg2d: Sum(rhs),rhsMax =  -2.89667992072702E-01  1.31165947868857E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.78965985889577E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.32917826176573E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.32917826052206E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5901944630486E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234117039475E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100217402230E-04
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234117039476E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100217402231E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379286666464E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433022553220E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433022553217E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5739352778241E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4879234606579E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728482806794E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359397594635E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383865238917E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359397602868E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383865005086E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5873393006783E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5773119177539E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5461075869997E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838093156724E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931298859374E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838093146008E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931300081183E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8989891142390E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251161206207E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434115624190E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213740921818E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987533658172E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434115624202E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213740883918E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987533186399E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1222710237771E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002308883004E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920380579600E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366232204255E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3007629665054E-05
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366232204328E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3007629995277E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699562851827E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0288920744280E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610141679E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184137902449E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2201159717362E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184137902046E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2201159730884E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3210309404514E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8258516668232E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7380840216567E+01
@@ -5109,16 +5193,16 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7474740302065E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691393705763E-05
 (PID.TID 0000.0001) %MON ke_max                       =   9.9277088111487E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3333733928679E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3333733925461E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979035714E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.0937711709687E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.3293128553806E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292366E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292367E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525964211E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410398774E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729597539678E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636121021829E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410400831E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729597539734E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636121022092E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5162,24 +5246,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   8.7395092657237E-01
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -5.8535530089935E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.5409209925152E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.6115582142973E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.5228782843461E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.5409209925231E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.6115582142987E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.5228782843261E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   5.6070078317531E-01
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -6.4232352997070E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.0729257342986E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.7095342930890E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.7171874388500E-05
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.0729257342907E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.7095342930904E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.7171874388408E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.1058761351411E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5770376042287E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.2506779430364E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5569779768407E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0097863375832E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.2506779430269E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5569779768415E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0097863376290E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.1263204911274E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947255065370E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.0852240449975E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4932097476545E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834179825194E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.0852240449786E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4932097476532E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834179823525E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8143659315325E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6386292701266E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.9995680111159E-01
@@ -5207,14 +5291,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4450134252705E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157563660880E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0706584532814E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8870052460700E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8870052460710E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7619904334611E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4299743496945E-02
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4299743497818E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.5629559171084E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9581136089418E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6296948165746E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5123038472193E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5321681145013E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6296948165765E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5123038472181E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5321681145823E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8682981508973E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0258273948293E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689307363123E-08
@@ -5248,89 +5332,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.26224449285173E-01  1.27905011464686E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.36968525564745E+00
+ cg2d: Sum(rhs),rhsMax =  -4.26224449285407E-01  1.27905011464686E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.36968525444578E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.88805554805504E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.88805560858676E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852434736139E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371596791533E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433175005798E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239327125410E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6942880091022E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0991256867564E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8578922437945E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757981468902E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478414123166E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058774765170E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992069275896E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8026345978532E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9249868982799E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391077726581E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392536580732E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051687E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093851E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7369044932268E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668607885756E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568115553007E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852434731235E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371596791290E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433175005801E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239327123753E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6942880112635E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0991256867566E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8578922183793E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757981460814E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478414491192E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058782978138E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992069298777E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8026345979235E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9249868870607E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391077868694E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392544590096E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051681E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093392E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7369044959523E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668608153465E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568113840582E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1210551784620E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661235358E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072923E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260844996E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511358909989E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661235355E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072924E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260846136E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511367264378E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697156897789E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0318799939218E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609342233E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184382318668E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1927612566019E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184382329828E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1927616531542E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3096929610956E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3350613557702E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6826178319599E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3588565792299E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2383552697819E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6826178319498E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3588565792310E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2383552697863E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1828127219075E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407189623652E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1397080465376E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2220667011185E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   4.8444674164820E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   4.8444674164819E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1531082093213E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0960037150203E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6666033635545E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6622027319071E-07
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0960037150221E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6666033635551E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6622027319137E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   8.6356523115538E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3148155983243E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5759732717209E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.6593057914487E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8745796949035E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5759732717289E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.6593057914501E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8745796948952E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   6.1945781064940E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -6.2931863274540E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8243075091970E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7333547489698E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1057887027860E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995059473963E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1110973558916E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419828E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3060883215453E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327809880471E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312347E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789215082E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521114065012E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8243075091888E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7333547489713E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1057887027857E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995059053510E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1110973947886E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419806E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3060882997654E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327809900543E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312324E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789215059E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521114072720E-05
 (PID.TID 0000.0001) %MON ke_max                       =   1.3313107009681E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.2348085581655E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   2.2348086306017E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979310002E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -1.5011413893878E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2237592678367E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2237592651162E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956128E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956593E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524076675E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720124213E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160975841835E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6606529792812E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720107348E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160975801283E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6606529620548E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5341,18 +5425,18 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1105978604936E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337399852364E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8142368719712E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1105978604925E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337399852367E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8142368719250E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6534876363404E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853214563015E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8422173157071E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6534876363413E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853214563016E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8422173157258E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4809172584734E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9217617520536E-01
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9217617520535E-01
 (PID.TID 0000.0001) %MON seaice_area_del2             =   2.4358758997561E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8282464626234E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
@@ -5373,25 +5457,25 @@
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     3
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   9.2344675752536E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.6473925163848E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.6381822052016E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9198891687828E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.7897002557173E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.1973395318439E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.6473925163909E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.6381822052088E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9198891687884E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.7897002556912E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.1973395318396E-01
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -6.9669975184919E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.1709856671496E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1143958794301E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0215487212847E-05
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.1709856671420E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1143958794330E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0215487212600E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.1371226656589E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5759648457271E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078477102552E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342513367E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564288754270E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961534E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078477102269E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342513427E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564288755256E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961404E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1959313010779E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967983900E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671552486E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2983094238063E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967983395E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671552496E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2983094236237E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8377804165155E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7300123195215E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.9731919914113E-01
@@ -5418,15 +5502,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3049237339092E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4452384486965E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5090022723799E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0610391612381E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867058504223E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7589415393227E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4265980499213E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.7443598489602E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.3273191857047E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6633819793307E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5611002593074E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6183286036107E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0610391612379E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867058504251E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7589415393265E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4265980500492E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.7443598489472E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.3273191857038E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6633819793358E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5611002593109E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6183286037807E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8674614663454E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0306894204118E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689156069507E-08
@@ -5460,89 +5544,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.59284749024853E-01  1.25698027958140E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.10916377493572E+00
+ cg2d: Sum(rhs),rhsMax =  -5.59284749032712E-01  1.25698027958438E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.10916376186209E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.57975926098017E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.57975907859729E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514671586E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125940943667E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560542600789E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068862052260E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6892154278092E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5258375534461E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2150974702655E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646948963765E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820777186310E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8424610141733E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529363E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1326532725269E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354414231935E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819336948580E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6561559641888E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366748814E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851198009E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2071679224430E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769612264519E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161277247217E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514672310E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125941060680E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560542601180E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068862026121E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6892154340857E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5258371800005E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2150972780396E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646948941946E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820779321470E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8424643069548E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529039E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1326532725175E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354413578503E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819336841862E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6561578076241E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366748209E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851166853E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2071680682799E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769604881537E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161276219507E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1205582170152E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920323728E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137737E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315520953E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857734614587E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920323719E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137739E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315522436E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857746187128E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694681496378E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0349724301766E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608743590E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184629423732E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1661429300561E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3067391886758E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.0717968736832E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5891712494932E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3742336389010E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2008723221747E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184629437159E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1661433290067E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3067391886893E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.0717968736748E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5891712494344E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3742336389064E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2008723232545E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409268140178E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1365543464802E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2152801340428E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.8661626089864E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1243140563182E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0372392375681E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6379084600475E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5177564634215E-07
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1365543464803E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2152801340304E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.8661626089838E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1243140556992E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0372392376771E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6379084601073E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5177564682895E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   9.1348105208740E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.9128795491040E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.6894462327042E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9711363433179E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1314957051265E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.6912046022927E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.9128795216288E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.6894462330343E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9711363433304E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1314957164115E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.6912046025137E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -6.9128743129779E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9466947730978E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1311395488567E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9557858448475E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3877148676986E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0042614032549E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316524489E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6122015961010E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5032837765835E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2601661691139E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372788060E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452282915046E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.6804276849207E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.0314800095849E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9466947733558E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1311395488824E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9557858483769E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3877147053167E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0042615142087E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316522506E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6122014313696E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5032839077019E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2601661689071E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372785971E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452282912779E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.6804274836495E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.0314803360943E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979572532E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7464980459811E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4422500774177E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7464979737729E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4422500773816E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876465154E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876467129E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523225355E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196495671E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026206957180E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6681477364215E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196393414E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026206757038E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6681477701189E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5553,29 +5637,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1036451345033E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3467928816804E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8139477496373E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1036451350238E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3467928816647E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8139477681837E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6720063493031E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956529998254E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8870250173705E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6720063491819E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956529998029E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8870249866809E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713013021421E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9191243154956E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4226116862837E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713013021417E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9191243154946E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4226116864932E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8277576041862E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4582083731117E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2521074060323E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6950039478407E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4582083731112E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2521074060320E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6950039478397E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8059157443754E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4917296182999E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5187760946156E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9570095063081E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4917296183000E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5187760946152E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9570095063642E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5584,26 +5668,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   9.5970547637498E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.4364361535011E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4894531033354E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8160221278311E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6664102156943E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.4453638013585E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.5031145425417E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2253457530108E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0377375911198E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.9870198905387E-05
+(PID.TID 0000.0001) %MON exf_ustress_max              =   9.5970547637497E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.4364361535134E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4894531034865E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8160221279484E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6664102180652E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.4453638013316E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.5031145425415E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2253457528668E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0377375911675E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.9870198916589E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.1048789532727E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5711805917316E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516930028217E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794438496001E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532605923958E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877179676E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5711805917318E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516930026708E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794438497433E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532605930542E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877178523E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1953168675345E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688489734690E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941368574309E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777782212E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688489731498E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941368575110E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777782093E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8655087463369E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7050055040743E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.8836561680071E-01
@@ -5630,15 +5714,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2992477109139E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4444818183202E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5023324034258E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530496702870E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423782866E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322378589E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236191603636E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865976002E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945879E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611999182E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460849297625E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5994549294861E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530496702800E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423782669E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322377909E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236191605282E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865974849E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945807E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611999501E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460849298917E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5994549303747E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8666247817934E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0355514459942E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689004775892E-08
@@ -5672,89 +5756,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -6.90938017659009E-01  1.23313674956454E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.04940086917227E+00
+ cg2d: Sum(rhs),rhsMax =  -6.90938016339523E-01  1.23313674960492E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.04940080733895E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   7.05019137777478E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.05019234270238E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558351740817E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368821650075E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577657819579E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793084309468E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6741838523659E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8934443141446E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690531853E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274930418386E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837433728828E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8724538861874E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399850241E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8640460627234E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303086157678E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662402855206E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373070498482E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1886122271728E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589464807E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9968458090560E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191389627829E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854468190050E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558351744362E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368821226311E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577657752796E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793084344680E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6741838504005E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8934450164746E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690540225E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274930534958E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837440695630E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8724608665229E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399849301E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8640451417633E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303083317698E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662401152285E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373105094632E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1886122269183E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589366813E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9968463500908E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191352785732E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854464718170E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1199063567507E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001246647E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901083E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404808447E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215801689019E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692092293853E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001246601E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901086E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404809968E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215814659541E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692092293852E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0380536133796E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608317438E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873326929E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416948215406E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027821997196E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0049661779352E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396670488786E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662368499619E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577751351339E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873339059E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416950975670E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027821997173E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0050559357388E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396670551141E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662368516261E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577753998952E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411340663931E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336243105062E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2089859046048E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1352437309980E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1118162592056E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057254333729E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013330085089E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699459544960E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948883745E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281781195019E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5343780828132E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8718909599457E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9514278266145E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.8999414001043E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.4686855380669E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0399621459653E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0552330030018E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8397381214993E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5093307423133E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596316045347E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472424421E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8654801685244E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1462524953036E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378196903E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502551846E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3418656287538E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0680658492667E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.7587379506196E-04
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336243105060E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2089859042887E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1352437325556E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1118162547741E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057254141708E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013330260582E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699471672378E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948883251E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281781555663E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5343781147238E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8718909788553E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9514290889742E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.8999414025698E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.4686855380668E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0399621453203E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0552330020920E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8397379902916E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5093307150614E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596315435268E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472416069E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8654798554186E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1462528787395E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378188190E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502543054E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3418656395235E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.0680659200977E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.7587388842522E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979827701E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9652319392867E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6835037986713E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9652318616986E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6835037865793E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661214268E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661219329E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523297139E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776684637E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2768015421387E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5069041490289E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776427130E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2768015121374E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5069042876617E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5765,29 +5849,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0681720475874E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235175652022E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7432456129586E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0681720427778E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235175642068E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7432456161347E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7213161994624E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668003200610E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8734653271669E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7213161976876E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668003203061E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8734652994862E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625517440782E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9166195377040E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4008645336855E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625517441311E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9166195377252E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4008645329673E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8272812516990E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4505975778354E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2500386292812E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6809758274535E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8026020681496E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4505975779099E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2500386293406E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6809758313479E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8026020681501E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4827966528841E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5159090183807E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9421815310912E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4827966529131E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5159090184031E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9421815332458E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5796,26 +5880,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     5
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945457435E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083194342E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417944700220E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770802498E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075023261181E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546217762E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.0611177970479E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2507507966693E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0258392993468E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0158959986710E-05
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945457394E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083193200E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417944703013E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770804210E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075023288078E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546216834E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.0611177970474E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2507507964553E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0258392994211E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0158959998239E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0733654980685E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5670986344276E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688226338486E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355957763E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535214649433E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859538668E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5670986344299E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688226336986E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355959752E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535214652726E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859535780E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947146923263E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068548371366E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846874330827E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2551448775027E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068548366173E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846874332109E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2551448766293E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8932370761583E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6799986886272E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.7941203446030E-01
@@ -5842,15 +5926,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2944037231979E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4438385083419E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4957462594537E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282924241E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704953913E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616014191E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205944885685E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165603252E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897167521E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750516467E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696632715E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5985774794193E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282923805E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704953250E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616012030E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205944879153E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165600364E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897167150E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750516987E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696635205E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5985774800126E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8657880972414E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0404134715766E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688853482276E-08
@@ -5884,89 +5968,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.20012503985305E-01  1.21310980028905E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.00015779387198E+00
+ cg2d: Sum(rhs),rhsMax =  -8.20012499907984E-01  1.21310980036511E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.00015725806016E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.53653170382514E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53654307985334E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942701611E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271662331655E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478709651864E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685261521794E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6636135977443E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0248193957896E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541711910E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555210156294E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547395159143E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7823521216205E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465044182410E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4807825947763E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830685124293E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926278023262E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873271727297E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046833137E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565099816E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4225697058463E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179480072882E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145361334270E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942705183E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271661496681E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478709445465E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685261958879E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6636135607121E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0248300255996E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541733400E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555210725407E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547411554636E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7823627285465E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465043575200E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4807822649774E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830677644376E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926272921291E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873315296839E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046827473E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565055150E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4225824306721E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179386226261E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145356698316E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192840140288E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880812235E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764895E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518610910E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553094856467E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880812149E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764894E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518612376E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553107715727E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689419470055E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410367180224E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031540E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185106027004E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1192318137090E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2993663703301E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0694712073661E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661666187991E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609628940944E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310947195056E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410367180225E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031539E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185106037687E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1192320120134E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2993663694807E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0694726236378E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661666318267E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609628945592E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310948066206E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413323769388E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1309077147019E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1874573655782E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.6713720828691E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0977178845127E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725506487277E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711209990463E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974581544736E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525521119213E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282618423683E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3651371793846E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8370223619840E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8838164780816E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.1085654947751E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453477811E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0860393104561E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0442255777539E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9139893257926E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3855255960904E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8787464474982E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808991551E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324250013370E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5654766239357E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177186640E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018233258E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992481284996E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.3692084537094E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3541821290062E-04
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1309077147007E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1874573646539E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.6713720752057E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0977178717458E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725506088216E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711210111122E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974585294805E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525521119196E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282621932868E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3651372396750E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8370223913933E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8838170071448E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.1085654964801E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453477809E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0860393236253E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0442255730860E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9139888370808E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3858989445520E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8787461330170E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808973012E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324246368809E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5654772042330E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177167284E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018213767E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992481889706E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.3692082965883E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3541843193575E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980078924E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1071784745449E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.8803882790055E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1071804512562E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.8803882152651E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629606113E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629616415E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523960980E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230149083526E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149948499110E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2102485833069E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230148623583E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149948610567E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2102488738766E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5977,29 +6061,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0319402299157E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849188331080E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5783100473278E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0319402165181E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849188318109E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5783097447108E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7254127421150E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180204533631E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7450247085895E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7254127291132E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180204540294E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7450245857400E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550169872933E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142986481911E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3758732277714E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550169876460E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142986483431E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3758732237080E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8268173253719E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4431170666831E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480686061811E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6675610226384E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7993114477009E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738900714651E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131654739613E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9269849290932E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4431170669139E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480686063409E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6675610321082E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7993114477027E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738900715356E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131654740143E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9269849339759E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6008,26 +6092,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0533610354386E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.0751292914301E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.1920978960960E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8121410526840E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6143336105361E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.9754450218530E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.6406961715395E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2475183258065E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0785986875697E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.1017497759294E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0425523058870E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5630237586444E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618379189698E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594408580E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585908512629E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171390081E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0533610355212E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.0751292909875E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.1920978964803E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8121410529023E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6143336135247E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.9754450216534E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.6406961715387E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2475183254527E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0785986876601E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.1017497768873E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0425523058869E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5630237586576E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618379193460E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594410676E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585908490795E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171384884E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1941211875677E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413624717E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346968635E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955676216E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413624457E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346970928E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955648205E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9209654059797E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6549918731801E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.7045845211988E-01
@@ -6053,16 +6137,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0853361081149E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2903940562447E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4433086702889E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4892373729994E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0379666254201E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692128183E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503490989077E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177228396306E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794722923E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007332204E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508372086E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867276412E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6172929955152E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4892373729992E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0379666252623E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692125787E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503490982577E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177228338941E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794717725E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007331149E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508372112E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867281265E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6172929940612E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8649514126894E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0452754971591E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688702188661E-08
@@ -6096,89 +6180,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.46889222966411E-01  1.19643084183855E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.42690787011374E-01
+ cg2d: Sum(rhs),rhsMax =  -9.46889216589065E-01  1.19643084184519E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.42689743468363E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.50650129824333E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.50650568652083E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217254669087E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719435068712E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0272942813124E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323746338049E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6590738766138E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5563475958738E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237903165E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4855007027724E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897756739560E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5529640655736E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588133026889E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2706239540508E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5638995631249E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582258917623E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2162533074190E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005455328E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237598384E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3921464055845E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503986949059E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138454608054E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217254679605E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719433610378E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0272942490252E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323747771123E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6590737926490E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5563482205762E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237943017E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4855008342748E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897788105129E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5529801672968E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588131847304E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2706232289067E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5638979131742E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582248632052E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2162585231953E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005447838E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237652005E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3921689664372E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503789542019E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138452846350E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192003518495E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554768369E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820984E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644690186E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9926997298779E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686687532167E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439365122669E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773864E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326476384E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989612566993E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962426406560E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237586444E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695411342484E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586492774236E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880490353397E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554768246E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820972E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644691613E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9927011031760E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686687532160E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439365122671E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773863E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326485719E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989613969667E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962426384871E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237586576E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695411454177E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586492738488E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880487754048E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415258347912E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284226097938E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1519842753402E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721998690333E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0834202897969E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420183119262E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456671242928E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902410600251E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820801748E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860893795746E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1906329460012E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8721499529764E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9730909960312E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.3236139930421E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074179730E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1033968177131E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0977289049197E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0614888042053E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0184039741347E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8038678936773E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462906209E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6242895320985E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7950472599854E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893514082169E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204892624E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430861657063E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9022263007693E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.7555789598863E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415258347915E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284226097868E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1519842728181E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721998567510E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0834202645362E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420182786342E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456670987521E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902402914519E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820802258E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860902453567E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1906330230139E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8721499700827E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9730914479829E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.3236139833806E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074179723E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1033968375463E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0977289009963E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0614879884653E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0188197871592E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8038775087146E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462879342E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6242888766917E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7950480610609E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893506563202E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204864421E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430863405085E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9022258340870E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.7555833744430E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980325991E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1823148674212E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0129286658310E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1823202747401E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0129285022779E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761383573E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761401788E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525020837E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228686132670E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867044568178E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9352606504590E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228685470495E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867045813593E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9352658481411E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6189,29 +6273,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5651344380876E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328572364114E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3455000487005E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5651344952538E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328572367401E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3454992831274E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6909669726304E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529434920992E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4805087686726E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6909669632771E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529434898902E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4805077514377E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465976555591E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120203208446E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3693977318104E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465976562460E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120203210846E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3693977238282E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8263657235874E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357570153209E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461921443209E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6546449525652E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960453001499E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357570156816E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461921445666E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6546449679040E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960453001533E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649925204554E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5105249753299E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9113383519538E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649925205755E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5105249753872E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9113383545470E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6220,26 +6304,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1024633416257E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.9099627996489E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.0390492427792E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9160983143519E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6924952827124E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   7.3777814127652E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9564202348694E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2150175254844E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1976381292544E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295594851E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124052922234E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5589638243903E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902941737E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020473349E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676965030654E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263103294E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1024633420394E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.9099627986049E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.0390492433383E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9160983145918E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6924952855180E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   7.3777814140913E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9564202348687E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2150175251965E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1976381293709E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295601258E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124052922230E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5589638244338E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902938739E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020476892E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676965009962E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263100727E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935326777510E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614708932E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510755608E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557589717100E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614698691E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510759225E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557589686286E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9486937358010E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6299850577329E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.6150486977946E-01
@@ -6265,16 +6349,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0852775148810E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2872206082251E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4428924291636E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828126125463E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187955167E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125018617E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477968459917E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150374032581E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433450464E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204530349E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732644617E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585884857E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495601732E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828126125454E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187950907E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125017453E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477968455857E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150373982772E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433443030E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204528265E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732645642E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585891134E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495581445E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8641147281375E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0501375227415E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688550895045E-08
@@ -6308,89 +6392,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.07163930774529E+00  1.18154306554588E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.79620609051991E-01
+ cg2d: Sum(rhs),rhsMax =  -1.07163930097040E+00  1.18154306531811E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.79619305093942E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.63002419902155E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.63002906235179E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744024599E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430418934785E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954813578696E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316032025739E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6539534032748E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0948074941030E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174821160E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279762056846E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802428454874E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184567919217E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401974320752E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8645063803974E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249549186340E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751667690101E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8592786730162E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182466049E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221636038E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4789080818208E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5981140716169E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926360670477E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190755067682E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013005477E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838145007E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772146946E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368734597783E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684631335885E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467138134820E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744049141E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430416663015E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954813235566E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316035322115E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6539532502284E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0948083043173E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174881937E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279764720371E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802479258554E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184587451165E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401972712825E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8645037530306E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249516803573E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751651095314E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8592849334184E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182460938E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221930209E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4785195958656E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5980770516792E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926356249528E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190755067681E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013005193E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144974E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772148340E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368749783911E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684631335866E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467138134827E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471389E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534628631E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803895160747E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929052701935E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5589638243903E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512291391572E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591356676788E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644488396817E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534636823E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803896136597E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929052691131E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5589638244338E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512291409249E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591356643914E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644485632510E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316192674E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261774969313E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521177473222E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834880870776E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0686889676525E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099013938255E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217401674213E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1168943939649E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890829575E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041593477718E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0050535083701E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9781684204300E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1372594962164E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522192230363E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423054707E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0845930343712E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2167341591374E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2289412940695E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7266986191192E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2780342028243E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286187724878E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9056318750457E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4680619917145E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4027773935373E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361437430352E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228879481024E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.3881788058836E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9530894969802E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316192677E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261774969109E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521177431463E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834880748073E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0686889374843E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099013880380E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217401387260E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1168936059826E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890831426E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041609833235E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0050536051244E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9781684124419E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1372587004791E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522192059010E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423054699E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0845930690300E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2167341580302E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2289402968212E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7271265332008E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2780430894470E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286172811301E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9056308998742E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4680600683147E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4027759132001E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361422481149E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228883210974E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.3881769238969E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9530970603763E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980569234E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2704585230642E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0989621660631E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2704623430256E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0989614626103E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000806323E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261435E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228398817143E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872299568304E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3278817293086E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000835023E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261434E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228397939195E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872334523569E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3278903076638E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6401,29 +6485,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2472955033343E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679207381849E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9959730605830E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2472961010053E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679207384468E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9959723884241E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6324083743171E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744168219232E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0136908041602E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6324083857105E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744168135454E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0136905154269E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399681178127E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099251634654E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3408725576810E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266841299E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399681187247E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099251637105E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3408725409458E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266841298E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285203779120E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443908021747E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6421982386884E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927940643366E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561953999788E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079865178147E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8953510104890E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285203782921E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443908024707E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6421982561711E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927940643434E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561954001976E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079865178436E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8953510046117E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6432,247 +6516,247 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.116967485547892D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.178494744282895D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.116966764041153D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.178494336630211D+05 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.295462229830787D+05
+(PID.TID 0000.0001)  --> fc               = 0.295461100671364D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.111806005955401D+04
-(PID.TID 0000.0001)  global fc =  0.295462229830787D+05
+(PID.TID 0000.0001)   local fc =  0.111803527416655D+04
+(PID.TID 0000.0001)  global fc =  0.295461100671364D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   283.12677510082722
-(PID.TID 0000.0001)         System time:   12.680083282291889
-(PID.TID 0000.0001)     Wall clock time:   321.50366878509521
+(PID.TID 0000.0001)           User time:   173.52026906237006
+(PID.TID 0000.0001)         System time:   12.111337155103683
+(PID.TID 0000.0001)     Wall clock time:   190.94166302680969
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   7.5626209750771523
-(PID.TID 0000.0001)         System time:   2.2441820353269577
-(PID.TID 0000.0001)     Wall clock time:   10.976119995117188
+(PID.TID 0000.0001)           User time:   4.5002089776098728
+(PID.TID 0000.0001)         System time:   2.4259709417819977
+(PID.TID 0000.0001)     Wall clock time:   7.2815248966217041
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   275.56401538848877
-(PID.TID 0000.0001)         System time:   10.435862302780151
-(PID.TID 0000.0001)     Wall clock time:   310.52742195129395
+(PID.TID 0000.0001)           User time:   169.02000522613525
+(PID.TID 0000.0001)         System time:   9.6853058338165283
+(PID.TID 0000.0001)     Wall clock time:   183.66003012657166
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   21.619200229644775
-(PID.TID 0000.0001)         System time:   4.9981217384338379
-(PID.TID 0000.0001)     Wall clock time:   28.488234996795654
+(PID.TID 0000.0001)           User time:   11.213326930999756
+(PID.TID 0000.0001)         System time:   4.0189146995544434
+(PID.TID 0000.0001)     Wall clock time:   15.416032791137695
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   253.94476509094238
-(PID.TID 0000.0001)         System time:   5.4377264976501465
-(PID.TID 0000.0001)     Wall clock time:   282.03913021087646
+(PID.TID 0000.0001)           User time:   157.80664062500000
+(PID.TID 0000.0001)         System time:   5.6663622856140137
+(PID.TID 0000.0001)     Wall clock time:   168.24393415451050
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1744632720947266
-(PID.TID 0000.0001)         System time:   7.2426795959472656E-003
-(PID.TID 0000.0001)     Wall clock time:   2.3113713264465332
+(PID.TID 0000.0001)           User time:   1.8532695770263672
+(PID.TID 0000.0001)         System time:   1.1106491088867188E-002
+(PID.TID 0000.0001)     Wall clock time:   1.8919718265533447
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   7.1525573730468750E-003
-(PID.TID 0000.0001)         System time:   3.0183792114257812E-004
-(PID.TID 0000.0001)     Wall clock time:   7.4720382690429688E-003
+(PID.TID 0000.0001)           User time:   5.5847167968750000E-003
+(PID.TID 0000.0001)         System time:   2.6845932006835938E-004
+(PID.TID 0000.0001)     Wall clock time:   5.8588981628417969E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   243.17802619934082
-(PID.TID 0000.0001)         System time:   4.2128458023071289
-(PID.TID 0000.0001)     Wall clock time:   269.04182982444763
+(PID.TID 0000.0001)           User time:   152.04429244995117
+(PID.TID 0000.0001)         System time:   4.0123305320739746
+(PID.TID 0000.0001)     Wall clock time:   157.65521168708801
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   243.17786979675293
-(PID.TID 0000.0001)         System time:   4.2128386497497559
-(PID.TID 0000.0001)     Wall clock time:   269.04162454605103
+(PID.TID 0000.0001)           User time:   152.04415321350098
+(PID.TID 0000.0001)         System time:   4.0123252868652344
+(PID.TID 0000.0001)     Wall clock time:   157.65506815910339
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0972385406494141
-(PID.TID 0000.0001)         System time:   1.9931793212890625E-004
-(PID.TID 0000.0001)     Wall clock time:   3.2587938308715820
+(PID.TID 0000.0001)           User time:   2.7697906494140625
+(PID.TID 0000.0001)         System time:   1.5830993652343750E-004
+(PID.TID 0000.0001)     Wall clock time:   2.7728245258331299
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1333713531494141
-(PID.TID 0000.0001)         System time:   3.5838603973388672E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4059324264526367
+(PID.TID 0000.0001)           User time:   1.4251537322998047
+(PID.TID 0000.0001)         System time:   5.4712295532226562E-002
+(PID.TID 0000.0001)     Wall clock time:   1.5234668254852295
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8933849334716797
-(PID.TID 0000.0001)         System time:   2.9339313507080078E-002
-(PID.TID 0000.0001)     Wall clock time:   3.4295639991760254
+(PID.TID 0000.0001)           User time:   1.1679973602294922
+(PID.TID 0000.0001)         System time:   5.7645797729492188E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4533376693725586
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.8565578460693359
-(PID.TID 0000.0001)         System time:   2.9305458068847656E-002
-(PID.TID 0000.0001)     Wall clock time:   3.3926966190338135
+(PID.TID 0000.0001)           User time:   1.1674976348876953
+(PID.TID 0000.0001)         System time:   5.7632923126220703E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4528529644012451
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.1934509277343750E-004
-(PID.TID 0000.0001)         System time:   2.3841857910156250E-005
-(PID.TID 0000.0001)     Wall clock time:   2.3651123046875000E-004
+(PID.TID 0000.0001)           User time:   9.3460083007812500E-005
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.9420547485351562E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32266807556152344
-(PID.TID 0000.0001)         System time:   1.0452270507812500E-003
-(PID.TID 0000.0001)     Wall clock time:  0.37417984008789062
+(PID.TID 0000.0001)           User time:  0.15634918212890625
+(PID.TID 0000.0001)         System time:   1.0972023010253906E-002
+(PID.TID 0000.0001)     Wall clock time:  0.17174077033996582
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12877655029296875
-(PID.TID 0000.0001)         System time:   3.5619735717773438E-004
-(PID.TID 0000.0001)     Wall clock time:  0.15315032005310059
+(PID.TID 0000.0001)           User time:  0.10628890991210938
+(PID.TID 0000.0001)         System time:   2.6988983154296875E-004
+(PID.TID 0000.0001)     Wall clock time:  0.10662603378295898
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   53.344512939453125
-(PID.TID 0000.0001)         System time:  0.11373186111450195
-(PID.TID 0000.0001)     Wall clock time:   56.581757545471191
+(PID.TID 0000.0001)           User time:   28.639062881469727
+(PID.TID 0000.0001)         System time:  0.20505666732788086
+(PID.TID 0000.0001)     Wall clock time:   29.418332576751709
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   19.359794616699219
-(PID.TID 0000.0001)         System time:   3.8746833801269531E-002
-(PID.TID 0000.0001)     Wall clock time:   20.332746267318726
+(PID.TID 0000.0001)           User time:   7.7056198120117188
+(PID.TID 0000.0001)         System time:   5.2281379699707031E-002
+(PID.TID 0000.0001)     Wall clock time:   7.8048000335693359
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   18.075149536132812
-(PID.TID 0000.0001)         System time:   3.3699512481689453E-002
-(PID.TID 0000.0001)     Wall clock time:   19.004469394683838
+(PID.TID 0000.0001)           User time:   7.0710582733154297
+(PID.TID 0000.0001)         System time:   4.4823169708251953E-002
+(PID.TID 0000.0001)     Wall clock time:   7.1406469345092773
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   11.582721710205078
-(PID.TID 0000.0001)         System time:   3.3336162567138672E-002
-(PID.TID 0000.0001)     Wall clock time:   12.320916414260864
+(PID.TID 0000.0001)           User time:   6.1297397613525391
+(PID.TID 0000.0001)         System time:   7.5087547302246094E-002
+(PID.TID 0000.0001)     Wall clock time:   6.6881949901580811
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   40.558212280273438
-(PID.TID 0000.0001)         System time:   2.0729541778564453E-002
-(PID.TID 0000.0001)     Wall clock time:   44.381767272949219
+(PID.TID 0000.0001)           User time:   28.772338867187500
+(PID.TID 0000.0001)         System time:   4.5954227447509766E-002
+(PID.TID 0000.0001)     Wall clock time:   28.899775266647339
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3210029602050781
-(PID.TID 0000.0001)         System time:   2.2459030151367188E-004
-(PID.TID 0000.0001)     Wall clock time:   3.4496779441833496
+(PID.TID 0000.0001)           User time:   1.2260723114013672
+(PID.TID 0000.0001)         System time:   3.5467147827148438E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2328228950500488
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.914367675781250
-(PID.TID 0000.0001)         System time:   1.0989189147949219E-002
-(PID.TID 0000.0001)     Wall clock time:   15.101436138153076
+(PID.TID 0000.0001)           User time:   4.3197345733642578
+(PID.TID 0000.0001)         System time:   1.5244483947753906E-002
+(PID.TID 0000.0001)     Wall clock time:   4.3614666461944580
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.88034057617187500
-(PID.TID 0000.0001)         System time:   4.8255920410156250E-004
-(PID.TID 0000.0001)     Wall clock time:  0.93047523498535156
+(PID.TID 0000.0001)           User time:  0.58784103393554688
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.58785700798034668
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3827476501464844
-(PID.TID 0000.0001)         System time:   3.4761428833007812E-004
-(PID.TID 0000.0001)     Wall clock time:   2.6163821220397949
+(PID.TID 0000.0001)           User time:   1.3104114532470703
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.3135838508605957
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18024826049804688
-(PID.TID 0000.0001)         System time:   5.2928924560546875E-005
-(PID.TID 0000.0001)     Wall clock time:  0.18070197105407715
+(PID.TID 0000.0001)           User time:   9.3795776367187500E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   9.3817472457885742E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9407386779785156
-(PID.TID 0000.0001)         System time:   2.3452281951904297E-002
-(PID.TID 0000.0001)     Wall clock time:   2.1577587127685547
+(PID.TID 0000.0001)           User time:   1.9169406890869141
+(PID.TID 0000.0001)         System time:   4.4498443603515625E-002
+(PID.TID 0000.0001)     Wall clock time:   1.9647758007049561
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   45.818351745605469
-(PID.TID 0000.0001)         System time:   4.8033237457275391E-002
-(PID.TID 0000.0001)     Wall clock time:   49.980439901351929
+(PID.TID 0000.0001)           User time:   31.039337158203125
+(PID.TID 0000.0001)         System time:   6.4766407012939453E-002
+(PID.TID 0000.0001)     Wall clock time:   31.289303779602051
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2207031250000000E-004
+(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
 (PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.1229515075683594E-004
+(PID.TID 0000.0001)     Wall clock time:   9.0599060058593750E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.178737640380859
-(PID.TID 0000.0001)         System time:   3.6282539367675781E-003
-(PID.TID 0000.0001)     Wall clock time:   14.009415149688721
+(PID.TID 0000.0001)           User time:   6.3383331298828125
+(PID.TID 0000.0001)         System time:   4.7054290771484375E-003
+(PID.TID 0000.0001)     Wall clock time:   6.3559491634368896
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.7738037109375000E-005
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.6797943115234375E-005
+(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
+(PID.TID 0000.0001)         System time:   5.2452087402343750E-006
+(PID.TID 0000.0001)     Wall clock time:   8.2492828369140625E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   15.460208892822266
-(PID.TID 0000.0001)         System time:   2.3029050827026367
-(PID.TID 0000.0001)     Wall clock time:   20.543206453323364
+(PID.TID 0000.0001)           User time:   6.3504219055175781
+(PID.TID 0000.0001)         System time:   1.9460525512695312
+(PID.TID 0000.0001)     Wall clock time:   8.3870100975036621
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7680664062500000
-(PID.TID 0000.0001)         System time:   1.6008205413818359
-(PID.TID 0000.0001)     Wall clock time:   7.0537669658660889
+(PID.TID 0000.0001)           User time:   2.3364181518554688
+(PID.TID 0000.0001)         System time:   1.5584478378295898
+(PID.TID 0000.0001)     Wall clock time:   4.1768958568572998
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.4854431152343750
-(PID.TID 0000.0001)         System time:  0.20474243164062500
-(PID.TID 0000.0001)     Wall clock time:   1.7439811229705811
+(PID.TID 0000.0001)           User time:  0.65492248535156250
+(PID.TID 0000.0001)         System time:  0.19482421875000000
+(PID.TID 0000.0001)     Wall clock time:   1.2437920570373535
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1291503906250000E-003
-(PID.TID 0000.0001)         System time:   4.8637390136718750E-005
-(PID.TID 0000.0001)     Wall clock time:   1.1670589447021484E-003
+(PID.TID 0000.0001)           User time:   6.2561035156250000E-004
+(PID.TID 0000.0001)         System time:   4.0054321289062500E-005
+(PID.TID 0000.0001)     Wall clock time:   6.7400932312011719E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.7172546386718750
-(PID.TID 0000.0001)         System time:  0.96452713012695312
-(PID.TID 0000.0001)     Wall clock time:   8.3237500190734863
+(PID.TID 0000.0001)           User time:   3.2443695068359375
+(PID.TID 0000.0001)         System time:   1.4460229873657227
+(PID.TID 0000.0001)     Wall clock time:   7.4406640529632568
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   4.9929504394531250
-(PID.TID 0000.0001)         System time:  0.88866806030273438
-(PID.TID 0000.0001)     Wall clock time:   6.4343290328979492
+(PID.TID 0000.0001)           User time:   2.4296112060546875
+(PID.TID 0000.0001)         System time:   1.2420768737792969
+(PID.TID 0000.0001)     Wall clock time:   6.2908709049224854
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.7242431640625000
-(PID.TID 0000.0001)         System time:   7.5858116149902344E-002
-(PID.TID 0000.0001)     Wall clock time:   1.8893752098083496
+(PID.TID 0000.0001)           User time:  0.81468200683593750
+(PID.TID 0000.0001)         System time:  0.20394325256347656
+(PID.TID 0000.0001)     Wall clock time:   1.1497368812561035
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.4841308593750000E-002
-(PID.TID 0000.0001)         System time:   4.0054321289062500E-005
-(PID.TID 0000.0001)     Wall clock time:   2.4893045425415039E-002
+(PID.TID 0000.0001)           User time:   0.0000000000000000
+(PID.TID 0000.0001)         System time:   1.7299652099609375E-003
+(PID.TID 0000.0001)     Wall clock time:   2.1998882293701172E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6811,9 +6895,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          37342
+(PID.TID 0000.0001) //            No. barriers =          37144
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          37342
+(PID.TID 0000.0001) //     Total barrier spins =          37144
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.ecco_v4.txt
+++ b/global_oce_llc90/results/output.ecco_v4.txt
@@ -5,9 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67t
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Dec 15 02:22:54 EST 2020
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -166,9 +167,9 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># Continuous equation parameters
 (PID.TID 0000.0001) > &PARM01
-(PID.TID 0000.0001) > tRef               = 3*23.,3*22.,21.,2*20.,19.,2*18.,17.,2*16.,15.,14.,13.,
-(PID.TID 0000.0001) >                      12.,11.,2*9.,8.,7.,2*6.,2*5.,3*4.,3*3.,4*2.,12*1.,
-(PID.TID 0000.0001) > sRef               = 50*34.5,
+(PID.TID 0000.0001) > tRef = 3*23., 3*22., 21., 2*20., 19., 2*18., 17., 2*16., 15., 14., 13.,
+(PID.TID 0000.0001) >        12., 11., 2*9., 8., 7., 2*6., 2*5., 3*4., 3*3., 4*2., 12*1.,
+(PID.TID 0000.0001) > sRef = 50*34.5,
 (PID.TID 0000.0001) > no_slip_sides  = .TRUE.,
 (PID.TID 0000.0001) > no_slip_bottom = .TRUE.,
 (PID.TID 0000.0001) >#
@@ -193,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -264,7 +265,6 @@
 (PID.TID 0000.0001) ># dumpFreq    =31536000.0,
 (PID.TID 0000.0001) > monitorFreq = 3600.0,
 (PID.TID 0000.0001) > dumpInitAndLast = .TRUE.,
-(PID.TID 0000.0001) > adjMonitorFreq = 864000.0,
 (PID.TID 0000.0001) > pickupStrictlyMatch=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -289,7 +289,6 @@
 (PID.TID 0000.0001) > hydrogSaltFile ='some_S_atlas.bin',
 (PID.TID 0000.0001) > viscA4Dfile    ='viscA4Dfld_eccollc_90x50.bin',
 (PID.TID 0000.0001) > viscA4Zfile    ='viscA4Zfld_eccollc_90x50.bin',
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
@@ -628,58 +627,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -864,6 +863,7 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -967,7 +967,12 @@
 (PID.TID 0000.0001) > gencost_posproc_i(1,6)=300,
 (PID.TID 0000.0001) > gencost_outputlevel(6)=0,
 (PID.TID 0000.0001) > mult_gencost(6) = 0.,
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#- To use cost_gencost_bpv4, needs to switch name to 'bpv4-grace':
+(PID.TID 0000.0001) ># gencost_name(6) = 'bpv4-grace',
+(PID.TID 0000.0001) >#- the hard-coded (before PR 693) values used in gencost_bpv4 for smooth_basic2D calls:
+(PID.TID 0000.0001) ># gencost_posproc_i(1,6)=3000,
+(PID.TID 0000.0001) ># gencost_posproc_r(1,6)=3.E+5,
+(PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > gencost_avgperiod(7)  = 'month',
 (PID.TID 0000.0001) > gencost_barfile(7) = 'm_theta_mon',
 (PID.TID 0000.0001) > gencost_datafile(7) = 'some_T_atlas.bin',
@@ -1121,24 +1126,30 @@
 (PID.TID 0000.0001) // Parameter file "data.diagnostics"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Diagnostic Package Choices
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-(PID.TID 0000.0001) >#               > 0 : write time-average output every multiple of frequency (iter)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
 (PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-(PID.TID 0000.0001) >#                 when this entry is missing, select all common levels of this list
-(PID.TID 0000.0001) >#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file
-(PID.TID 0000.0001) >#                 for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#--------------------------------------------------------------------
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &diagnostics_list
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
 (PID.TID 0000.0001) >   dumpatlast = .TRUE.,
 (PID.TID 0000.0001) >   diagMdsDir = 'diags',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(1) = 2635200.0,
-(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 (PID.TID 0000.0001) >#stuff that is not quite state variables (and may not be quite
 (PID.TID 0000.0001) >#synchroneous) but are added here to reduce number of files
 (PID.TID 0000.0001) >                 'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -1271,19 +1282,24 @@
 (PID.TID 0000.0001) >#  filename(17) = 'state_2d_set2',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
 (PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 (PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-(PID.TID 0000.0001) >#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) > &DIAG_STATIS_PARMS
 (PID.TID 0000.0001) ># diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 (PID.TID 0000.0001) ># nSetRegMskFile=1,
@@ -1292,17 +1308,17 @@
 (PID.TID 0000.0001) ># val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 (PID.TID 0000.0001) >#                10.,11.,12.,13.,14.,15.,16.,17.
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-(PID.TID 0000.0001) >#                   'UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >#                   'THETA   ','SALT    ',
+(PID.TID 0000.0001) ># stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+(PID.TID 0000.0001) >#                      'UVEL    ','VVEL    ','WVEL    ',
+(PID.TID 0000.0001) >#                      'THETA   ','SALT    ',
 (PID.TID 0000.0001) >#    stat_fname(1)= 'dynStDiag',
 (PID.TID 0000.0001) >#     stat_freq(1)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 (PID.TID 0000.0001) >#                   10,11,12,13,14,15,16,17
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-(PID.TID 0000.0001) >#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-(PID.TID 0000.0001) >#                   'oceQnet ','oceSflux','oceFWflx',
+(PID.TID 0000.0001) ># stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+(PID.TID 0000.0001) >#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+(PID.TID 0000.0001) >#                      'oceQnet ','oceSflux','oceFWflx',
 (PID.TID 0000.0001) >#    stat_fname(2)= 'surfStDiag',
 (PID.TID 0000.0001) >#     stat_freq(2)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -1605,6 +1621,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1665,22 +1684,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -1861,6 +1889,7 @@
 (PID.TID 0000.0001)  preprocess = clim
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 8) = saltclim
@@ -1871,6 +1900,7 @@
 (PID.TID 0000.0001)  preprocess = clim
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(11) = sshv4-mdt
@@ -1881,6 +1911,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag = -1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(15) = sshv4-lsc
@@ -1890,6 +1921,7 @@
 (PID.TID 0000.0001)  posprocess = smooth
 (PID.TID 0000.0001)  gencost_flag = -1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(16) = sshv4-gmsl
@@ -1898,6 +1930,7 @@
 (PID.TID 0000.0001)  error file =
 (PID.TID 0000.0001)  gencost_flag = -1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost(17) = sss_repeat
@@ -1907,6 +1940,7 @@
 (PID.TID 0000.0001)  error file = sigma_surf_0p5.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  0
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  3
 (PID.TID 0000.0001)  skip barfile write =  T
 (PID.TID 0000.0001) 
@@ -2106,7 +2140,7 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
-(PID.TID 0000.0001)                    1500
+(PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2841,8 +2875,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:         7220976
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2870,16 +2904,21 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2887,74 +2926,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   317
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   236 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   239 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   317 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   261 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   296 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   299 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   253 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   254 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   230 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   123 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   130 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVxHEFF , Parms: UU      M1 , mate:   289
-(PID.TID 0000.0001)   set mate pointer for diag #   289  ADVyHEFF , Parms: VV      M1 , mate:   288
-(PID.TID 0000.0001)   set mate pointer for diag #   290  DFxEHEFF , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  DFyEHEFF , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #   296  ADVxSNOW , Parms: UU      M1 , mate:   297
-(PID.TID 0000.0001)   set mate pointer for diag #   297  ADVySNOW , Parms: VV      M1 , mate:   296
-(PID.TID 0000.0001)   set mate pointer for diag #   298  DFxESNOW , Parms: UU      M1 , mate:   299
-(PID.TID 0000.0001)   set mate pointer for diag #   299  DFyESNOW , Parms: VV      M1 , mate:   298
-(PID.TID 0000.0001)   set mate pointer for diag #   253  SIuice   , Parms: UU      M1 , mate:   254
-(PID.TID 0000.0001)   set mate pointer for diag #   254  SIvice   , Parms: VV      M1 , mate:   253
+(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
+(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
+(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
+(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
+(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
+(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiX  , Parms: UU      LR , mate:   230
-(PID.TID 0000.0001)   set mate pointer for diag #   230  GM_PsiY  , Parms: VV      LR , mate:   229
-(PID.TID 0000.0001)   set mate pointer for diag #   123  DFxE_TH  , Parms: UU      MR , mate:   124
-(PID.TID 0000.0001)   set mate pointer for diag #   124  DFyE_TH  , Parms: VV      MR , mate:   123
-(PID.TID 0000.0001)   set mate pointer for diag #   120  ADVx_TH  , Parms: UU      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   121  ADVy_TH  , Parms: VV      MR , mate:   120
-(PID.TID 0000.0001)   set mate pointer for diag #   130  DFxE_SLT , Parms: UU      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   131  DFyE_SLT , Parms: VV      MR , mate:   130
-(PID.TID 0000.0001)   set mate pointer for diag #   127  ADVx_SLT , Parms: UU      MR , mate:   128
-(PID.TID 0000.0001)   set mate pointer for diag #   128  ADVy_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
+(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
+(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
+(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
+(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
+(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
+(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
+(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -3037,8 +3076,95 @@
 (PID.TID 0000.0001)     4 @  2.000000000000000E+00,             /* K = 35: 38 */
 (PID.TID 0000.0001)    12 @  1.000000000000000E+00              /* K = 39: 50 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3233,17 +3359,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -3251,10 +3380,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3276,7 +3405,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -3285,7 +3414,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -3446,8 +3575,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3464,7 +3593,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3501,8 +3630,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3517,6 +3646,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -3962,47 +4094,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -4791,7 +4882,9 @@
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
-(PID.TID 0000.0001) CTRL_CHECK: #define ALLOW_CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
@@ -4834,6 +4927,8 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -5232,7 +5327,7 @@
  cg2d: Sum(rhs),rhsMax =   3.01131476956519E+00  1.10183783642738E+00
 (PID.TID 0000.0001)      cg2d_init_res =   4.03291087967738E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      97
-(PID.TID 0000.0001)      cg2d_last_res =   6.88051360107838E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.88051360107281E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5246,28 +5341,28 @@
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0485872675818E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0553129845408E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5139774465512E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1938700076554E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8163312562358E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1938701435059E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8163333513551E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4002289039950E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4479586115573E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1360952206931E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3993809447664E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9536906712862E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3993813297252E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9536982481392E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0928693106848E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2072774739881E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0337178718190E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1049614519107E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.8305651490126E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2072774759460E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0337178718193E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1049613716711E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.8305704026182E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2641500127209E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421242488937E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905919203750E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366224266504E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0893021150974E-04
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366224266007E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0893021788892E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711525591028E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7458314026201E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688754895E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887842944851E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7179850420917E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887842941409E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7179850118639E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.3607681866551E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5446533945148E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.7841231892067E+00
@@ -5302,16 +5397,16 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3443192018111E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   4.3852361305106E-04
 (PID.TID 0000.0001) %MON ke_max                       =   4.9603099473441E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1141425890474E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1141437672861E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973313513E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -3.1806217692959E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.6481652874459E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543433051682E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543433054553E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535770861E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720990856E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6686001597184E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.6524420816166E-08
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720999934E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6686001604660E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.6524420725452E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5365,14 +5460,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.4837461086138E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.6313815521884E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -8.7180082412194E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   6.4254852001358E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8539929881668E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.6373786649306E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   6.4254852091529E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8539929883352E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.6373786645386E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0132889153471E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1874770648526E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.2191688892967E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0682429773103E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5255405849081E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.2191688903313E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0682429773526E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5255405848308E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   3.1023215152125E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.4405696746102E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0357432074842E+00
@@ -5390,14 +5485,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943211487414E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2977500525357E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.4123135704899E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8188612825966E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.9273780735997E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0864349920901E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8188612826822E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.9273780737367E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0864349920818E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2107236478334E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9745350550993E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3518712309695E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.9135745615791E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1510864663139E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3518712310730E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.9135745616957E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1510864645277E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.2382273106148E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6253943692965E-08
@@ -5426,89 +5521,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01096285090896E+00  1.09717250638475E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.75524417404144E-01
+ cg2d: Sum(rhs),rhsMax =   3.01096285026427E+00  1.09717250638400E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.75526144676127E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      95
-(PID.TID 0000.0001)      cg2d_last_res =   6.79754117461156E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.79765838843589E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3328663160654E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5663553039812E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5298507265898E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4433613982064E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7984248249729E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8317328195366E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1029776183290E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5201796381976E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1941682835967E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7525472353797E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5532834722572E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4425714205055E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1407216129616E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3973933316171E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8853494864361E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.4501078699529E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1515801241873E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.4590373653095E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0595932719862E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5825374525730E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3328663158897E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5663553354032E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5298507262637E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4433614004983E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7984251403169E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8317328552007E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1029776451596E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5201796124485E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1941684596011E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7525509810445E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5532834722608E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4425714205046E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1407215909668E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3973939962640E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8853648631964E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   9.4501076967257E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1515801242166E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.4590582946367E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0595936433528E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.5825476275769E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2629166101444E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421299759591E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905938726990E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063506245E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0884096661835E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421299759595E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905938726988E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063505382E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0884097823267E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711523006047E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7457223472438E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7457223472437E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688781702E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887796683619E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7128488176411E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887796675783E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7128487809381E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.6856814224721E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.7180082412194E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.2904943139155E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6396631478589E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6712247147941E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.2904942837521E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6396631481297E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6712247153391E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -9.2659486649252E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8694441213908E+02
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8694441213907E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3952482703132E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.7764312418679E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3478073769697E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.1903728374866E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   8.5560139294497E-07
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1396277849835E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.9838339047423E-07
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.7764312443684E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3478073769672E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.1903728374864E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   8.5560129970705E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1396277847938E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.9838339401686E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.9027013207119E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0961877442638E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4337799367423E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0984059533452E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.0043675266169E-04
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4337799733069E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0984059464068E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.0043675499587E-04
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3501239362180E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5795865728158E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0413841127854E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1478529505146E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7348877587319E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3866522208456E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8633625631875E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0689579924369E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0641573077902E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.8411554252950E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0871750570782E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0996466343943E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3839302177546E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.5536370279360E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1103170424381E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0413840393407E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1478529472326E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7348817738773E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3866522429021E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8635047611891E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0689579927945E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.0641573297876E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.8412973278455E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0871750574344E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.0996466347519E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3839302244042E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.5536370279387E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1103189510279E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973303032E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0042367608733E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0042367689328E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.5104117294420E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543413680878E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543413685951E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535830104E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239972734798E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5733357449751E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.2836120792170E-08
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239972701323E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5733373674907E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.2836174327956E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5519,29 +5614,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   3.1910670717214E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8365599825436E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2031582867637E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   3.1910665240646E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8365599864519E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2031583356441E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -8.0810278057408E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8948391301263E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.2436069689642E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -8.0810269481622E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8948391331062E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.2436070336612E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9461116443664E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7988895502790E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6862827250205E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9461116444014E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7988895502391E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6862827283717E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   3.8228461174181E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3418201726371E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0476974082302E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.9045355288886E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.2319652361542E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3418201726020E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0476974081282E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.9045355290390E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.2319652312391E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -8.6736173798840E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2482394817035E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1450119645467E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.4612943296240E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2482394816566E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1450119650303E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.4612943328612E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5560,16 +5655,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.8739079370912E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1469991562767E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5515538638585E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.4976339628410E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.0414188527310E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5863784298930E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.3488049287103E-01
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5515538638481E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.4976339628412E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.0414188579326E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5863784300228E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.3488049287590E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0385390960054E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.3132705873887E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.9998840246617E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.8126900000526E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3232661761759E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.9998840247105E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.8126900001586E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3232661760365E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8848542238091E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.3040566798063E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0151300912066E+00
@@ -5586,15 +5681,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7073963366029E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4901468161263E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2993503434651E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3822495778110E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8178139612818E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8879626662374E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0827251068344E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3822495777640E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8178139613357E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8879626663096E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0827251068805E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2341541638877E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4203555722265E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3506034027029E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8634159872560E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0412450976830E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4203555722264E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3506034027077E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8634159872623E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0412450958571E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -5623,89 +5718,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01038097586267E+00  1.09443701668826E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.32105417747588E-01
+ cg2d: Sum(rhs),rhsMax =   3.01036950130346E+00  1.09443701669866E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.32213134550256E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   7.05786883229201E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.05928771128775E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3131623194675E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5299530531424E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5332009940161E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4445173989409E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7716663253769E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.1773368137998E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2468578282861E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5205028288108E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1958964412936E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7005763870547E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6615206497295E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4340042953133E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1479675721698E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3965047823355E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8286224826430E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3013725242418E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1944397605725E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.2547898492328E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0334643477810E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4362935966559E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.3131623173104E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5299531284190E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5331951863846E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4445172394188E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7716682777503E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.1773369880006E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2468578496904E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5205028188504E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1958966426208E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7005812768728E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6615206497457E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4340042953140E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1479675193401E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3965055558530E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8286424093179E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3013720828741E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.1944397609536E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.2558033097481E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0334661027765E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4363209608216E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2617215975616E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421416949287E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905969024293E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365967896304E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0873868302522E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421416949304E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905969022950E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365967896604E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0873869798145E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711520602497E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7456382055559E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688801020E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887754046611E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7071366233466E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.8334870681289E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.4976339628410E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2722914956581E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3478177324992E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6133612520105E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7456382055535E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688800972E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887754042979E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7071364463726E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.8334870681279E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.4976339628412E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.2722351000080E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3478131566327E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.6136437946064E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.1497703549041E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9118161252590E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0644575235793E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1499793601347E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3299051327119E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.3159442138047E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   9.5761810599170E-07
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1086136869841E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8769698143851E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9118098620837E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0644539470110E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1499082782652E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3299051297602E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.3159442167476E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   9.5595818456591E-07
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1086856261238E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8781524297543E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7960612181076E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0572030248335E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4214375075221E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0703937926190E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4023727160141E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0572030232729E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4214375541484E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0703937918825E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4023757067353E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3447743191057E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5561106391493E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.9362572980876E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1370733310772E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1555737665216E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5981642962464E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5797762467716E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8357582999681E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.9694000173697E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.5619387744613E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8549256589692E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8664468114917E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3826409888333E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.6607916145979E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1120050759476E-04
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5561106389888E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.9362566357039E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1370733286889E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1555666291122E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5981759481634E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5796570177954E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8357583021145E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.9694115780178E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.5618198705605E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.8549256611067E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8664468136381E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3826410710819E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.6607916146086E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1120072894152E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973292315E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.8604604661135E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.3562665135144E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.8604606973818E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.3562178126116E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543397934304E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535890719E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240168670811E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0976448994929E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0633431280534E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543397941022E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535890718E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240168587665E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0976634337681E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0634711412618E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5716,29 +5811,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.7604595750806E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8735660934098E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1459923229696E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.7604593404722E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8735660988961E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1459925307607E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -8.5219393127559E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9350086381058E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1907562799237E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -8.5219375756256E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9350086474634E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1907583337223E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9441241301661E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7993288412493E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6932737952505E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8231867900970E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9441235194611E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7993286837303E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6932762429921E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8231867900971E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3423024440274E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0482888258587E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8807951727855E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.3630322001947E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2453872257353E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1444436449311E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.4180595954620E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3423017873264E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0482887442345E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8807973064419E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.3630322455165E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2453872255122E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1444436462224E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.4180595715314E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5757,16 +5852,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7899366864812E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1419459236811E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.4517337306647E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4744368212667E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3179159278553E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.2895952783507E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4227036610647E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1858755528229E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0629923732467E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4744368212316E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3179159278407E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.2895955613087E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4227036673416E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1858755111322E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0629923732466E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4397200922157E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.7899905688835E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7046033832124E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2142628940279E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.7899905293711E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7046033838394E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2142628932251E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.6673869324057E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.1954436301909E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9945169749291E+00
@@ -5783,15 +5878,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6937182364123E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4865810313694E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3009506304395E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3514913449289E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8169628245835E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8629587427071E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0815736650910E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2579313644299E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2883358292594E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502747153219E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8283228360818E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9730045356499E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3514913453004E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8169628087504E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8629587484104E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0815736494437E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2579313644298E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2883358292584E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502747113707E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8283228414281E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9730045340337E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.4886747942940E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6668061282529E-08
@@ -5820,89 +5915,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01126825691400E+00  1.08987441767850E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.28233121299469E-01
+ cg2d: Sum(rhs),rhsMax =   3.01123698530932E+00  1.08987441748664E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.28364955361420E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   6.70463675357127E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70987508246740E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471024533E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314453961152E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5370152420641E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4455345974405E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7478629302925E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760081198691E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988935311E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5188484034784E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978008468964E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6574423617846E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383031966655E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223636551428E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1568587269508E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960114428052E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7812386993501E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424525635855E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868906060E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0909227262414E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260357829321E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3780986627498E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955470977964E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314452252826E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5369994182364E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4455341694601E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7478657218792E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760085585650E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644989266951E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5188484197264E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978010828242E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6574474122070E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383031967787E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223636551493E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1568585460294E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960122058192E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7812604153598E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424519871319E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868911671E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.0924255598464E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260388463578E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3781428879509E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631432599E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421583298828E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009723081E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365936536265E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0862491568486E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421583298875E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009719454E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365936538743E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0862493486531E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711518357461E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7455628111648E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688821484E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887712605575E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7009012548677E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9794468026122E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3179159278553E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7101713008341E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1651218455999E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5786533298674E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7455628111581E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688821354E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887712612201E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.7009011148446E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9794468026101E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3179159278407E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7100779465252E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1651155434278E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5788972059164E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9541315651623E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8461268040507E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8669577278409E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3130488106583E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.4421814595087E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0902392337279E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0910573669148E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8155192975480E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9541221350167E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8461243679628E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8738821448750E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3130488097373E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.4421814604219E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.0873762709490E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0911650181758E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.8156837110491E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0067009882604E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4060605360546E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0490236917581E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9659907322420E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3394247024139E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5328358123682E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8403696730110E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1326784192552E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.8021401081301E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976242656861E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3023530892665E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568788823E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646709812104E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2850688207058E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634364630E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453154920E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3812156108942E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.7437360684761E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1149734255584E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973280321E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391231305082E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.1981390997707E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0067009872330E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4060605563818E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0490236915988E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9659937383849E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3394247024138E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5328358124052E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8403696139196E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1326784201824E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.8021388411997E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976238060108E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3017571288489E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568843949E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646705292244E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2844740068655E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634419528E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453210046E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3812157891547E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.7437360685736E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1149756870318E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973280342E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391228882292E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.1980340443750E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543385125808E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535934398E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240320442534E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.9793871559083E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.1432104516178E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543385133492E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535934364E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240320332765E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.9796907559785E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.1434034003421E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5913,29 +6008,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5720173910812E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884422985347E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1046310013846E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5720187518587E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884423019508E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1046316548885E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0071452986699E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554284511681E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1525783143906E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0071439244356E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554284675858E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1525820115891E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430835895950E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998689206959E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7079258257965E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8235293926845E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430813499326E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998683866514E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7079237885863E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8235293926846E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3428083014010E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488348294213E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8582004064735E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4877998360658E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3428065121126E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488346477367E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8582037245267E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4878000166564E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433313443457E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439868209953E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782529191633E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433313437556E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439868231700E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782528554149E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5954,16 +6049,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131741552E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438714441E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5736724789344E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3836228116540E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1622390695671E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031861079E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131740850E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438714418E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5736733425643E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3836228271450E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1622390383737E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031861066E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660502712E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5890073341385E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7493137608670E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122766432602E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5890071996711E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7493137620972E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122766400621E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -5980,15 +6075,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3025509150153E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202910892284E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8161373253419E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8527309349216E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0829844195562E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804661005921E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282755144542E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3508370500443E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8082897688484E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9443848395237E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202910907584E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8161372860941E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8527309480603E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0829844046926E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804661005908E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282755144496E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3508370365975E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8082897870070E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9443848290617E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -6017,89 +6112,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01330805416516E+00  1.08661842160993E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.24970314608135E-01
+ cg2d: Sum(rhs),rhsMax =   3.01331887035770E+00  1.08661842749350E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.24939789284725E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
-(PID.TID 0000.0001)      cg2d_last_res =   6.74431731853310E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.74173369554545E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2886080756400E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5304568525095E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5411456538541E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4462768217852E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7262051720652E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.2758892216938E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2741355730272E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5155651584685E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1982153614139E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6211374221912E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7969062919038E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4076933261998E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1660180615772E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3956865205301E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7414034771883E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.9084070531336E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2493033917993E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.1745789651089E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0336382709402E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3845483709646E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2594399428769E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421788278534E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906060561094E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365968667382E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0849907216016E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2886080618934E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5304563366300E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5411511331191E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4462769644083E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7262101699620E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.2758900212879E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2741356056887E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5155651835046E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1982156310281E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6211420861917E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7969062923576E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4076933262944E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1660176571044E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3956872101439E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7414259540872E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.9084064021295E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2493033921966E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.1718025756508E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0336421545628E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3846011261692E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2594399428768E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0421788278612E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906060563007E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365968663046E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0849909724457E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711516256021E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454995390448E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688846629E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887670901015E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6942891245704E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.1364399784227E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.0917164489420E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1420227188041E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1189697771877E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5492752306104E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454995390396E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688846674E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887670853590E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6942891659229E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.1364399784173E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.0917164476209E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.1422596944560E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1189844797561E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5487131948969E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.2856876703622E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9964198790684E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821429991349E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9349268347888E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2970121028878E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.5691237997631E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.1806093699607E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0872240108052E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7283497794429E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9964439285809E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821513640882E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9257640784507E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2970121279561E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.5691237747494E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.1866985039757E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0870046126265E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7276634141755E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5334456274282E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9517171952004E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3895024737848E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0350693948029E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7092356342498E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3340750877155E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5097466096252E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7527851965143E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1347027097735E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.7231390654959E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.6196729722940E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0248632991366E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4450623444765E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1480062705784E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.0081488078465E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4658101019680E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4757507291200E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3795481412959E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.8115931341239E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1151557321555E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973266665E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0026834019878E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.0415529921012E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9517171937378E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3895025962309E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0350693911267E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7092381414435E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3340750877159E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5097466106336E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7527849989288E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1347027003957E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.7231399633625E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.6196861800051E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0239183314024E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4450623547241E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1480018241787E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.0072056594992E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.4658101121724E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.4757507393677E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3795482111448E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.8115931345093E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1151578928844E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973266722E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0026823048778E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.0414014745226E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543374447853E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535962620E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240441572657E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -9.8781121582620E-09
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.0357051755168E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543374456023E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535962526E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240441452549E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -9.8865178539493E-09
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.0351160774655E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6110,29 +6205,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0976042725763E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8919636571766E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0695550560424E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0976066375606E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8919636586298E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0695558487152E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.3481307474067E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9622920059025E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1253188506460E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.3481307929199E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9622920292844E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1253232236191E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9438362391182E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8005639438450E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6801211736378E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8238739425554E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9438366446591E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8005639886654E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6801224274094E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8238739425556E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3433303592763E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0493445538525E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8368276628410E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.6085812493633E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3433309789016E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0493445247010E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8368338014935E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.6085815746612E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2418145778814E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1436162881028E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3410093495471E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2418145765874E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1436162909869E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3410092439195E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6151,16 +6246,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6219941852612E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1521402093961E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6116067776970E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3255723469031E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.2606226965345E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0802901469558E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4744038183222E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2800116267684E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1094534261178E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6947516715398E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.3983846524121E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9443842832006E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3176285857600E-10
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3255723467956E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.2606226965308E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0802900488429E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4744038042354E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2800109583475E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1094534261171E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6947516715399E-06
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.3983848133099E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9443842829283E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3176285807538E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.2324523495989E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.4407348923388E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9532907423740E+00
@@ -6177,15 +6272,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6718525851041E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4812919343602E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3041511974036E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2887663863332E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8153807628522E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8574497433536E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0869553879808E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3030402639029E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2268733605853E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3524354400685E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8036007736757E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9561938105043E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2887298118867E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8153807923555E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8574497410630E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0869554863059E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3030402639022E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2268733605801E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3524354561583E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8036007499364E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9561938436015E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.7391222779732E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.3183406187123E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7082178872092E-08
@@ -6214,89 +6309,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01626856593095E+00  1.08470790518950E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.17565448314870E-01
+ cg2d: Sum(rhs),rhsMax =   3.01630776289169E+00  1.08470790816857E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.17388417699739E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      90
-(PID.TID 0000.0001)      cg2d_last_res =   6.40887080343773E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.40586663997318E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2495278620161E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5239543172804E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5454857837692E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4466336209660E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7070304725652E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9302831998823E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0431170782700E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5110678403816E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1962505199635E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5902442438249E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8517333893070E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3905845779494E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1754293722636E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3959238814659E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7077900524025E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.7923508058339E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2556007252645E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1050364883159E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0482008007946E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4250564657287E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2495278337332E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5239535330831E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5455055959397E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4466341236164E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7070352961066E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.9302844243998E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0431171111980E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5110678573985E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1962508091253E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5902483473976E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8517333903979E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3905845780001E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1754286968135E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3959244661530E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7078130722678E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.7923506238152E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2556007249178E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1048515166301E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0482054308483E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4251135442794E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2583503061518E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422021144557E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906121360879E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063766410E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0836954541660E-04
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422021144701E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906121367119E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366063757008E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0836957517086E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711514283324E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454488296057E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688877568E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887628727814E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6875515126824E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.3850754660957E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3637786851073E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5678164478216E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2172637462594E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5541040680174E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454488295964E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688877731E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887628644447E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6875514891232E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.3850754660929E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3637786802592E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5679896471204E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2172716925281E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5537671997626E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0387374661954E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8882793854978E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.3485683134123E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2817055952340E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.6968156359514E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2405538007479E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0974710536323E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7316179722789E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0387546308598E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8882809234419E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.3431349863784E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2817056458663E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.6968155855459E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2446506229093E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.0973555327445E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7305939701688E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9024782108786E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3738866543907E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0290431561323E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7363283235053E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3287254822510E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4863918790871E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6606268900083E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1433068173210E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.9184109025712E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3502693409662E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.7516410997553E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2863272513578E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4510703516584E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7340554618404E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3077142222793E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3170156109247E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3775471056709E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.8702647556005E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1115822706116E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973251878E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0302572358481E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8906854057293E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9024782091439E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3738867740823E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0290431630415E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.7363314843357E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3287254822515E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4863918815008E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6606275022726E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1433068128427E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.9184138396638E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3503050444617E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.7505518714817E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.2863272703909E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4510623658510E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7329146191048E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.3077142412256E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3170156299579E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3775471172683E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.8702647564813E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1115842266859E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973251858E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0302552684625E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8905017323493E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543365520950E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535976145E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240548435957E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -6.5796766763469E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.5244108146175E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543365529311E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535976182E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240548315392E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -6.5802665901211E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.5240217606963E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6307,29 +6402,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.2971459511238E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8865177495847E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0457996862891E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.2971474436905E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8865177580377E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0458001617195E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.5582886517568E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9594886159797E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1069436700123E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.5582902920684E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9594886387086E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1069481609412E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9450870952317E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8012354062181E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6529251680243E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8242204407288E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9450895070304E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8012358889961E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6529343479479E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8242204407291E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3438632762298E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0498313511622E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8172129700336E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.7221826807803E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2406523033530E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1432609689043E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3072139167766E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3438655165852E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0498313905618E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8172188953077E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.7221830927265E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2406523018064E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1432609722441E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3072137685594E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6348,16 +6443,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.5380229346511E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1672104366781E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.1371690064713E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2541554891232E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.5153462517198E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4970891805285E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.6812798165911E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5281405950495E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1320020691552E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2541554889715E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.5153462517282E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4970889462669E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.6812797890221E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5281399061713E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1320020691559E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.8234205268129E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.2190773508176E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.2804130735454E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5169680974205E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.2190777251133E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.2804130737078E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5169680948750E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.1230918947362E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.9974688084646E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9326776260964E+00
@@ -6374,15 +6469,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6636862312512E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4795752084831E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3057514779055E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3084956038515E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8147200593704E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8770382987241E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0934636445259E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3249128302413E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4056976151766E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3551653681059E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8146819770350E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0105715138875E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3084956038458E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8147201339605E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8770383029202E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0934637668093E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3249128302420E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.4056976151594E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3551654055355E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8146819239400E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.0105715615778E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.8643460198128E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -3.0412607572472E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7289237666874E-08
@@ -6411,89 +6506,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01989047534328E+00  1.08353186757255E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.10597419467150E-01
+ cg2d: Sum(rhs),rhsMax =   3.01995412191042E+00  1.08353186428219E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.10512009916359E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      87
-(PID.TID 0000.0001)      cg2d_last_res =   7.00618607568295E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.00108281322553E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1960826681394E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5071468371771E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5499167594588E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465670208378E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6908110304652E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6338723679584E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7727327855208E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5060462067100E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1921712515183E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5637942949827E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9153185169072E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3717328409873E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1847145650784E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3969303666611E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.6792619600758E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.8040619112864E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2472373273764E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1384613647244E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0616645809903E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4733946557922E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572923344627E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422270418114E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906191915366E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366221557584E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0823340129887E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1960826366137E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5071460322778E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5499488828923E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465677980029E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6908151101769E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6338740367765E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7727328348297E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5060461991870E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1921715450272E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5637977267930E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9153185189819E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3717328412557E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1847135825536E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3969308331269E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.6792853611057E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.8040619072966E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2472373259168E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1382949331094E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0616696370405E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4734505602466E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572923344623E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0422270418305E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906191922651E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366221546936E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0823343654830E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711512421740E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454128681304E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688915157E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887586201490E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6807349965292E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.6319518295589E+02
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.5674522327250E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.9875014980925E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.4417827184513E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5691328186320E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7454128680414E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725688915421E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7887586077045E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6807348766544E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   9.6319518295619E+02
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.5674522323394E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.9875373880296E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.4417844693665E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.5693224547596E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.0191167862034E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0810347452511E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.1393569394856E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   9.0578368551481E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2670596896913E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8253013924947E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2665205512630E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1208369833348E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7273801838436E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0810389746141E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.1393594499885E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   9.0607213363101E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.2670596702340E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -2.8253014125073E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   1.2700395206238E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.1207292546945E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   4.7270491511542E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.1371588902365E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8593129832985E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3575016022026E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0307221933255E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9657972989042E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3233759060640E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4628043948800E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.5496410980274E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1582155723455E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3386344775988E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2644794943531E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5631213974741E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1527407347906E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.6144651976657E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4745367182624E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1746621524834E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1834291204171E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3751868837425E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.9236127554914E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1053109740731E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973236340E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0157338283744E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7485479740236E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8593129816480E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3575016971234E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0307222135140E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9658011595620E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.3233759060643E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4628043990626E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.5496418143778E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1582155712821E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3386391100426E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2644675950524E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5619883398220E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1527407655714E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.6144528691578E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4733231149585E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1746621831230E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1834291511982E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3751868860519E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.9236127571428E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1053126615319E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973236269E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0157313199641E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7483528080015E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543358219203E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535972624E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240652685416E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.1152965443443E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.4105091716908E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543358227527E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535972750E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240652576904E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.1153717726500E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.4100508472046E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6504,29 +6599,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.2400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0969784796988E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8738026105987E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0322365538065E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.0969785593929E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8738026295958E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0322366461154E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.6369841707108E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9518611952100E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1008429608494E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.6369870432438E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9518612109365E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1008470112904E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9460728775697E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8018979317568E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6296639614209E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8245688572964E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9460770925730E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8018987232874E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6296678892723E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8245688572966E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3444012498732E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0503115648706E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.7998729060615E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.8245670715349E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3444048823605E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0503115891839E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.7998781866434E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.8245675139071E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2396338604130E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1428995174299E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.2772787980087E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2396338585300E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1428995210631E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.2772786180949E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6535,248 +6630,248 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427572467625737D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490822357431556D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101769692638291D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427572450015610D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490822322919029D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101769702990439D+0617
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918394825057294D+07
+(PID.TID 0000.0001)  --> fc               = 0.918394772934639D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.151257844841188D+07
-(PID.TID 0000.0001)  global fc =  0.918394825057294D+07
+(PID.TID 0000.0001)   local fc =  0.151257848014580D+07
+(PID.TID 0000.0001)  global fc =  0.918394772934639D+07
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   284.76083794236183
-(PID.TID 0000.0001)         System time:   14.195460725575686
-(PID.TID 0000.0001)     Wall clock time:   366.53544092178345
+(PID.TID 0000.0001)           User time:   179.25060348957777
+(PID.TID 0000.0001)         System time:   15.415907554328442
+(PID.TID 0000.0001)     Wall clock time:   218.28228402137756
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   9.5588832050561905
-(PID.TID 0000.0001)         System time:   3.2274909950792789
-(PID.TID 0000.0001)     Wall clock time:   17.881329774856567
+(PID.TID 0000.0001)           User time:   5.1993158385157585
+(PID.TID 0000.0001)         System time:   3.5040230229496956
+(PID.TID 0000.0001)     Wall clock time:   8.9087638854980469
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   275.20183277130127
-(PID.TID 0000.0001)         System time:   10.967934608459473
-(PID.TID 0000.0001)     Wall clock time:   348.65397691726685
+(PID.TID 0000.0001)           User time:   174.05123329162598
+(PID.TID 0000.0001)         System time:   11.911805629730225
+(PID.TID 0000.0001)     Wall clock time:   209.37342000007629
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   21.494992256164551
-(PID.TID 0000.0001)         System time:   6.5829076766967773
-(PID.TID 0000.0001)     Wall clock time:   64.788843870162964
+(PID.TID 0000.0001)           User time:   15.757159709930420
+(PID.TID 0000.0001)         System time:   6.2747375965118408
+(PID.TID 0000.0001)     Wall clock time:   37.418164968490601
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   253.70676803588867
-(PID.TID 0000.0001)         System time:   4.3850040435791016
-(PID.TID 0000.0001)     Wall clock time:   283.86505818367004
+(PID.TID 0000.0001)           User time:   158.29395675659180
+(PID.TID 0000.0001)         System time:   5.6370096206665039
+(PID.TID 0000.0001)     Wall clock time:   171.95510792732239
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1168003082275391
-(PID.TID 0000.0001)         System time:   3.9873123168945312E-003
-(PID.TID 0000.0001)     Wall clock time:   2.3613424301147461
+(PID.TID 0000.0001)           User time:   1.8798465728759766
+(PID.TID 0000.0001)         System time:   2.3565292358398438E-003
+(PID.TID 0000.0001)     Wall clock time:   2.1898152828216553
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   7.4653625488281250E-003
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-005
-(PID.TID 0000.0001)     Wall clock time:   7.5571537017822266E-003
+(PID.TID 0000.0001)           User time:   5.3501129150390625E-003
+(PID.TID 0000.0001)         System time:   3.2424926757812500E-004
+(PID.TID 0000.0001)     Wall clock time:   5.6767463684082031E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   242.16019058227539
-(PID.TID 0000.0001)         System time:   3.0156469345092773
-(PID.TID 0000.0001)     Wall clock time:   264.02646183967590
+(PID.TID 0000.0001)           User time:   151.14856338500977
+(PID.TID 0000.0001)         System time:   3.4913473129272461
+(PID.TID 0000.0001)     Wall clock time:   157.13636374473572
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   242.15996742248535
-(PID.TID 0000.0001)         System time:   3.0156440734863281
-(PID.TID 0000.0001)     Wall clock time:   264.02626681327820
+(PID.TID 0000.0001)           User time:   151.14838409423828
+(PID.TID 0000.0001)         System time:   3.4913406372070312
+(PID.TID 0000.0001)     Wall clock time:   157.13621520996094
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2588119506835938
-(PID.TID 0000.0001)         System time:   8.8691711425781250E-005
-(PID.TID 0000.0001)     Wall clock time:   3.3919947147369385
+(PID.TID 0000.0001)           User time:   2.6277103424072266
+(PID.TID 0000.0001)         System time:   1.9931793212890625E-004
+(PID.TID 0000.0001)     Wall clock time:   2.6307477951049805
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1735458374023438
-(PID.TID 0000.0001)         System time:   1.2707710266113281E-002
-(PID.TID 0000.0001)     Wall clock time:   1.3069064617156982
+(PID.TID 0000.0001)           User time:   1.3719215393066406
+(PID.TID 0000.0001)         System time:   2.8581619262695312E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4040780067443848
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6208152770996094
-(PID.TID 0000.0001)         System time:   8.2367897033691406E-002
-(PID.TID 0000.0001)     Wall clock time:   3.5421040058135986
+(PID.TID 0000.0001)           User time:   1.5137138366699219
+(PID.TID 0000.0001)         System time:  0.11807537078857422
+(PID.TID 0000.0001)     Wall clock time:   2.0836420059204102
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.5848999023437500
-(PID.TID 0000.0001)         System time:   7.9119682312011719E-002
-(PID.TID 0000.0001)     Wall clock time:   3.5028872489929199
+(PID.TID 0000.0001)           User time:   1.5132198333740234
+(PID.TID 0000.0001)         System time:  0.11803627014160156
+(PID.TID 0000.0001)     Wall clock time:   2.0831711292266846
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7166137695312500E-004
-(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
-(PID.TID 0000.0001)     Wall clock time:   1.9574165344238281E-004
+(PID.TID 0000.0001)           User time:   1.0681152343750000E-004
+(PID.TID 0000.0001)         System time:   1.3351440429687500E-005
+(PID.TID 0000.0001)     Wall clock time:   1.3399124145507812E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.34709930419921875
-(PID.TID 0000.0001)         System time:   4.7225952148437500E-003
-(PID.TID 0000.0001)     Wall clock time:  0.41135191917419434
+(PID.TID 0000.0001)           User time:  0.19662857055664062
+(PID.TID 0000.0001)         System time:   1.1291503906250000E-003
+(PID.TID 0000.0001)     Wall clock time:  0.20941781997680664
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14046859741210938
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.15659499168395996
+(PID.TID 0000.0001)           User time:  0.11429214477539062
+(PID.TID 0000.0001)         System time:   2.1266937255859375E-004
+(PID.TID 0000.0001)     Wall clock time:  0.11480116844177246
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   57.917495727539062
-(PID.TID 0000.0001)         System time:   6.8823814392089844E-002
-(PID.TID 0000.0001)     Wall clock time:   62.830278158187866
+(PID.TID 0000.0001)           User time:   30.809169769287109
+(PID.TID 0000.0001)         System time:   8.1671714782714844E-002
+(PID.TID 0000.0001)     Wall clock time:   31.052325248718262
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   24.482067108154297
-(PID.TID 0000.0001)         System time:   1.6742706298828125E-002
-(PID.TID 0000.0001)     Wall clock time:   25.951732873916626
+(PID.TID 0000.0001)           User time:   9.6968517303466797
+(PID.TID 0000.0001)         System time:   1.9706726074218750E-002
+(PID.TID 0000.0001)     Wall clock time:   9.7551999092102051
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   23.295917510986328
-(PID.TID 0000.0001)         System time:   1.3314247131347656E-002
-(PID.TID 0000.0001)     Wall clock time:   24.722091913223267
+(PID.TID 0000.0001)           User time:   9.0752773284912109
+(PID.TID 0000.0001)         System time:   1.9259452819824219E-002
+(PID.TID 0000.0001)     Wall clock time:   9.1321492195129395
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   11.251075744628906
-(PID.TID 0000.0001)         System time:   3.7542343139648438E-002
-(PID.TID 0000.0001)     Wall clock time:   12.531599283218384
+(PID.TID 0000.0001)           User time:   5.7814502716064453
+(PID.TID 0000.0001)         System time:   2.1646499633789062E-002
+(PID.TID 0000.0001)     Wall clock time:   5.8599669933319092
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   39.698040008544922
-(PID.TID 0000.0001)         System time:   1.4560699462890625E-002
-(PID.TID 0000.0001)     Wall clock time:   42.782292127609253
+(PID.TID 0000.0001)           User time:   28.244770050048828
+(PID.TID 0000.0001)         System time:   2.1521568298339844E-002
+(PID.TID 0000.0001)     Wall clock time:   28.379514932632446
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.9981575012207031
-(PID.TID 0000.0001)         System time:   3.2606124877929688E-003
-(PID.TID 0000.0001)     Wall clock time:   4.1862607002258301
+(PID.TID 0000.0001)           User time:   1.0042667388916016
+(PID.TID 0000.0001)         System time:   3.4332275390625000E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0048360824584961
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.9179496765136719
-(PID.TID 0000.0001)         System time:   3.3674240112304688E-003
-(PID.TID 0000.0001)     Wall clock time:   10.491510868072510
+(PID.TID 0000.0001)           User time:   3.4775314331054688
+(PID.TID 0000.0001)         System time:   3.0221939086914062E-003
+(PID.TID 0000.0001)     Wall clock time:   3.5611221790313721
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.81363677978515625
-(PID.TID 0000.0001)         System time:   3.2424926757812500E-005
-(PID.TID 0000.0001)     Wall clock time:  0.81529235839843750
+(PID.TID 0000.0001)           User time:  0.61731910705566406
+(PID.TID 0000.0001)         System time:   2.8896331787109375E-004
+(PID.TID 0000.0001)     Wall clock time:  0.62029504776000977
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5470504760742188
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.6881289482116699
+(PID.TID 0000.0001)           User time:   1.2310047149658203
+(PID.TID 0000.0001)         System time:   1.0490417480468750E-005
+(PID.TID 0000.0001)     Wall clock time:   1.2317488193511963
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18374252319335938
-(PID.TID 0000.0001)         System time:   3.6239624023437500E-005
-(PID.TID 0000.0001)     Wall clock time:  0.18382692337036133
+(PID.TID 0000.0001)           User time:   7.9732894897460938E-002
+(PID.TID 0000.0001)         System time:   1.1539459228515625E-004
+(PID.TID 0000.0001)     Wall clock time:   7.9875946044921875E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2144699096679688
-(PID.TID 0000.0001)         System time:   3.0402183532714844E-002
-(PID.TID 0000.0001)     Wall clock time:   2.3034064769744873
+(PID.TID 0000.0001)           User time:   1.1641292572021484
+(PID.TID 0000.0001)         System time:   3.4526824951171875E-002
+(PID.TID 0000.0001)     Wall clock time:   1.1990919113159180
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   45.763008117675781
-(PID.TID 0000.0001)         System time:   1.3216972351074219E-002
-(PID.TID 0000.0001)     Wall clock time:   48.809545993804932
+(PID.TID 0000.0001)           User time:   30.432571411132812
+(PID.TID 0000.0001)         System time:   2.5956153869628906E-002
+(PID.TID 0000.0001)     Wall clock time:   30.771935224533081
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2207031250000000E-004
+(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
 (PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.2421607971191406E-004
+(PID.TID 0000.0001)     Wall clock time:   7.2717666625976562E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.302871704101562
-(PID.TID 0000.0001)         System time:   5.8364868164062500E-004
-(PID.TID 0000.0001)     Wall clock time:   12.985019922256470
+(PID.TID 0000.0001)           User time:   6.3388671875000000
+(PID.TID 0000.0001)         System time:   3.9072036743164062E-003
+(PID.TID 0000.0001)     Wall clock time:   6.3699591159820557
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.8664550781250000E-005
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   8.7976455688476562E-005
+(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
+(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
+(PID.TID 0000.0001)     Wall clock time:   7.8678131103515625E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.315715789794922
-(PID.TID 0000.0001)         System time:   1.6812629699707031
-(PID.TID 0000.0001)     Wall clock time:   16.069981336593628
+(PID.TID 0000.0001)           User time:   7.1694145202636719
+(PID.TID 0000.0001)         System time:   1.7634897232055664
+(PID.TID 0000.0001)     Wall clock time:   9.2272875308990479
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0466194152832031
-(PID.TID 0000.0001)         System time:   1.0989704132080078
-(PID.TID 0000.0001)     Wall clock time:   6.6905777454376221
+(PID.TID 0000.0001)           User time:   2.0300712585449219
+(PID.TID 0000.0001)         System time:   1.4068727493286133
+(PID.TID 0000.0001)     Wall clock time:   4.3664622306823730
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2543945312500000
-(PID.TID 0000.0001)         System time:  0.13574409484863281
-(PID.TID 0000.0001)     Wall clock time:   1.4399030208587646
+(PID.TID 0000.0001)           User time:  0.68118286132812500
+(PID.TID 0000.0001)         System time:  0.14794731140136719
+(PID.TID 0000.0001)     Wall clock time:  0.83621692657470703
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.7983398437500000E-004
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-005
-(PID.TID 0000.0001)     Wall clock time:   6.1702728271484375E-004
+(PID.TID 0000.0001)           User time:   7.1716308593750000E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.2002410888671875E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   7.7123718261718750
-(PID.TID 0000.0001)         System time:   1.1816711425781250
-(PID.TID 0000.0001)     Wall clock time:   15.477593898773193
+(PID.TID 0000.0001)           User time:   4.5725250244140625
+(PID.TID 0000.0001)         System time:   1.9948501586914062
+(PID.TID 0000.0001)     Wall clock time:   11.780397891998291
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   6.2547607421875000
-(PID.TID 0000.0001)         System time:   1.1091871261596680
-(PID.TID 0000.0001)     Wall clock time:   13.508739948272705
+(PID.TID 0000.0001)           User time:   3.7020721435546875
+(PID.TID 0000.0001)         System time:   1.5313825607299805
+(PID.TID 0000.0001)     Wall clock time:   8.5863080024719238
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.4575195312500000
-(PID.TID 0000.0001)         System time:   7.2481155395507812E-002
-(PID.TID 0000.0001)     Wall clock time:   1.9688057899475098
+(PID.TID 0000.0001)           User time:  0.87039184570312500
+(PID.TID 0000.0001)         System time:  0.46346282958984375
+(PID.TID 0000.0001)     Wall clock time:   3.1940279006958008
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.8747558593750000E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8746843338012695E-002
+(PID.TID 0000.0001)           User time:   1.4801025390625000E-003
+(PID.TID 0000.0001)         System time:   1.2874603271484375E-004
+(PID.TID 0000.0001)     Wall clock time:   1.6160011291503906E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6915,9 +7010,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          38018
+(PID.TID 0000.0001) //            No. barriers =          37820
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          38018
+(PID.TID 0000.0001) //     Total barrier spins =          37820
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.ecmwf.txt
+++ b/global_oce_llc90/results/output.ecmwf.txt
@@ -5,9 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67t
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Dec 15 02:22:54 EST 2020
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -166,9 +167,9 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># Continuous equation parameters
 (PID.TID 0000.0001) > &PARM01
-(PID.TID 0000.0001) > tRef               = 3*23.,3*22.,21.,2*20.,19.,2*18.,17.,2*16.,15.,14.,13.,
-(PID.TID 0000.0001) >                      12.,11.,2*9.,8.,7.,2*6.,2*5.,3*4.,3*3.,4*2.,12*1.,
-(PID.TID 0000.0001) > sRef               = 50*34.5,
+(PID.TID 0000.0001) > tRef = 3*23., 3*22., 21., 2*20., 19., 2*18., 17., 2*16., 15., 14., 13.,
+(PID.TID 0000.0001) >        12., 11., 2*9., 8., 7., 2*6., 2*5., 3*4., 3*3., 4*2., 12*1.,
+(PID.TID 0000.0001) > sRef = 50*34.5,
 (PID.TID 0000.0001) > no_slip_sides  = .TRUE.,
 (PID.TID 0000.0001) > no_slip_bottom = .TRUE.,
 (PID.TID 0000.0001) >#
@@ -193,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -258,8 +259,7 @@
 (PID.TID 0000.0001) ># dumpFreq    =31536000.0,
 (PID.TID 0000.0001) > monitorFreq = 3600.0,
 (PID.TID 0000.0001) > dumpInitAndLast = .TRUE.,
-(PID.TID 0000.0001) > adjMonitorFreq = 864000.0,
-(PID.TID 0000.0001) > pickupStrictlyMatch=.FALSE.,
+(PID.TID 0000.0001) >#pickupStrictlyMatch=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -283,7 +283,6 @@
 (PID.TID 0000.0001) > hydrogSaltFile ='some_S_atlas.bin',
 (PID.TID 0000.0001) > viscA4Dfile    ='viscA4Dfld_eccollc_90x50.bin',
 (PID.TID 0000.0001) > viscA4Zfile    ='viscA4Zfld_eccollc_90x50.bin',
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
@@ -629,58 +628,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -870,6 +869,7 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -952,24 +952,30 @@
 (PID.TID 0000.0001) // Parameter file "data.diagnostics"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Diagnostic Package Choices
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-(PID.TID 0000.0001) >#               > 0 : write time-average output every multiple of frequency (iter)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
 (PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-(PID.TID 0000.0001) >#                 when this entry is missing, select all common levels of this list
-(PID.TID 0000.0001) >#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file
-(PID.TID 0000.0001) >#                 for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#--------------------------------------------------------------------
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &diagnostics_list
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
 (PID.TID 0000.0001) >   dumpatlast = .TRUE.,
 (PID.TID 0000.0001) >   diagMdsDir = 'diags',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(1) = 2635200.0,
-(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 (PID.TID 0000.0001) >#stuff that is not quite state variables (and may not be quite
 (PID.TID 0000.0001) >#synchroneous) but are added here to reduce number of files
 (PID.TID 0000.0001) >                 'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -1102,19 +1108,24 @@
 (PID.TID 0000.0001) >#  filename(17) = 'state_2d_set2',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
 (PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 (PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-(PID.TID 0000.0001) >#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) > &DIAG_STATIS_PARMS
 (PID.TID 0000.0001) ># diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 (PID.TID 0000.0001) ># nSetRegMskFile=1,
@@ -1123,17 +1134,17 @@
 (PID.TID 0000.0001) ># val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 (PID.TID 0000.0001) >#                10.,11.,12.,13.,14.,15.,16.,17.
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-(PID.TID 0000.0001) >#                   'UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >#                   'THETA   ','SALT    ',
+(PID.TID 0000.0001) ># stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+(PID.TID 0000.0001) >#                      'UVEL    ','VVEL    ','WVEL    ',
+(PID.TID 0000.0001) >#                      'THETA   ','SALT    ',
 (PID.TID 0000.0001) >#    stat_fname(1)= 'dynStDiag',
 (PID.TID 0000.0001) >#     stat_freq(1)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 (PID.TID 0000.0001) >#                   10,11,12,13,14,15,16,17
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-(PID.TID 0000.0001) >#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-(PID.TID 0000.0001) >#                   'oceQnet ','oceSflux','oceFWflx',
+(PID.TID 0000.0001) ># stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+(PID.TID 0000.0001) >#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+(PID.TID 0000.0001) >#                      'oceQnet ','oceSflux','oceFWflx',
 (PID.TID 0000.0001) >#    stat_fname(2)= 'surfStDiag',
 (PID.TID 0000.0001) >#     stat_freq(2)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -1436,6 +1447,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1496,22 +1510,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -1695,6 +1718,7 @@
 (PID.TID 0000.0001)  error file = some_T_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = saltatlas
@@ -1704,6 +1728,7 @@
 (PID.TID 0000.0001)  error file = some_S_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -1902,7 +1927,7 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
-(PID.TID 0000.0001)                    1500
+(PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2637,8 +2662,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:         7220976
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2666,16 +2691,21 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2683,74 +2713,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   317
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   236 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   239 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   317 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   261 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   296 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   299 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   253 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   254 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   230 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   123 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   130 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVxHEFF , Parms: UU      M1 , mate:   289
-(PID.TID 0000.0001)   set mate pointer for diag #   289  ADVyHEFF , Parms: VV      M1 , mate:   288
-(PID.TID 0000.0001)   set mate pointer for diag #   290  DFxEHEFF , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  DFyEHEFF , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #   296  ADVxSNOW , Parms: UU      M1 , mate:   297
-(PID.TID 0000.0001)   set mate pointer for diag #   297  ADVySNOW , Parms: VV      M1 , mate:   296
-(PID.TID 0000.0001)   set mate pointer for diag #   298  DFxESNOW , Parms: UU      M1 , mate:   299
-(PID.TID 0000.0001)   set mate pointer for diag #   299  DFyESNOW , Parms: VV      M1 , mate:   298
-(PID.TID 0000.0001)   set mate pointer for diag #   253  SIuice   , Parms: UU      M1 , mate:   254
-(PID.TID 0000.0001)   set mate pointer for diag #   254  SIvice   , Parms: VV      M1 , mate:   253
+(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
+(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
+(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
+(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
+(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
+(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiX  , Parms: UU      LR , mate:   230
-(PID.TID 0000.0001)   set mate pointer for diag #   230  GM_PsiY  , Parms: VV      LR , mate:   229
-(PID.TID 0000.0001)   set mate pointer for diag #   123  DFxE_TH  , Parms: UU      MR , mate:   124
-(PID.TID 0000.0001)   set mate pointer for diag #   124  DFyE_TH  , Parms: VV      MR , mate:   123
-(PID.TID 0000.0001)   set mate pointer for diag #   120  ADVx_TH  , Parms: UU      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   121  ADVy_TH  , Parms: VV      MR , mate:   120
-(PID.TID 0000.0001)   set mate pointer for diag #   130  DFxE_SLT , Parms: UU      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   131  DFyE_SLT , Parms: VV      MR , mate:   130
-(PID.TID 0000.0001)   set mate pointer for diag #   127  ADVx_SLT , Parms: UU      MR , mate:   128
-(PID.TID 0000.0001)   set mate pointer for diag #   128  ADVy_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
+(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
+(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
+(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
+(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
+(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
+(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
+(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2833,8 +2863,95 @@
 (PID.TID 0000.0001)     4 @  2.000000000000000E+00,             /* K = 35: 38 */
 (PID.TID 0000.0001)    12 @  1.000000000000000E+00              /* K = 39: 50 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3029,17 +3146,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -3047,10 +3167,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3072,7 +3192,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -3081,7 +3201,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -3242,8 +3362,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3260,7 +3380,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3297,8 +3417,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3313,6 +3433,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -3364,7 +3487,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
 (PID.TID 0000.0001)                       0
@@ -3758,47 +3881,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -4587,7 +4669,9 @@
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
-(PID.TID 0000.0001) CTRL_CHECK: #define ALLOW_CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) etaday defined by gencost   0
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
@@ -5004,45 +5088,45 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -3.02000398532668E-01  1.24442605872837E+00
+ cg2d: Sum(rhs),rhsMax =  -3.02000398532654E-01  1.24442605872837E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.82875879833587E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.36980808326339E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.36980819316052E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.4847535134487E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5227615587005E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5227615587004E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5213963505624E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0391766971844E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7354125175964E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7354125175822E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8847794536576E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.8256387900037E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5559753481165E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1666417071619E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6599160594960E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5559753481166E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1666417079706E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6599160372508E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4602213324423E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5776583139670E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7522366949677E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2122273076319E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4930152630082E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5776583139671E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7522366949673E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2122273065871E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4930153808108E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8992772254698E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3234478371643E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4043589510875E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6219938756039E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1037897516256E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4043589509905E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6219938717404E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1037897037542E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1213683153251E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002518370432E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920287767691E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365820561938E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3009164225975E-05
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365820562012E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3009164607330E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699647486928E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0289563744293E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610153864E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184040179576E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2171805332995E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184040179170E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2171805345755E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3284778429342E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.4790185087006E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =   7.8020356327298E-01
@@ -5075,18 +5159,18 @@
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.5543391515074E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6631535948513E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7504166205010E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4783168883599E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4783168883597E-05
 (PID.TID 0000.0001) %MON ke_max                       =   4.3324431303683E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.4000474847133E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.4000474844014E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979032097E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -2.8818053871651E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   2.9303326746983E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541848415924E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525958251E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243354047594E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1824628039195E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4413367784087E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243354049641E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1824628039284E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4413367784322E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5140,14 +5224,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8647225187899E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.4784191535281E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -7.7084629272893E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   4.9411138294231E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5556555683911E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2914829617244E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   4.9411138295698E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5556555683923E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2914829618145E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9897065576917E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.0707600312948E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7354210747683E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6721791609541E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2715356004412E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7354210747987E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6721791609477E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2715356004069E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.9662385819350E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   6.7645036785843E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0288462093920E+00
@@ -5165,14 +5249,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943555151673E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2927197612966E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2088943054577E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7412504504967E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8358738184381E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0741164509407E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7412504504977E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8358738184365E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0741164509433E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2646032019213E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1711895115929E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2283229527686E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7563016969131E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8062023216086E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2283229527716E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7563016969147E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8062023219508E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8974578178756E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.0040313248140E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6501756512671E-08
@@ -5206,50 +5290,50 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.56988144307565E-01  1.19140039587201E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.44155675004729E+00
+ cg2d: Sum(rhs),rhsMax =  -4.56988144307780E-01  1.19140039587201E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.44155674934397E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.93215322618665E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.93215318780706E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9895440500461E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1356620129509E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2942289634520E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8274511511609E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6901083393693E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.1346651976252E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0586374895075E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0507374820413E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4800432174829E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9965128360061E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3629462141710E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0590565905093E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6556867683662E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5690093873417E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.8069700630338E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351249651145E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438944643221E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6880779193006E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3675449669005E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9586436889258E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9895440495577E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1356620129265E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2942289634534E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8274511510129E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6901083415330E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.1346651976754E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0586374889206E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0507374811774E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4800432535360E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9965136182618E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3629462138629E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0590565904835E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6556867562660E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5690094012423E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.8069708168864E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351249651139E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438944642762E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6880779231857E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3675449930499E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9586435153379E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1198300157509E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659307535E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659307533E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920277560661E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365668906414E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2505485183889E-05
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365668907553E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2505493528655E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697287110988E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0321082980082E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609333716E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184131999935E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1876778982738E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184132011079E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1876782951967E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3164619138511E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3576503753999E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.9104455105674E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3393500763083E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3631466195704E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.9104455104099E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3393500763099E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3631466195782E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.0593549145477E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8183528761905E+02
@@ -5257,9 +5341,9 @@
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8464817513709E-02
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   4.1988217571776E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3729687791409E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.2090132185091E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8671141107471E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   7.1106639574603E-07
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.2090132185129E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8671141107474E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   7.1106639574659E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7707957663300E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.7939371385237E+00
 (PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4326853602310E-02
@@ -5270,25 +5354,25 @@
 (PID.TID 0000.0001) %MON forcing_fv_mean              =   5.1567154159563E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2241038733079E-01
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0097809544408E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.2471849679994E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7929457668858E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7984769504426E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1799381960580E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.3757553716905E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8786041852933E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9717960185555E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4920407410687E-05
-(PID.TID 0000.0001) %MON ke_max                       =   5.0920409204934E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3239510814592E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.2471849634003E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7929457668735E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7984769504404E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.1799381915230E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.3757553714237E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8786041852910E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9717960185532E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4920407420564E-05
+(PID.TID 0000.0001) %MON ke_max                       =   5.0920409136139E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3239511539058E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979314074E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0568581422351E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.1572095132588E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0568581421453E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.1572095115084E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541288565146E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541288565610E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524151714E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239609897484E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3278154963110E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6252187802009E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239609881222E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3278154922014E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6252187630133E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5299,29 +5383,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3501412559165E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3501412559158E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6807025877763E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1612868427300E-04
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1612868427313E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.4348618279653E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7898424735660E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1735369601765E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.4348618279693E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7898424735662E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1735369601786E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4855876490862E-02
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4855876490861E-02
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.9219793169184E-01
 (PID.TID 0000.0001) %MON seaice_area_del2             =   2.3895355520769E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8281725900413E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4658507690207E-02
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2549659272532E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6933635121063E-04
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6933635121062E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8066546810815E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4873539220891E-03
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5162299598002E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9251903408981E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9251903408982E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5340,16 +5424,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.9578791877013E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1587407852827E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.4837461086138E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5815926322280E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5815926322314E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -8.9304796689603E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.3811590582052E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8164470925818E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5750625550091E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9834911063188E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.3811590588473E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8164470925901E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5750625550792E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9834911063187E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1862228755171E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.1014337924338E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0382200607418E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5164780009326E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.1014337925433E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0382200607359E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5164780008744E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   3.1023215152125E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.4405696746102E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0357432074842E+00
@@ -5367,14 +5451,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943211487414E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3146367644091E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2836929673291E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7651814868239E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8798316876338E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0843854817025E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7651814868299E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8798316876346E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0843854817032E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2673489898868E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2989474589393E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2400977212832E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7871741626032E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9299669528993E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2989474589385E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2400977212942E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7871741626121E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9299669533289E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.2382273106148E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6253943692965E-08
@@ -5408,89 +5492,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -6.11540860410080E-01  1.15502291609287E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.17614228055931E+00
+ cg2d: Sum(rhs),rhsMax =  -6.11540860442266E-01  1.15502291609614E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.17614227454788E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.67183992630819E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.67183968596965E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0023090891820E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1101023794790E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.0603325611077E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4134953128562E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6831084697579E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.3947651767238E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0812687227636E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8355768559828E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7171645912719E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1906959572202E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.1481509216407E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2754262393579E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1032384682541E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8121925391663E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.9975763940790E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303505062954E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093769537443E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1703124250572E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2805685662448E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0164941675866E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0023090892530E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1101023911862E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.0603325612691E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4134953103462E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6831084760464E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.3947651767421E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0812687250534E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8355768536143E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7171648005896E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1906993856582E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.1481509116931E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2754262387342E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1032384026316E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8121925287525E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.9975781669664E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303505062348E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093769506279E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1703125742771E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2805678297800E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0164940653736E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190094581192E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000927842206E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920327524073E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365563968193E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1828454881042E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000927842204E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920327524075E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365563969677E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1828466642061E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694842300136E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0358604313851E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608687574E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184235208341E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1594587810428E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3083248972212E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184235221745E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1594591817103E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3083248972495E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.9304796689603E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.4780579300208E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6128631460586E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3421987504284E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.4780579280409E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.6128631460876E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3421987513859E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -9.2659486649252E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8497333633273E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3884463715431E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.4990144509431E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.0852980560499E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3407814133850E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1897794499660E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8685851351581E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.9899956236749E-07
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.4990144510505E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.0852980560485E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3407814134307E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1897794504238E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8685851352590E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.9899956245373E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.9027013207119E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.7353369628480E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4172912958417E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1674242927818E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1931874054979E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6311988014593E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.5141293862331E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.5086121317614E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2470245806582E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0607490547948E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1623343751144E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8779871052575E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653708550841E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3548064499884E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.0556833496908E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636493917774E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3793486652067E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0537991601448E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.4649242359709E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1394081265762E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.7353369635987E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4172912958280E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1674242927693E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1931874056097E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6311988014268E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.5141293862344E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.5086121312364E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2470245806917E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0607490574457E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1623335663932E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8779870967564E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653708548858E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3548064676813E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.0556833410770E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636493915706E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3793486649977E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0537991600522E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.4649242399992E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1394084535041E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979590759E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2873171606498E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2247033868851E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2873145275741E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2247033937141E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540894537600E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540894539571E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523427704E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236014540198E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9124467478190E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6348993437101E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236014440168E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9124467278075E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6348993775446E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5501,29 +5585,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3841044496471E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7699405637385E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2945588716583E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3841044499930E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7699405637057E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2945588718332E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5781268429557E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8872572855064E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3017211852115E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5781268423247E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8872572854694E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3017211828003E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4751445485019E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9190258212757E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3733437274328E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4751445484972E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9190258212737E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3733437276196E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276595725334E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4577379800636E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2530515631686E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6790203208685E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4577379800618E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2530515631690E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6790203208825E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8019746816009E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4721851927292E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5107921376706E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9030018193056E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4721851927275E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5107921376705E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9030018193488E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5542,16 +5626,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.8739079370912E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1469991562767E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5011878357440E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.5891368144760E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.0114535764743E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5437589483473E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2805843625014E-01
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5011878357571E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.5891368144762E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -2.0114535832364E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5437589482279E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2805843629947E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0058955798097E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.3119253651580E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8802646415885E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7878977303116E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3142777428759E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8802646407179E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7878977301876E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3142777425547E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8848542238091E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.3040566798063E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0151300912066E+00
@@ -5568,15 +5652,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7073963366029E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4901468161263E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3160192502172E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1720932863054E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7629022645233E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8404669484109E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0805694451561E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1720932863060E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7629022644307E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8404669482861E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0805694450859E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2760420233393E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022456374230E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2386414643955E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7429389218693E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8238480650607E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022456374185E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2386414643085E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7429389218591E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8238480674595E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -5610,89 +5694,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.63317194711098E-01  1.13206050183458E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.11150084000897E+00
+ cg2d: Sum(rhs),rhsMax =  -7.63317193578010E-01  1.13206050186053E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.11150078356972E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   7.09318547366113E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.09318651875891E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0569024240570E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3404153212506E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.8077692401444E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7885699932456E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702564464420E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4889639621585E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0746963214672E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.0971196652178E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9224906472341E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2783084085589E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.0017064307703E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4854922185194E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3928180027923E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9969752089425E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.0611039187946E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896460363133E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243149931239E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9652404468011E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6273349863622E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0865685271025E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0569024244099E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3404152787991E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.8077692344088E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7885699970684E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702564356161E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4889639503571E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0746963361213E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.0971196766840E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9224913292425E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2783157938707E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.0017069988754E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4854921790620E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3928177179781E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9969750420890E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.0611068914282E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896460360583E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243149833172E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9652409919975E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6273313134413E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0865681763907E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1187094351585E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000021542420E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920409389981E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365555445682E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1212612906354E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000021542403E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920409389984E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365555447163E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1212622189678E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692241471957E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0402933245070E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0402933245072E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608218812E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184352359057E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1336875826502E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2954404271878E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5891368144760E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -9.2710405881573E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3217785360809E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2508227277553E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184352371141E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1336878418616E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2954404272854E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5891368144762E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -9.2710406456762E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3217785360235E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2508229730124E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.1497703549041E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949049534260E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0596820975490E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8766061357730E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1374820351261E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3140251615318E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1364231742485E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8187702265694E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7347629241691E-07
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0596820975492E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8766061359422E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1374820351233E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3140251621685E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1364231573917E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8187702303463E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7347638570023E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7960612181076E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0231535046467E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3907039320753E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1449860792817E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1658300519820E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6099829618558E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3305086738180E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.4367168943867E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2405816939610E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0401414350994E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2195110014338E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7915790069472E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222453595084E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3040224593051E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.9479490422282E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344303485457E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679821592217E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3548119441186E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.5924680083291E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.8858526051646E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0231535081660E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3907039337522E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1449860799029E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1658299996551E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6099829616566E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3305086737552E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.4367168841242E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2405816938976E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0401414454368E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2195112923706E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7915789781835E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222453586733E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.3040225725354E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.9479495355187E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344303476744E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679821583426E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3548119553915E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.5924681175149E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.8858535392670E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979865034E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3754994454753E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2051022976515E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3754999967937E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2051023413550E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540682599840E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540682604886E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523586239E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232518036115E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2832110046480E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4767752793498E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232517787460E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2832109746931E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4767754204800E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5703,29 +5787,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4235734618435E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8228098048913E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3577521865250E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4235734583086E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8228098046414E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3577521899275E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6609668309352E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9489208774595E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591568187036E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6609668243751E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9489208769365E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3591568061730E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4626970167488E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9159713547100E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3787247463421E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4626970169297E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9159713547608E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3787247469794E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8271570855193E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4497948961217E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2512790674552E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6673094031069E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7976638434107E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4581574036319E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5059170876620E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8830007097997E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4497948961853E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2512790674947E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6673094050579E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7976638434112E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4581574036671E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5059170876648E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8830007090501E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5744,16 +5828,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7899366864812E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1419459236811E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.4517337306647E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4232500586480E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3824594702746E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3450151705891E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3759571341902E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1131085428156E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0268554814490E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4232500587546E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3824594702779E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3450151666257E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3759571342065E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1131085422867E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0268554814491E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4382817231233E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6700904144792E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6848725478346E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052382339311E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6700904152088E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6848725476997E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052382335731E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.6673869324057E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.1954436301909E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9945169749291E+00
@@ -5770,15 +5854,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6937182364123E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4865810313694E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3174126476127E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281938337884E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7609246911473E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8157454485531E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0793285581046E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437698780E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510491053901E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2382846998815E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7131183688989E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7573986092852E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281938337907E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7609246911765E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8157454484613E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0793285579145E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437698779E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510491053842E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2382846999544E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7131183688004E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7573986095959E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.4886747942940E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6668061282529E-08
@@ -5812,89 +5896,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.10501455474117E-01  1.14261627766333E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05839386205943E+00
+ cg2d: Sum(rhs),rhsMax =  -9.10501452525746E-01  1.14261627760108E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.05839335470553E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     127
-(PID.TID 0000.0001)      cg2d_last_res =   6.99104438089607E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.99105757059887E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442301505266E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4309909864629E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.5347752050150E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9792180263152E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6664583736099E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4115219340577E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9287497613103E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9259652553285E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0951820589361E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2518248553654E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.5877321008346E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.6089035854100E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2408441320134E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1241464818486E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0117542287342E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199500511747E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763262317222E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.0405896584169E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6303167414085E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1169026293605E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442301507040E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4309909027635E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.5347751900908E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9792180708350E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6664583264170E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4115219051822E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.9287500989327E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9259653101827E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0951836627075E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.2518366611402E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.5877337299719E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.6089033947688E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2408433794843E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1241459894733E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0117583613655E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199500506085E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763262272047E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.0406025200154E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6303074040835E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1169021545059E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1178155785969E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998903443054E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920505925670E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365634602233E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0527674930687E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998903443000E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920505925669E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365634603647E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0527683124016E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689475792603E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0460217651113E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607902322E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184478521726E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1101007775855E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2812570131229E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3824594702746E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3998528109280E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1412806153014E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2182003276638E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0460217651117E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607902321E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184478532331E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1101009460430E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2812570128995E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3824594702779E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3998528192740E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1412806156399E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2182005432709E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400541662506E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437040366788E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5830200342559E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8450174023471E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2834467241742E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0780253829208E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7804141060647E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7010161759050E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400541662503E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437040366787E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5830200331090E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8450174024910E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2834467259936E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0780253566572E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7804141149741E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7010169602165E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9492914100277E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3653502545629E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1286641102934E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1242295352678E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5871124362709E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.1609026020361E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.3537420569838E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2385462653098E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0263879061177E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1457806001206E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.0118011731829E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775722278299E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.6718008021261E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4568000639787E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995644619546E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8465144050864E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5150884760052E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.0523719761658E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4960480674822E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9492914166074E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3653502547612E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1286641096845E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1242296862575E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.5871124359609E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.1609025988182E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.3537420309929E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2385462650937E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0263878515375E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1457810427148E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.0118011310192E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775722259777E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.6718010630020E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4568014785723E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995644600208E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8465144031391E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5150885384722E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.0523723012203E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4960502704976E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980132627E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3498463986905E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9610837998717E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3498479705829E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.9610839005619E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540653913943E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540653924223E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524312946E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229819065319E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6170777292390E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1787045288054E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229818630287E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6170777391454E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1787048214556E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5905,29 +5989,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4523826022465E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8569316291037E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4102281145736E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4523825918357E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8569316279279E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4102280982538E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6820247198460E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9917426948067E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4276553033132E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6820246942630E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9917426918098E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4276552653721E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4546139413808E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9132489513778E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3485505843013E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4546139416179E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9132489514381E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3485505819336E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8266648281192E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4420290684438E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2496263287885E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6582993036272E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7933791721313E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4456123069181E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5018640831251E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8650552387932E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4420290686118E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2496263288825E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6582993073449E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7933791721325E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4456123069381E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5018640831166E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8650552396913E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5946,16 +6030,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3497258202672E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302679747521E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0623961957063E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3349478902207E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0869815727179E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437283963E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3497258204100E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302679747043E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0623961947382E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3349478903992E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0869815711409E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437283964E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5653315604409E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4703735462600E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7342103728479E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2031869198320E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4703735477785E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7342103728449E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2031869194867E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -5972,15 +6056,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3188121890605E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461434200492E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7591087079741E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8060742840548E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0806700686838E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946959507E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881941340362E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2389736712564E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6979157055004E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7291565024021E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461434200577E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7591087080673E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8060742840604E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0806700682726E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946959506E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881941340209E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2389736714083E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6979157055339E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7291565014168E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -6014,89 +6098,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.05309424584436E+00  1.15147095900339E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.94285722860463E-01
+ cg2d: Sum(rhs),rhsMax =  -1.05309431204551E+00  1.15147095859162E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.94284793129925E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.39617581085711E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39618031691673E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379157919350E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3759554708968E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.2412141042272E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0431234966946E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702505066198E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4473187926844E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5112755193959E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4583108481445E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2288467525808E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0087443209545E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.7667861479799E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5983213367795E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5175086282737E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1910218678559E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8395841090726E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291428468960E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8472316351768E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.2697481875076E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5631297039870E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1176777529280E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960333894E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997553602929E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920600603507E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365790312689E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9892685993627E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686526788757E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0532935486478E+01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379157929942E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3759553245474E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.2412144392815E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0431236405465E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6702504200182E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4473194490786E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5112757582021E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4583109665579E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2288498181550E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0087461791754E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.7667882701583E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5983209185889E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5175069677676E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1910208833135E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8395897366547E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291428461490E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8472316404503E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -9.2699795462011E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5631100898883E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1176775519822E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960333895E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997553604112E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920600603449E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365790314106E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9892693101090E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686526788754E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0532935486451E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607622149E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184609681069E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0889014579850E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2658041822199E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302679747521E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8679011361877E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0986499869124E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1831382598599E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184609690408E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0889015548196E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2658041811814E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302679747043E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8678991239216E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0986502327347E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1831367065431E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.2856876703622E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851874144363E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7820429667101E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6623800676780E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6634443184017E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2508585063351E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0192378535830E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7524169928618E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6065676010510E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851872121566E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7820430825130E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6623651554264E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6634443001677E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2508585085744E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0192388539376E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7524174275847E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6065677288284E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5334456274282E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9945049808298E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3416190632644E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1195830943716E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1254993012025E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6048721122714E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.0011213122837E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.2722241661647E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2428438684407E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0457948942622E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1101668980078E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8560255558128E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9252753363502E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7604636937363E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6159365536886E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1922862873147E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2237780655358E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5599200002130E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.9667658996591E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9043947989845E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9945049902108E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3416190723503E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1195830974548E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1254992671484E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6048662007344E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.0011213174770E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.2722240891674E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2428438682349E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0457948757512E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1101683914775E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8560255216677E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9252746397754E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7604686387380E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.6159383972804E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.1922855964429E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2237773676919E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5599201811728E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.9667662845551E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9043992393174E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980392905E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.4865712986677E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6593863937253E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.4865733406625E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6593858395380E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540788155010E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525432944E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228296981085E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0841336427484E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6101762350282E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540788173195E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525432943E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228296370418E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0841337620155E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6101815704014E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6107,29 +6191,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4401014311484E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8752934536346E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4707571470166E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.4401014408995E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8752934536600E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4707571053941E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6513815756418E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0167847723359E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4945476119186E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6513815399826E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0167847661995E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4945476293085E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4447036362064E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9104189084356E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3575481078518E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8619449180057E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4447036338757E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9104189076196E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3575480894087E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8619449180637E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4344494408221E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480742660492E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6514563539162E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7891156873196E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4344494370322E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480742655191E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6514563514611E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7891156873213E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4343457876098E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4985075976962E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8488375291605E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4343457876438E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4985075976131E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8488375253812E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6148,16 +6232,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6219941852612E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1521402093961E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6116067776970E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2782969219858E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953487764E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4836284866368E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4264120950558E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2050716710919E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104384914E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2782969221418E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953487765E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4836284883323E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4264120953637E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2050716683023E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104384915E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6931169411588E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2810625715367E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9332844588846E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084476075310E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2810625693678E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9332844588627E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084476072082E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.2324523495989E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.4407348923388E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9532907423740E+00
@@ -6174,15 +6258,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6718525851041E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4812919343602E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3202165759534E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651287217135E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7574376255155E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8116163737574E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0845825694673E-01
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651287217401E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7574376249867E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8116163739686E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0845825690295E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2970736101907E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539422647954E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2407032319809E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6975831845243E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7402278731817E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539422647788E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2407032317641E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6975831848076E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7402278697007E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.7391222779732E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.3183406187123E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7082178872092E-08
@@ -6216,89 +6300,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.19099897786529E+00  1.15876340902258E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.19211728832505E-01
+ cg2d: Sum(rhs),rhsMax =  -1.19099878222504E+00  1.15876340794680E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.19210293774998E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.60657108336686E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.60657633640561E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484194653111E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2472543285122E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.9264863096343E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0414527172200E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6738726267192E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4739243083664E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1714005700366E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9037078822483E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3156084066094E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0786260677234E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9246632381242E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4566019785922E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2747117578132E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2096598087895E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0563677880166E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256225935817E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224946688103E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.3823909819786E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6052623795027E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0978595961570E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484194677690E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2472540999292E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.9264852907179E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0414530484383E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6738724479681E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.4739249858733E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.1714005334472E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9037081155319E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3156133746217E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0786284046527E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.9246663010878E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4566013688274E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2747085048477E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2096582243332E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0563684691740E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256225930829E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224946982027E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.3820156150247E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6052256355446E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0978591498747E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154933921541E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995968288077E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920685815672E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366013038300E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9339573844117E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995968295812E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920685815655E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366013039618E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9339580063332E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684477642248E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0614328732050E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0614328731960E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607303973E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184739609324E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0689074517131E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2486529841098E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953487764E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.3305334902229E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2007229772043E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1350967779924E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184739616878E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0689074939672E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2486529843776E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953487765E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.3305361885920E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2007229619030E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1350629194088E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302980673119E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8898687470778E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.0904113972530E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.5305047553266E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2179342466048E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9587363871210E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7321752468019E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4672445613437E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302983316164E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8898689040966E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.0903217124589E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.5305047549600E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2179342450020E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9587325170226E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.7321737250388E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4672017238373E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0268348738089E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3177077069338E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1184298466414E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1331183843432E-04
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6297472305813E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -8.8507984069753E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.1924322749989E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2539060522995E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0815898540946E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0997923374679E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.4741082627250E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.4433091738660E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5132865777944E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7530885135429E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7007618057237E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7371975203719E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5392667207390E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.6525510000884E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1013889246596E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0268348948761E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3177077104193E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1184298419022E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   1.1331188064541E-04
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.6297344660024E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -8.8507984017314E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   5.1924322553820E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2539060553127E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   1.0815896274520E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0998052497809E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.4741068146763E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.4433080416548E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5132862589457E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.7530911744196E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7007606818914E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7371963853519E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5392671041464E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.6525503393553E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1013965147732E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980645820E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.5254190022350E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6642921730025E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.5254214527681E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6642979919542E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541030042648E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526730504E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7227965180330E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6187391647278E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.0120119395563E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541030071323E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526730503E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7227964371145E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6187426238932E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.0120198091281E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6309,29 +6393,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3733020484820E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8808303298892E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5297955581420E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3733021104056E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8808303304700E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5297955016595E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5836504262157E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0273208805383E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5589232859096E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5836503853500E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   2.0273208763781E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5589233314560E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4345547013378E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9076700527521E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3409254472471E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.9107326348271E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4345547231423E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9076700540900E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3409254604194E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.9107326344871E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4270676210853E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2465930810681E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6467314321225E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7848707996259E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4270676326026E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2465930806407E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6467313704485E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7848707996281E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4242247259996E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4956797988850E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8342897763081E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4242247261173E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4956797986349E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8342897706291E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6340,247 +6424,247 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.122184424328549D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.209013694547114D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.122183699253426D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.209013368212312D+05 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331198118875663D+05
+(PID.TID 0000.0001)  --> fc               = 0.331197067465738D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.144176652587558D+04
-(PID.TID 0000.0001)  global fc =  0.331198118875663D+05
+(PID.TID 0000.0001)   local fc =  0.144173950850288D+04
+(PID.TID 0000.0001)  global fc =  0.331197067465738D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   290.58844195678830
-(PID.TID 0000.0001)         System time:   13.078510712832212
-(PID.TID 0000.0001)     Wall clock time:   331.81739497184753
+(PID.TID 0000.0001)           User time:   185.34016630053520
+(PID.TID 0000.0001)         System time:   13.110895946621895
+(PID.TID 0000.0001)     Wall clock time:   203.26866316795349
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   9.9010211676359177
-(PID.TID 0000.0001)         System time:   3.1525209676474333
-(PID.TID 0000.0001)     Wall clock time:   13.869328975677490
+(PID.TID 0000.0001)           User time:   5.0892708264291286
+(PID.TID 0000.0001)         System time:   2.0266560092568398
+(PID.TID 0000.0001)     Wall clock time:   7.2051048278808594
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   280.68732738494873
-(PID.TID 0000.0001)         System time:   9.9259536266326904
-(PID.TID 0000.0001)     Wall clock time:   317.94794297218323
+(PID.TID 0000.0001)           User time:   180.25080919265747
+(PID.TID 0000.0001)         System time:   11.084197998046875
+(PID.TID 0000.0001)     Wall clock time:   196.06343102455139
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   20.931767463684082
-(PID.TID 0000.0001)         System time:   5.0359177589416504
-(PID.TID 0000.0001)     Wall clock time:   28.136868000030518
+(PID.TID 0000.0001)           User time:   11.601641654968262
+(PID.TID 0000.0001)         System time:   4.2026431560516357
+(PID.TID 0000.0001)     Wall clock time:   15.988434791564941
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   259.75546264648438
-(PID.TID 0000.0001)         System time:   4.8900175094604492
-(PID.TID 0000.0001)     Wall clock time:   289.81100702285767
+(PID.TID 0000.0001)           User time:   168.64907836914062
+(PID.TID 0000.0001)         System time:   6.8815269470214844
+(PID.TID 0000.0001)     Wall clock time:   180.07492685317993
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8363990783691406
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.9728846549987793
+(PID.TID 0000.0001)           User time:   1.9473686218261719
+(PID.TID 0000.0001)         System time:   1.6141891479492188E-002
+(PID.TID 0000.0001)     Wall clock time:   1.9764668941497803
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   6.9751739501953125E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.9880485534667969E-003
+(PID.TID 0000.0001)           User time:   5.7506561279296875E-003
+(PID.TID 0000.0001)         System time:   5.1975250244140625E-005
+(PID.TID 0000.0001)     Wall clock time:   5.8052539825439453E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   250.49815177917480
-(PID.TID 0000.0001)         System time:   3.8990821838378906
-(PID.TID 0000.0001)     Wall clock time:   278.06314706802368
+(PID.TID 0000.0001)           User time:   162.77866935729980
+(PID.TID 0000.0001)         System time:   3.6328411102294922
+(PID.TID 0000.0001)     Wall clock time:   168.03558015823364
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   250.49797439575195
-(PID.TID 0000.0001)         System time:   3.8990821838378906
-(PID.TID 0000.0001)     Wall clock time:   278.06297731399536
+(PID.TID 0000.0001)           User time:   162.77851295471191
+(PID.TID 0000.0001)         System time:   3.6328372955322266
+(PID.TID 0000.0001)     Wall clock time:   168.03541469573975
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0244102478027344
-(PID.TID 0000.0001)         System time:   1.9264221191406250E-004
-(PID.TID 0000.0001)     Wall clock time:   3.4745573997497559
+(PID.TID 0000.0001)           User time:   2.8143081665039062
+(PID.TID 0000.0001)         System time:   7.3957443237304688E-004
+(PID.TID 0000.0001)     Wall clock time:   2.8171107769012451
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1554031372070312
-(PID.TID 0000.0001)         System time:   5.2239418029785156E-002
-(PID.TID 0000.0001)     Wall clock time:   1.8928835391998291
+(PID.TID 0000.0001)           User time:   1.6011238098144531
+(PID.TID 0000.0001)         System time:   3.6976337432861328E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6504762172698975
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6124496459960938
-(PID.TID 0000.0001)         System time:  0.13136100769042969
-(PID.TID 0000.0001)     Wall clock time:   4.9956922531127930
+(PID.TID 0000.0001)           User time:   1.3688697814941406
+(PID.TID 0000.0001)         System time:  0.15167808532714844
+(PID.TID 0000.0001)     Wall clock time:   1.6326849460601807
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.5755596160888672
-(PID.TID 0000.0001)         System time:  0.13131523132324219
-(PID.TID 0000.0001)     Wall clock time:   4.9587912559509277
+(PID.TID 0000.0001)           User time:   1.3683929443359375
+(PID.TID 0000.0001)         System time:  0.15164804458618164
+(PID.TID 0000.0001)     Wall clock time:   1.6322033405303955
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.0217895507812500E-004
-(PID.TID 0000.0001)         System time:   2.0980834960937500E-005
-(PID.TID 0000.0001)     Wall clock time:   2.0313262939453125E-004
+(PID.TID 0000.0001)           User time:   1.9073486328125000E-004
+(PID.TID 0000.0001)         System time:   1.8119812011718750E-005
+(PID.TID 0000.0001)     Wall clock time:   1.9240379333496094E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.38951492309570312
-(PID.TID 0000.0001)         System time:   3.2424926757812500E-005
-(PID.TID 0000.0001)     Wall clock time:  0.40619516372680664
+(PID.TID 0000.0001)           User time:  0.15786170959472656
+(PID.TID 0000.0001)         System time:   3.0899047851562500E-004
+(PID.TID 0000.0001)     Wall clock time:  0.15883493423461914
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10666656494140625
-(PID.TID 0000.0001)         System time:   1.9359588623046875E-004
-(PID.TID 0000.0001)     Wall clock time:  0.12299585342407227
+(PID.TID 0000.0001)           User time:  0.11961174011230469
+(PID.TID 0000.0001)         System time:   2.5796890258789062E-004
+(PID.TID 0000.0001)     Wall clock time:  0.11990237236022949
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   64.255664825439453
-(PID.TID 0000.0001)         System time:  0.13932704925537109
-(PID.TID 0000.0001)     Wall clock time:   69.866570949554443
+(PID.TID 0000.0001)           User time:   33.407947540283203
+(PID.TID 0000.0001)         System time:  0.12263011932373047
+(PID.TID 0000.0001)     Wall clock time:   33.684087038040161
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   30.980709075927734
-(PID.TID 0000.0001)         System time:   3.6149978637695312E-002
-(PID.TID 0000.0001)     Wall clock time:   33.298655748367310
+(PID.TID 0000.0001)           User time:   12.595140457153320
+(PID.TID 0000.0001)         System time:   3.3950805664062500E-002
+(PID.TID 0000.0001)     Wall clock time:   12.680030107498169
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   29.781230926513672
-(PID.TID 0000.0001)         System time:   3.1970977783203125E-002
-(PID.TID 0000.0001)     Wall clock time:   32.014305591583252
+(PID.TID 0000.0001)           User time:   11.985143661499023
+(PID.TID 0000.0001)         System time:   2.2454738616943359E-002
+(PID.TID 0000.0001)     Wall clock time:   12.057176828384399
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   11.266258239746094
-(PID.TID 0000.0001)         System time:   5.8246612548828125E-002
-(PID.TID 0000.0001)     Wall clock time:   12.342943906784058
+(PID.TID 0000.0001)           User time:   6.0407581329345703
+(PID.TID 0000.0001)         System time:   3.2523632049560547E-002
+(PID.TID 0000.0001)     Wall clock time:   6.1010162830352783
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   39.233589172363281
-(PID.TID 0000.0001)         System time:   1.5883445739746094E-002
-(PID.TID 0000.0001)     Wall clock time:   42.702104091644287
+(PID.TID 0000.0001)           User time:   29.920364379882812
+(PID.TID 0000.0001)         System time:   2.0864963531494141E-002
+(PID.TID 0000.0001)     Wall clock time:   30.337508916854858
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.6677360534667969
-(PID.TID 0000.0001)         System time:   4.0769577026367188E-003
-(PID.TID 0000.0001)     Wall clock time:   4.9508681297302246
+(PID.TID 0000.0001)           User time:   1.6961765289306641
+(PID.TID 0000.0001)         System time:   4.1122436523437500E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7144365310668945
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.645992279052734
-(PID.TID 0000.0001)         System time:   4.5604705810546875E-003
-(PID.TID 0000.0001)     Wall clock time:   14.016102790832520
+(PID.TID 0000.0001)           User time:   4.8538494110107422
+(PID.TID 0000.0001)         System time:   1.2645721435546875E-002
+(PID.TID 0000.0001)     Wall clock time:   4.9119141101837158
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.87325286865234375
-(PID.TID 0000.0001)         System time:   8.4877014160156250E-005
-(PID.TID 0000.0001)     Wall clock time:  0.93126177787780762
+(PID.TID 0000.0001)           User time:  0.79534721374511719
+(PID.TID 0000.0001)         System time:   8.7738037109375000E-005
+(PID.TID 0000.0001)     Wall clock time:  0.79747509956359863
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3986053466796875
-(PID.TID 0000.0001)         System time:   4.1007995605468750E-005
-(PID.TID 0000.0001)     Wall clock time:   2.4595088958740234
+(PID.TID 0000.0001)           User time:   1.1789436340332031
+(PID.TID 0000.0001)         System time:   4.5776367187500000E-005
+(PID.TID 0000.0001)     Wall clock time:   1.1803221702575684
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.38073730468750000
-(PID.TID 0000.0001)         System time:   3.5753250122070312E-003
-(PID.TID 0000.0001)     Wall clock time:  0.42083811759948730
+(PID.TID 0000.0001)           User time:  0.10534095764160156
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.10535979270935059
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.1515312194824219
-(PID.TID 0000.0001)         System time:   4.5022010803222656E-002
-(PID.TID 0000.0001)     Wall clock time:   2.2795224189758301
+(PID.TID 0000.0001)           User time:   1.2681903839111328
+(PID.TID 0000.0001)         System time:   3.7425994873046875E-002
+(PID.TID 0000.0001)     Wall clock time:   1.3149130344390869
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   45.196010589599609
-(PID.TID 0000.0001)         System time:   4.4129371643066406E-002
-(PID.TID 0000.0001)     Wall clock time:   48.936966419219971
+(PID.TID 0000.0001)           User time:   32.420175552368164
+(PID.TID 0000.0001)         System time:   5.5581569671630859E-002
+(PID.TID 0000.0001)     Wall clock time:   32.702152490615845
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0681152343750000E-004
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.5367431640625000E-005
+(PID.TID 0000.0001)           User time:   8.0108642578125000E-005
+(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
+(PID.TID 0000.0001)     Wall clock time:   8.4161758422851562E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.081981658935547
-(PID.TID 0000.0001)         System time:   8.2645416259765625E-003
-(PID.TID 0000.0001)     Wall clock time:   13.151161670684814
+(PID.TID 0000.0001)           User time:   7.3821334838867188
+(PID.TID 0000.0001)         System time:   3.3283233642578125E-004
+(PID.TID 0000.0001)     Wall clock time:   7.4547357559204102
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.8664550781250000E-005
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   8.3923339843750000E-005
+(PID.TID 0000.0001)           User time:   7.6293945312500000E-005
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   9.2506408691406250E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   15.409835815429688
-(PID.TID 0000.0001)         System time:   2.2223234176635742
-(PID.TID 0000.0001)     Wall clock time:   19.450916767120361
+(PID.TID 0000.0001)           User time:   5.8671607971191406
+(PID.TID 0000.0001)         System time:   1.8739557266235352
+(PID.TID 0000.0001)     Wall clock time:   7.9081749916076660
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0091247558593750
-(PID.TID 0000.0001)         System time:   1.2230052947998047
-(PID.TID 0000.0001)     Wall clock time:   6.8323907852172852
+(PID.TID 0000.0001)           User time:   2.2512283325195312
+(PID.TID 0000.0001)         System time:   1.3022365570068359
+(PID.TID 0000.0001)     Wall clock time:   3.8578076362609863
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1150817871093750
-(PID.TID 0000.0001)         System time:  0.17961120605468750
-(PID.TID 0000.0001)     Wall clock time:   1.3752479553222656
+(PID.TID 0000.0001)           User time:  0.62188720703125000
+(PID.TID 0000.0001)         System time:  0.14772129058837891
+(PID.TID 0000.0001)     Wall clock time:  0.77149081230163574
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.7983398437500000E-004
-(PID.TID 0000.0001)         System time:   2.6702880859375000E-005
-(PID.TID 0000.0001)     Wall clock time:   6.2203407287597656E-004
+(PID.TID 0000.0001)           User time:   6.2561035156250000E-004
+(PID.TID 0000.0001)         System time:   3.4332275390625000E-005
+(PID.TID 0000.0001)     Wall clock time:   6.6614151000976562E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8802795410156250
-(PID.TID 0000.0001)         System time:  0.77134132385253906
-(PID.TID 0000.0001)     Wall clock time:   7.8264930248260498
+(PID.TID 0000.0001)           User time:   3.2841644287109375
+(PID.TID 0000.0001)         System time:   3.0847063064575195
+(PID.TID 0000.0001)     Wall clock time:   9.2743179798126221
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   4.4623107910156250
-(PID.TID 0000.0001)         System time:  0.67560100555419922
-(PID.TID 0000.0001)     Wall clock time:   6.2183570861816406
+(PID.TID 0000.0001)           User time:   2.5214233398437500
+(PID.TID 0000.0001)         System time:   2.9409561157226562
+(PID.TID 0000.0001)     Wall clock time:   8.3454689979553223
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.4179382324218750
-(PID.TID 0000.0001)         System time:   9.5738410949707031E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6080889701843262
+(PID.TID 0000.0001)           User time:  0.76264953613281250
+(PID.TID 0000.0001)         System time:  0.14374732971191406
+(PID.TID 0000.0001)     Wall clock time:  0.92880296707153320
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.8402099609375000E-002
+(PID.TID 0000.0001)           User time:   6.5002441406250000E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8413066864013672E-002
+(PID.TID 0000.0001)     Wall clock time:   6.4921379089355469E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6719,9 +6803,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          44194
+(PID.TID 0000.0001) //            No. barriers =          43996
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          44194
+(PID.TID 0000.0001) //     Total barrier spins =          43996
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.txt
+++ b/global_oce_llc90/results/output.txt
@@ -5,9 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67t
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Dec 15 02:22:54 EST 2020
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -166,9 +167,9 @@
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># Continuous equation parameters
 (PID.TID 0000.0001) > &PARM01
-(PID.TID 0000.0001) > tRef               = 3*23.,3*22.,21.,2*20.,19.,2*18.,17.,2*16.,15.,14.,13.,
-(PID.TID 0000.0001) >                      12.,11.,2*9.,8.,7.,2*6.,2*5.,3*4.,3*3.,4*2.,12*1.,
-(PID.TID 0000.0001) > sRef               = 50*34.5,
+(PID.TID 0000.0001) > tRef = 3*23., 3*22., 21., 2*20., 19., 2*18., 17., 2*16., 15., 14., 13.,
+(PID.TID 0000.0001) >        12., 11., 2*9., 8., 7., 2*6., 2*5., 3*4., 3*3., 4*2., 12*1.,
+(PID.TID 0000.0001) > sRef = 50*34.5,
 (PID.TID 0000.0001) > no_slip_sides  = .TRUE.,
 (PID.TID 0000.0001) > no_slip_bottom = .TRUE.,
 (PID.TID 0000.0001) >#
@@ -193,7 +194,7 @@
 (PID.TID 0000.0001) > useRealFreshWaterFlux=.TRUE.,
 (PID.TID 0000.0001) ># balanceThetaClimRelax=.TRUE.,
 (PID.TID 0000.0001) > balanceSaltClimRelax=.TRUE.,
-(PID.TID 0000.0001) > balanceEmPmR=.TRUE.,
+(PID.TID 0000.0001) > selectBalanceEmPmR=1,
 (PID.TID 0000.0001) ># balanceQnet=.TRUE.,
 (PID.TID 0000.0001) > allowFreezing=.FALSE.,
 (PID.TID 0000.0001) >### hFacInf=0.2,
@@ -258,8 +259,7 @@
 (PID.TID 0000.0001) ># dumpFreq    =31536000.0,
 (PID.TID 0000.0001) > monitorFreq = 3600.0,
 (PID.TID 0000.0001) > dumpInitAndLast = .TRUE.,
-(PID.TID 0000.0001) > adjMonitorFreq = 864000.0,
-(PID.TID 0000.0001) > pickupStrictlyMatch=.FALSE.,
+(PID.TID 0000.0001) >#pickupStrictlyMatch=.FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Gridding parameters
@@ -283,7 +283,6 @@
 (PID.TID 0000.0001) > hydrogSaltFile ='some_S_atlas.bin',
 (PID.TID 0000.0001) > viscA4Dfile    ='viscA4Dfld_eccollc_90x50.bin',
 (PID.TID 0000.0001) > viscA4Zfile    ='viscA4Zfld_eccollc_90x50.bin',
-(PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  INI_PARMS ; starts to read PARM01
@@ -658,58 +657,58 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag. */
+(PID.TID 0000.0001) GGL90writeState =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter. */
+(PID.TID 0000.0001) GGL90ck =   /* GGL90 viscosity parameter */
 (PID.TID 0000.0001)                 1.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter. */
+(PID.TID 0000.0001) GGL90ceps =   /* GGL90 dissipation parameter */
 (PID.TID 0000.0001)                 7.000000000000000E-01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter. */
+(PID.TID 0000.0001) GGL90alpha =   /* GGL90 TKE diffusivity parameter */
 (PID.TID 0000.0001)                 3.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio. */
+(PID.TID 0000.0001) GGL90m2 =   /* GGL90 wind stress to vertical stress ratio */
 (PID.TID 0000.0001)                 3.750000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEmin =   /* GGL90 minimum kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEsurfMin =   /* GGL90 minimum surface kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ). */
+(PID.TID 0000.0001) GGL90TKEbottom =   /* GGL90 bottom kinetic energy ( m^2/s^2 ) */
 (PID.TID 0000.0001)                 1.000000000000000E-06
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90viscMax =   /* GGL90 upper limit for viscosity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffMax =   /* GGL90 upper limit for diffusivity (m^2/s ) */
 (PID.TID 0000.0001)                 1.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ). */
+(PID.TID 0000.0001) GGL90diffTKEh =   /* GGL90 horizontal diffusivity for TKE ( m^2/s ) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length ( m ). */
+(PID.TID 0000.0001) GGL90mixingLengthMin =   /* GGL90 minimum mixing length (m) */
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing. */
+(PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) calcMeanVertShear = /* calc Mean of Vert.Shear (vs shear of Mean flow) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90: GGL90TKEFile =
-(PID.TID 0000.0001) GGL90writeState =   /* GGL90 Boundary condition flag. */
+(PID.TID 0000.0001) GGL90_dirichlet =   /* GGL90 Boundary condition flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
@@ -889,6 +888,7 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -971,24 +971,30 @@
 (PID.TID 0000.0001) // Parameter file "data.diagnostics"
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># Diagnostic Package Choices
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  filename(n) : prefix of the output file name (only 8.c long) for outp.stream n
-(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every multiple of |frequency| (iter)
-(PID.TID 0000.0001) >#               > 0 : write time-average output every multiple of frequency (iter)
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  dumpAtLast (logical): always write output at the end of simulation (default=F)
+(PID.TID 0000.0001) >#  diag_mnc   (logical): write to NetCDF files (default=useMNC)
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  fileName(n) : prefix of the output file name (max 80c long) for outp.stream n
+(PID.TID 0000.0001) >#  frequency(n):< 0 : write snap-shot output every |frequency| seconds
+(PID.TID 0000.0001) >#               > 0 : write time-average output every frequency seconds
+(PID.TID 0000.0001) >#  timePhase(n)     : write at time = timePhase + multiple of |frequency|
+(PID.TID 0000.0001) >#    averagingFreq  : frequency (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    averagingPhase : phase     (in s) for periodic averaging interval
+(PID.TID 0000.0001) >#    repeatCycle    : number of averaging intervals in 1 cycle
 (PID.TID 0000.0001) >#  levels(:,n) : list of levels to write to file (Notes: declared as REAL)
-(PID.TID 0000.0001) >#                 when this entry is missing, select all common levels of this list
-(PID.TID 0000.0001) >#  fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics" file
-(PID.TID 0000.0001) >#                 for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#--------------------------------------------------------------------
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) > &diagnostics_list
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#                when this entry is missing, select all common levels of this list
+(PID.TID 0000.0001) >#  fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#  missing_value(n) : missing value for real-type fields in output file "n"
+(PID.TID 0000.0001) >#  fileFlags(n)     : specific code (8c string) for output file "n"
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) > &DIAGNOSTICS_LIST
 (PID.TID 0000.0001) >   dumpatlast = .TRUE.,
 (PID.TID 0000.0001) >   diagMdsDir = 'diags',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) >  frequency(1) = 2635200.0,
-(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff ','SIhsnow ',
+(PID.TID 0000.0001) >   fields(1:25,1) = 'ETAN    ','SIarea  ','SIheff  ','SIhsnow ',
 (PID.TID 0000.0001) >#stuff that is not quite state variables (and may not be quite
 (PID.TID 0000.0001) >#synchroneous) but are added here to reduce number of files
 (PID.TID 0000.0001) >                 'DETADT2 ','PHIBOT  ','sIceLoad',
@@ -1121,19 +1127,24 @@
 (PID.TID 0000.0001) >#  filename(17) = 'state_2d_set2',
 (PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) ># Parameter for Diagnostics of per level statistics:
-(PID.TID 0000.0001) >#-----------------
-(PID.TID 0000.0001) ># for each output-stream:
-(PID.TID 0000.0001) >#  stat_fname(n) : prefix of the output file name (only 8.c long) for outp.stream n
+(PID.TID 0000.0001) >#--------------------
+(PID.TID 0000.0001) >#  diagSt_mnc (logical): write stat-diags to NetCDF files (default=diag_mnc)
+(PID.TID 0000.0001) >#  diagSt_regMaskFile : file containing the region-mask to read-in
+(PID.TID 0000.0001) >#  nSetRegMskFile   : number of region-mask sets within the region-mask file
+(PID.TID 0000.0001) >#  set_regMask(i)   : region-mask set-index that identifies the region "i"
+(PID.TID 0000.0001) >#  val_regMask(i)   : region "i" identifier value in the region mask
+(PID.TID 0000.0001) >#--for each output-stream:
+(PID.TID 0000.0001) >#  stat_fName(n) : prefix of the output file name (max 80c long) for outp.stream n
 (PID.TID 0000.0001) >#  stat_freq(n):< 0 : write snap-shot output every |stat_freq| seconds
 (PID.TID 0000.0001) >#               > 0 : write time-average output every stat_freq seconds
 (PID.TID 0000.0001) >#  stat_phase(n)    : write at time = stat_phase + multiple of |stat_freq|
 (PID.TID 0000.0001) >#  stat_region(:,n) : list of "regions" (default: 1 region only=global)
-(PID.TID 0000.0001) >#  stat_fields(:,n) : list of diagnostics fields (8.c) (see "available_diagnostics.log"
-(PID.TID 0000.0001) >#                 file for the list of all available diag. in this particular config)
-(PID.TID 0000.0001) >#-----------------
+(PID.TID 0000.0001) >#  stat_fields(:,n) : list of selected diagnostics fields (8.c) in outp.stream n
+(PID.TID 0000.0001) >#                (see "available_diagnostics.log" file for the full list of diags)
+(PID.TID 0000.0001) >#--------------------
 (PID.TID 0000.0001) > &DIAG_STATIS_PARMS
 (PID.TID 0000.0001) ># diagSt_regMaskFile='basin_masks_eccollc_90x50.bin',
 (PID.TID 0000.0001) ># nSetRegMskFile=1,
@@ -1142,17 +1153,17 @@
 (PID.TID 0000.0001) ># val_regMask(1)= 1., 2., 3., 4., 5., 6., 7., 8., 9.,
 (PID.TID 0000.0001) >#                10.,11.,12.,13.,14.,15.,16.,17.
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,1)= 'ETAN    ','ETANSQ  ','DETADT2 ',
-(PID.TID 0000.0001) >#                   'UVEL    ','VVEL    ','WVEL    ',
-(PID.TID 0000.0001) >#                   'THETA   ','SALT    ',
+(PID.TID 0000.0001) ># stat_fields(1:8,1) = 'ETAN    ','ETANSQ  ','DETADT2 ',
+(PID.TID 0000.0001) >#                      'UVEL    ','VVEL    ','WVEL    ',
+(PID.TID 0000.0001) >#                      'THETA   ','SALT    ',
 (PID.TID 0000.0001) >#    stat_fname(1)= 'dynStDiag',
 (PID.TID 0000.0001) >#     stat_freq(1)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,1)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
 (PID.TID 0000.0001) >#                   10,11,12,13,14,15,16,17
 (PID.TID 0000.0001) >##---
-(PID.TID 0000.0001) ># stat_fields(1,2)= 'oceTAUX ','oceTAUY ',
-(PID.TID 0000.0001) >#                   'surForcT','surForcS','TFLUX   ','SFLUX   ',
-(PID.TID 0000.0001) >#                   'oceQnet ','oceSflux','oceFWflx',
+(PID.TID 0000.0001) ># stat_fields(1:9,2) = 'oceTAUX ','oceTAUY ',
+(PID.TID 0000.0001) >#                      'surForcT','surForcS','TFLUX   ','SFLUX   ',
+(PID.TID 0000.0001) >#                      'oceQnet ','oceSflux','oceFWflx',
 (PID.TID 0000.0001) >#    stat_fname(2)= 'surfStDiag',
 (PID.TID 0000.0001) >#     stat_freq(2)= 3153600.,
 (PID.TID 0000.0001) ># stat_region(1,2)=  1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -1455,6 +1466,9 @@
 (PID.TID 0000.0001) exf_monFreq  = /* EXF monitor frequency [ s ] */
 (PID.TID 0000.0001)                 3.600000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) exf_adjMonSelect = /* select group of exf AD-variables to monitor */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) repeatPeriod = /* period for cycling forcing dataset [ s ] */
 (PID.TID 0000.0001)                 3.153600000000000E+07
 (PID.TID 0000.0001)     ;
@@ -1515,22 +1529,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -1707,6 +1730,7 @@
 (PID.TID 0000.0001)  error file = some_T_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  1
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) gencost( 2) = saltatlas
@@ -1716,6 +1740,7 @@
 (PID.TID 0000.0001)  error file = some_S_sigma.bin
 (PID.TID 0000.0001)  gencost_flag =  1
 (PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
 (PID.TID 0000.0001)  gencost_pointer3d =  2
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
@@ -1914,7 +1939,7 @@
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICElinearIterMax = /* max. number of linear solver steps */
-(PID.TID 0000.0001)                    1500
+(PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEnonLinTol     = /* non-linear solver tolerance */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2649,8 +2674,8 @@
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl_init: no. of control variables:            3
-(PID.TID 0000.0001) ctrl_init: control vector length:         7220976
+(PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
+(PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> START <<<
@@ -2678,16 +2703,21 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0201
+(PID.TID 0000.0001)       ncvarindex =  0301
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0202
+(PID.TID 0000.0001)       ncvarindex =  0302
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
 (PID.TID 0000.0001)       weight     = wt_ones.bin
+(PID.TID 0000.0001)       index      =  0203
+(PID.TID 0000.0001)       ncvarindex =  0303
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2695,74 +2725,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   317
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   236 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   239 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   241 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   317 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   261 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   268 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   288 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   296 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   299 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   253 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   254 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   229 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   230 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   123 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   124 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   120 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   121 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   130 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   127 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   128 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
 (PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
 (PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   288  ADVxHEFF , Parms: UU      M1 , mate:   289
-(PID.TID 0000.0001)   set mate pointer for diag #   289  ADVyHEFF , Parms: VV      M1 , mate:   288
-(PID.TID 0000.0001)   set mate pointer for diag #   290  DFxEHEFF , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  DFyEHEFF , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #   296  ADVxSNOW , Parms: UU      M1 , mate:   297
-(PID.TID 0000.0001)   set mate pointer for diag #   297  ADVySNOW , Parms: VV      M1 , mate:   296
-(PID.TID 0000.0001)   set mate pointer for diag #   298  DFxESNOW , Parms: UU      M1 , mate:   299
-(PID.TID 0000.0001)   set mate pointer for diag #   299  DFyESNOW , Parms: VV      M1 , mate:   298
-(PID.TID 0000.0001)   set mate pointer for diag #   253  SIuice   , Parms: UU      M1 , mate:   254
-(PID.TID 0000.0001)   set mate pointer for diag #   254  SIvice   , Parms: VV      M1 , mate:   253
+(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
+(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
+(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
+(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
+(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
+(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
 (PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
 (PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   229  GM_PsiX  , Parms: UU      LR , mate:   230
-(PID.TID 0000.0001)   set mate pointer for diag #   230  GM_PsiY  , Parms: VV      LR , mate:   229
-(PID.TID 0000.0001)   set mate pointer for diag #   123  DFxE_TH  , Parms: UU      MR , mate:   124
-(PID.TID 0000.0001)   set mate pointer for diag #   124  DFyE_TH  , Parms: VV      MR , mate:   123
-(PID.TID 0000.0001)   set mate pointer for diag #   120  ADVx_TH  , Parms: UU      MR , mate:   121
-(PID.TID 0000.0001)   set mate pointer for diag #   121  ADVy_TH  , Parms: VV      MR , mate:   120
-(PID.TID 0000.0001)   set mate pointer for diag #   130  DFxE_SLT , Parms: UU      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   131  DFyE_SLT , Parms: VV      MR , mate:   130
-(PID.TID 0000.0001)   set mate pointer for diag #   127  ADVx_SLT , Parms: UU      MR , mate:   128
-(PID.TID 0000.0001)   set mate pointer for diag #   128  ADVy_SLT , Parms: VV      MR , mate:   127
+(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
+(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
+(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
+(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
+(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
+(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
+(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
+(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2845,8 +2875,95 @@
 (PID.TID 0000.0001)     4 @  2.000000000000000E+00,             /* K = 35: 38 */
 (PID.TID 0000.0001)    12 @  1.000000000000000E+00              /* K = 39: 50 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3041,17 +3158,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -3059,10 +3179,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -3084,7 +3204,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -3093,7 +3213,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -3254,8 +3374,8 @@
 (PID.TID 0000.0001) saltForcing  =  /* Salinity forcing on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balanceEmPmR =  /* balance net fresh-water flux on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectBalanceEmPmR = /* balancing glob.mean EmPmR selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doSaltClimRelax = /* apply SSS relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -3272,7 +3392,7 @@
 (PID.TID 0000.0001) writeBinaryPrec = /* Precision used for writing binary files */
 (PID.TID 0000.0001)                      32
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) balancePrintMean  =  /* print means for balancing fluxes */
+(PID.TID 0000.0001) balancePrintMean = /* print means for balancing fluxes */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  rwSuffixType =   /* select format of mds file suffix */
@@ -3309,8 +3429,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -3325,6 +3445,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -3376,7 +3499,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) pickupStrictlyMatch= /* stop if pickup do not strictly match */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nIter0   =   /* Run starting timestep number */
 (PID.TID 0000.0001)                       0
@@ -3770,47 +3893,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -4599,7 +4681,9 @@
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
-(PID.TID 0000.0001) CTRL_CHECK: #define ALLOW_CTRL
+(PID.TID 0000.0001) CTRL_CHECK:  --> Starts to check CTRL set-up
+(PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
 (PID.TID 0000.0001) etaday defined by gencost   0
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
@@ -5036,10 +5120,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.89207650950910E-01  1.27535774864827E+00
+ cg2d: Sum(rhs),rhsMax =  -2.89207650950903E-01  1.27535774864827E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.83641865407638E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.39424626867405E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39424620964275E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5047,34 +5131,34 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262376662395E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5171680801188E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468437351513E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468437351514E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0375517515402E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7367557597833E-04
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7367557597776E-04
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2635037224615E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3848072839099E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766667313250E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598116154538E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318487970624E-06
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598116162619E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318487742384E-06
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4612559434672E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2013183687207E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481324545005E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184238370729E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010698250996E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481324545003E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184238360316E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010699548700E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8990034776967E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251798245795E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967192532282E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204602325977E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009259389373E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967192531916E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204602288511E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009258917352E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1221846198577E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002431435509E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920325945655E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150249554E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3016215111150E-05
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150249627E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3016215404464E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0696401789330E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0287401465945E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610216795E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063465703E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203349178933E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063465300E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203349192381E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3301822453753E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8315836676857E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.0426692566356E+00
@@ -5107,18 +5191,18 @@
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2275956453778E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6666425959910E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7540183176685E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694754451182E-05
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694754451181E-05
 (PID.TID 0000.0001) %MON ke_max                       =   2.7026108461264E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3999925383809E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3999925380608E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979021026E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -9.7283070556239E-06
 (PID.TID 0000.0001) %MON vort_r_max                   =   1.3301766551003E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541841737610E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526005810E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243418962480E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791911007240E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364313685571E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243418964514E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791911007308E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364313685806E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5162,24 +5246,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.6070752252851E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0721768894532E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4080401142710E-03
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4080401142754E-03
 (PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1683205123755E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6590444344821E-05
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6590444344776E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.1828930560154E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2944199572625E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.6661604326428E-03
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.6661604326489E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3564340237571E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0525238431937E-05
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0525238431827E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0632294159607E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9877363613978E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.5242984231492E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7276261417569E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7166724220795E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.5242984232674E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7276261417595E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7166724222112E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.8560368588294E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9845852817752E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.0210821368499E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2445530381387E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8739733152195E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.0210821368725E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2445530381394E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8739733153020E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4419044704080E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.1151399871527E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.5722890313975E-02
@@ -5207,14 +5291,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4912465616232E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157615073825E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0648186028795E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8854780190611E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627624918267E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4280610516974E-02
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8854780190623E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627624918269E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4280610517883E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2468912299971E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -6.0639664185217E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1104960421457E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8185576306240E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3626269232005E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1104960421479E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8185576306263E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3626269234736E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590912547353E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.4010021173262E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5531116120526E-08
@@ -5248,89 +5332,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.36103301355387E-01  1.24223801417411E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.44235519439193E+00
+ cg2d: Sum(rhs),rhsMax =  -4.36103301356161E-01  1.24223801417413E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.44235519189816E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.97327339882709E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.97327335267369E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932696988596E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285240571647E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729410301320E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247169403341E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6820691693937E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883534944E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932696983759E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285240571256E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729410301361E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247169401675E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6820691712060E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883534916E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.7726823920712E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796597528374E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731509458342E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028317192688E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825300126E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318898613E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363315510689E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770046471249E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474844570828E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835956E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732048137E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641619390755E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645387119058E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519455695018E-08
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796597520474E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731509820413E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028325352413E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825300114E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318898644E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363315395436E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770046609774E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474852859927E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835950E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732047678E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641619416456E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645387390779E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519454000827E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1207805418001E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659994559E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659994557E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920324139776E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138323137E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524391916140E-05
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138324277E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524400247848E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692030172818E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0316468452690E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609436456E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241260908E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931216641111E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241272068E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931220605362E-05
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3190714409649E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3996176116447E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025805510514E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4306290703240E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3795175204438E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025805508980E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4306290703278E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3795175204689E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1828127219075E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407069220789E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1398710012697E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1691595229775E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.8989852213027E-03
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.8989852213026E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4639675004097E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0754281014869E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6506054231021E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7940351669503E-07
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0754281014985E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6506054230993E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7940351668305E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6030889502423E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0596231973745E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2750279377057E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1759858730741E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4238791671417E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2750279377100E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1759858730742E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4238791671418E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2704322309957E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.5633002257873E-03
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.5633002257935E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3598188467078E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8778552325709E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4916559940518E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337285193146E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7973422511481E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209674567566E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758593881560E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8774211805283E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511512648E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635889181494E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.7367852948958E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3275596627658E-04
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8778552325592E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4916559940519E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337264909974E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7973422511459E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209674571235E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758593827882E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8774211805260E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511512625E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635889189343E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.7367852948952E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3275597352284E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979287383E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3712142783234E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2483229552640E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3712142783274E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2483229527798E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278304820E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278305285E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524185475E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726026982E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236989610589E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6193062963662E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726010122E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236989570014E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6193062791124E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5341,24 +5425,24 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3341095674544E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196135995766E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1809073675269E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3341095672623E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196135995765E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1809073675249E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6966438302513E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158248659606E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1429380406270E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6966438302505E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158248659611E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1429380406268E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   4.4925648992250E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9238704332021E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4040291812798E-04
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9238704332020E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4040291812786E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8286763322779E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4670683118993E-02
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4670683118992E-02
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2547240984744E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7030853346681E-04
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7030853346680E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8070831514916E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4915990376763E-03
@@ -5374,24 +5458,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.7460812353986E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.2880075472116E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4062809636170E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2505564859908E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   9.4822093470630E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.4555929386903E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4062809636279E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2505564859909E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   9.4822093470282E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.4555929386902E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.4614409161053E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.3279354348663E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4511363645965E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.0168655752349E-04
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.3279354348816E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4511363645966E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.0168655752319E-04
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629901160661E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0274702988011E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   3.7985936845753E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7424648805889E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7565747500401E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   3.7985936851482E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7424648806072E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7565747501865E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9427654093935E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9860686757295E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.4299491213421E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2729065215188E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   6.0240568467575E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.4299491214281E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2729065215247E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   6.0240568468223E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.5385738615075E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.2700944862139E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.8949561680979E-02
@@ -5418,15 +5502,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7733491035386E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4927149202723E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5082757573105E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530591787639E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8840083706927E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7603722947493E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4230831453454E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6040624655519E-07
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530591787637E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8840083706994E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7603722947613E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4230831454908E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6040624655520E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -7.3102205391973E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1513576353928E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8778109420374E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.5407306119138E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1513576354013E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8778109420426E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.5407306122073E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590960045594E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3907017986231E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530833947075E-08
@@ -5460,89 +5544,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.81295744139983E-01  1.22564183553744E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.18649825671227E+00
+ cg2d: Sum(rhs),rhsMax =  -5.81295744177836E-01  1.22564183554089E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.18649824272784E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.70459378576910E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70459354422790E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284669972E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025084576545E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876544530056E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095703559978E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6715779165601E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532788036907E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959684275E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687228020927E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119875938375E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496074593958E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249366879E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067769293E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392456558936E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278616377951E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778871299934E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195455846E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274854956E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1061231015816E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746312763565E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151555999559E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284670698E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025084691781E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876544531963E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095703533499E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6715779215608E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532787914520E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959684265E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687227999651E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119878041193E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496107489700E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249366938E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067769195E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392455904148E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278616275811E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778890134316E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195455242E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274823793E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1061232471418E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746305387465E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151554971684E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1200643921829E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884008475E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692783E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150499502E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849164377739E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689786989452E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884008468E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692785E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150500990E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849176333676E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689786989405E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0346478241676E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608842191E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416224825E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666316395832E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123026860151E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097064713477E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5623037961370E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418854978354E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168629101976E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416238268E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666320394046E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123026860396E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097064713393E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5623037940063E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418854978886E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168629102633E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409094559967E+02
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1368757790270E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1422014367758E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110338762634E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368176515445E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428892003795E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263080716159E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6026339672300E-07
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1422014367214E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110338762608E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368176515923E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428892009140E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263080716488E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6026339648649E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7300591272462E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.2780756577411E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2175322969937E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2588359723160E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2330714326272E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2175322974259E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2588359723217E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2330714365552E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.4344083006843E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.3716874293008E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442813385251E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8266158682626E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2223061829096E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7791804170005E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823282709E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479069439295E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3369909901536E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2633494686379E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937876433E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486171733695E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.9456878804639E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1606440639754E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.3716874297782E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442813385174E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8266158741548E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2225646572400E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7791805304877E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823280728E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479069438269E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3369911208247E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2633494684313E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937874345E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486171731319E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.9456878804675E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1606443916352E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979547336E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1934696455182E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.1821025660277E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1934696707652E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.1821025664391E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881141689E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881143666E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523419776E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236197081284E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9110009833582E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6195359735586E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196978658E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9110009633250E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6195360070981E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5553,29 +5637,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4793431707452E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457594005674E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2978111908565E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4793431444568E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457594005745E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2978111904779E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9076206356928E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8344959602892E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2605712609756E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9076206362249E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8344959601688E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2605712593560E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865638504086E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218608125966E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3806269282317E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865638504088E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218608125962E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3806269283700E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8283388458671E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535083222E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527238777854E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6842267100498E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8030200906190E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223750626E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129192779074E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9047613610089E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535083201E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527238777852E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6842267100262E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8030200906191E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223750616E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129192779070E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9047613609598E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5586,24 +5670,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.5251081485483E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0471809665163E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3078856652209E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1771891327688E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6716141407679E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3078856650378E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1771891327644E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6716141411067E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.1721785446923E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2359021092171E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.5776641770706E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3767193946971E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2290686132774E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0628148883714E+03
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.5776641768296E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3767193946951E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2290686133513E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0628148883715E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9413896956428E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.2757075754812E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7263840973761E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7097703859800E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8786874982675E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.2757075629174E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7263840968792E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7097703864282E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8786874982673E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9838424676698E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.9738504204815E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2447986149608E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8876042915823E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.9738504187365E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2447986147843E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8876042920064E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4147215850298E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0031143515055E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -3.8456600374457E-02
@@ -5630,15 +5714,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7673323849956E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4922282378209E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4999975361784E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0424568043001E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8827380928243E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7578707669677E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4184444749841E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4458961751343E-07
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0424568042931E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8827380926819E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7578707666520E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4184444747367E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4458961751342E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2407463870764E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1057226601045E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8344423760878E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3558377608613E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1057226599300E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8344423759804E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3558377622139E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591007543835E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3804014799200E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530551773623E-08
@@ -5672,89 +5756,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.25727229094580E-01  1.21024823776090E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.12095611051861E+00
+ cg2d: Sum(rhs),rhsMax =  -7.25727227787834E-01  1.21024823775801E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.12095605606742E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.53868569652386E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53868614311491E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922110493E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3316624191672E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935142933445E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841978325228E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6519309208396E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965625447E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186462855E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324349998180E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180603970791E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9935556938799E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065585237E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868604999802E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359398001140E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197142930450E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742524853006E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790935598E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377536138E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687600494939E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194120590053E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842555816671E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922114018E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3316623765525E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935142867305E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841978360104E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6519309074333E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965258414E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186462793E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324350114749E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180610814900E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9935626717680E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065585536E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868604999181E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359395160098E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197141275438E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742558843972E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790933051E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377438103E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687605909763E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194083780383E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842552338513E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192833239803E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496844E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446996998E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202808788E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200214044933E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0687575469512E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496807E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446997001E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202810287E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200224911737E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0687575469330E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0376365963462E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608413594E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580266901E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420241303793E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029728704369E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990509272869E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312197355871E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282905594226E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928382954950E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580279015E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420243954251E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029728705329E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990509273151E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312198040801E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282905586674E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928384573962E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411051380789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1341272036319E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1285156554753E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3911809185867E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188864300193E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175827103029E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963919999129E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5678057337735E-07
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1341272036317E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1285156551045E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3911809185282E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188864294835E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175826908514E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963920033567E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5678062638578E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5073169292408E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0413476444913E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1088228678403E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861560929077E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4493487202610E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1088228608943E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861560929657E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4493487243618E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2241321533690E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5740224384831E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795817694679E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8524431303379E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2624033544401E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6204983344803E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574538402E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745249616486E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9566288003547E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5353844487015E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6689883444142E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3480662241636E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.4761451477381E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.9248602713292E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5740224429825E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795817694510E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8524431160551E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2624033258554E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6204983356874E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574530054E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745249611678E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9566291748648E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5353844478305E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6689883435354E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3480662349092E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.4761451477609E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.9248612058544E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979803213E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426493470125E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787478435260E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426494585891E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787477591197E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665821588E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665826645E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523573464E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771320831E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855814748673E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4561236228893E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771062514E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855814449492E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4561237633845E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5765,29 +5849,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0162030668215E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156245080188E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414239244030E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0162030449647E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156245083497E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414239181925E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0123522409093E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937384987626E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3027980265484E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0123522391793E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937384986024E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3027980148176E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796555325712E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198133966130E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3603644557753E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796555326697E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198133966187E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3603644551071E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8280086640459E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519271717065E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2508408765317E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6647904486480E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7989733914990E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519271717812E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2508408765300E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6647904478391E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7989733914994E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4661668769786E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5084813237105E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8738869363040E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4661668769817E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5084813236922E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8738869345359E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5798,24 +5882,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.3889986822667E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -8.7557819176677E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.1862432695095E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1353663240829E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2226672380732E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.1862432696323E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1353663240816E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2226672391130E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   1.9743039644200E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.0704230365841E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8986288454965E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3384926285928E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.7112577894395E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629912665500E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8757679947332E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920800241038E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173325044408E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755719956098E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481746E-07
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8986288453581E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3384926285934E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.7112577898950E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629912665502E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8757679947322E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920800232962E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173325043974E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755719959128E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481742E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9814667799294E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7081092349505E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2285801832996E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8080121582768E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7081092348804E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2285801832767E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8080121588070E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3352358384690E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8681139737310E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -4.7963639067935E-02
@@ -5842,15 +5926,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7626414634741E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4919559013695E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4913982162377E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547220449E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503680933E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225056658E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141808272304E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730613858E-07
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547220015E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503680829E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225056100E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141808261614E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730611241E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9685992420746E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234363493E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8121389632987E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2372241234016E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234363423E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8121389632971E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2372241239996E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591055042077E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3701011612169E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530269600171E-08
@@ -5884,89 +5968,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.67149197034585E-01  1.20371037440102E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05918903180887E+00
+ cg2d: Sum(rhs),rhsMax =  -8.67149194116921E-01  1.20371037418158E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.05918852555755E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.60071370064177E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.60072508365575E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340767236E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215246231287E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895540673471E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755463635059E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6366049942205E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617984396E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345798590E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625852664817E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924724885387E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9230690964262E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006582022026E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518304657E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896870994864E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520051367325E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360668711109E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399155550E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455621090E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9408214497093E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217609264528E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133363809571E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340770794E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215245389635E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895540525853E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755464069879E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6366049362456E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617086129E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345820842E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625853228592E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924740980637E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9230798284578E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006582022732E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518303548E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896863511017E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520046423320E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360713078394E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399149890E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455576586E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9408342108840E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217515529758E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133359152241E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1191979292709E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760074679E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525739031E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283388674E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518526245040E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0685358737846E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405660035871E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760074571E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525739030E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283390117E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518536545512E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0685358737428E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405660035872E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608120200E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734638062E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196725579430E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916870569673E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8729104566504E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511907946654E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203147073075E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400671970633E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734648715E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196727353694E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916870565923E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8729104566519E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511908708570E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203147077970E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400673284758E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413085044862E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874723240E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1085738066298E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298774100059E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907235854827E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9895136873569E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693309823136E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276608389532E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413085044861E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874723225E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1085738055500E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298774100040E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907235853645E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9895136640680E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693309886104E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276613203042E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.3668407825272E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -8.5617187280947E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9867974191319E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1447211671805E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0405925352846E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9867974041393E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1447211673908E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0405925194237E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.9655206104464E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.0530327881975E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8716666329547E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437586371738E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3748343600172E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2688105734008E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5453096227053E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625271165E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693650435489E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2447220490887E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509979640E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620927743E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081418700012E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.7885949866378E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.5517848982164E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8716666354805E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437586370645E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3748342246777E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2691737854473E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5453096231008E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625252647E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693650424465E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2447228049124E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509960306E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620908274E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081419303624E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.7885949866965E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.5517870911248E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980055921E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4304639651305E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4448039193142E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4304647942671E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4448039200468E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633814028E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633824300E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524311651E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230135019627E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237956265488E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610906590631E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230134559809E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237956377044E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610909539304E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5977,29 +6061,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2522558962786E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656654151545E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854241167615E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2522558646058E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656654150882E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854240864296E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0122557738928E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297274520532E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462579488267E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0122557653083E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297274498487E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462579198432E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734154434218E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178833893009E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3494466861581E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734154435268E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178833892956E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3494466794933E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276856009030E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444994002535E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2490567516677E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6457510974734E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7949467529206E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444994004204E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2490567516763E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6457510965208E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7949467529213E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4539554450924E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5043619440897E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8433400502163E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4539554450920E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5043619440291E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8433400465434E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6010,24 +6094,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.2831318509792E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434050E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484232684436E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962362734E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600943419426E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484232687517E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962362739E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600943434523E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   1.9175555650671E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3287879803731E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.2423852063564E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3329377393573E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021697629839E-05
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.2423852062689E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3329377393591E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021697636126E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.0634977156346E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655893300E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995817416422E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148222620374E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587902203768E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299319E-07
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655893347E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995817474404E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148222622337E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587902202622E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299332E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9789290821009E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503313784756E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214313568533E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7690887626480E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503313793413E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214313569171E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7690887631082E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2726117910117E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7761128863488E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.7470677761413E-02
@@ -6053,16 +6137,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144802493326E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7592795785517E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4918980283005E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4832029776207E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0245718410449E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807420228960E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666936257E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101676000761E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373861459E-07
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4832029776208E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0245718408878E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807420229659E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666937227E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101675985115E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373856386E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068078009E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733205454997E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074412145108E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765850607582E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733205455862E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074412145728E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765850610992E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591102540318E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3598008425138E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529987426719E-08
@@ -6096,89 +6180,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.00592192861238E+00  1.20159697286710E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.97628129061131E-01
+ cg2d: Sum(rhs),rhsMax =  -1.00592126168528E+00  1.20159697200379E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.97628045090659E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.53029604331292E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53030410193537E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300733803870E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662268094867E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9753066938578E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413282325431E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6275226594289E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721056473350E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160061977396E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954950941107E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301602369296E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176685286626E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495110624E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870559598813E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705534437981E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230412483851E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3723862843394E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739661822E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771664827E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6250590108240E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564433440181E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126909434958E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300733814450E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662266620638E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9753033183358E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413283853105E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6275225560855E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721055326871E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160062019487E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954952222682E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301633146774E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176852513225E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495111700E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870559216603E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705517930143E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230402539505E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3723917490219E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739654352E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771719301E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6248891265395E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564236437748E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126907648888E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190811894460E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381280171E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188664E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377346526E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894010491754E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0683073389758E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434312287331E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852219E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882519855E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991779570348E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769029057524E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655893300E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764560204574E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173626770286E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2239129675823E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381279961E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188727E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377347880E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894022209439E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0683073388660E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434312287334E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852221E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882528418E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991780730770E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769029048720E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655893347E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764878728097E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173623635784E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2239132407035E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415099503286E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289595903842E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0706488496788E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208620679548E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644235890560E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9601095907772E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460134633491E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3862919351095E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415102702953E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289558115579E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0706993085015E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208620679923E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644235892681E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9600999846033E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460081381312E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3862963225048E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2667053449446E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -7.5828157462759E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8432088411559E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1314706671193E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9391518035786E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8432088276719E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1314706672807E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9391516651528E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.9061087909401E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -9.2507416138126E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2083269479624E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383441627137E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2090836820817E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8491800512161E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9732333959038E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452921628E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068346585120E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1519602202410E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711423870E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566480416E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541838150445E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9025276942360E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9793106347594E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2083269409728E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383441624300E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2090833593552E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8495895526355E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9732348335331E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452894845E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068346566374E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1519612112710E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711395884E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566452303E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541839864644E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9025276943427E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9793150535787E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980305113E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460594982706E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6833524417622E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460619113304E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6833524563250E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765214316E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525442699E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228660467456E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948342655426E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4860084403502E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765232433E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525442698E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228659805479E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948343865178E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4860127691799E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6189,29 +6273,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6355334530564E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999373609256E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4296973518168E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6355332306810E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999373611344E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4296973006639E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9473469977376E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499002545399E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889120691127E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9473469885989E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499002481620E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889120524610E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672903189932E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160107815985E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3277815563380E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672903464495E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160107904851E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3277815099237E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8273693243316E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371765566134E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473574524939E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6274322176683E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7909324212943E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371765947830E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473574595291E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6274321159728E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7909324212949E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420582689018E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5005237686793E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8140982471332E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420582688949E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5005237685378E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8140982404647E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6222,24 +6306,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.2371508581871E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7514785530382E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006525084569E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419512727E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659096882932E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006525040223E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419513071E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659096914485E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.0591191646476E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3794009108900E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572470343040E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460670203E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776766987509E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661035683934E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8363753843850E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962897635819E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185812773240E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662560387918E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419661106E-07
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572470299302E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460670448E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776766990345E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661035683928E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8363753843976E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962898074719E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185812771610E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662560384681E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419658896E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9762180582361E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026214080646E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211145011537E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820071079500E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026214151812E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211145010551E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820071087746E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2409841947187E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8299208716971E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -6.6977716454892E-02
@@ -6265,16 +6349,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144758652374E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7572490584599E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4920546435694E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755389567986E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605619741E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799445466971E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508391575718E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063436515340E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873482821E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426819769E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885244432564E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196464265458E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820919444634E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755389567996E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605615491E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799445477293E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508391570997E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063436500512E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873470792E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426819772E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885244439681E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196464257788E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820919446648E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591150038559E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3495005238107E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529705253267E-08
@@ -6308,89 +6392,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.14222695022564E+00  1.19970674505746E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.23837311717082E-01
+ cg2d: Sum(rhs),rhsMax =  -1.14222628914908E+00  1.19970674306433E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.23836019184499E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.67498531973087E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.67498971084999E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291615863E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378327007423E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491935592194E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422588000426E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6186658506147E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167154426E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569525655E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408372955539E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229585505326E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372972214004E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916415476E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0765529923263E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305476085722E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454336665207E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018529564125E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740326324E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304655886617E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7346791804500E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6039359515058E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914845261672E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291640306E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378324699810E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491902133006E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422591379299E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6186656904722E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167168312E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569591478E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408375545647E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229635357589E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372993177299E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916417186E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0765530564230E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305443710827E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454320641302E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018536702812E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740321322E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304656183076E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7346401368402E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6038990239578E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914841171317E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1189299556257E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766176901E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546352E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470784822E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352044239468E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0680752822352E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461824978009E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539502E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185024017321E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803574759586E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582352018480E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8363753843850E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118488748140E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189933883031E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155846234574E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766176572E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546396E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470786168E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352056042197E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0680752819200E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461824978019E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539504E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185024024798E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803575471761E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582352021978E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8363753843976E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118485362385E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189933933331E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155847097593E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096977815E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267317544034E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0624634502282E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2098939252528E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214854361787E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261932901574E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240128354952E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291101477949E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096970674E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267317624053E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0624629292086E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2098939253085E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214854378729E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261933747734E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240128996939E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291104454444E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2357676847980E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850301E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6895546044395E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452627519908E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0520799792857E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850300E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6895545780395E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452627523333E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0520798151831E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3752841738518E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5092881521547E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659195026486E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3004238417539E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5584796739323E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9074644522086E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630564065E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682181479635E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446767642681E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660711754767E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952334526339E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356199970539E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.1301078877144E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1984100699804E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550622E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9194090250405E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.9202318324203E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5092881337342E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659195024229E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3004233594916E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5589072851872E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9074644257842E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630561483E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682181454397E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446750010041E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660697957044E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952320592439E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356203667734E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.1301078878759E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1984176403006E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550620E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9194145392478E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.9202318573333E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004608014E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526751795E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228358857280E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548704640947E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9262506577502E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004636514E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526751796E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228357974248E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548740250703E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9262594542158E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6401,29 +6485,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3182981969637E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235154878475E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794510288995E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3182974036271E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235154864519E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794509651385E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8464858006455E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613023486132E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376046622503E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8464857897120E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613023400092E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376046609483E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614062775721E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142080269842E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3242547088285E-04
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614063047771E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142080356702E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3242546592015E-04
 (PID.TID 0000.0001) %MON seaice_heff_max              =   2.8270594631784E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299746270763E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457182809526E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6103398671226E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7869283205130E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305267547867E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4969035855310E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7873139340769E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299746649107E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457182878244E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6103397695953E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7869283205139E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305267547927E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4969035852915E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7873139263875E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6432,247 +6516,247 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.118385567335094D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.183174713284878D+05 2
+(PID.TID 0000.0001)  --> f_gencost = 0.118384850545114D+05 1
+(PID.TID 0000.0001)  --> f_gencost = 0.183174381851149D+05 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.301560280619972D+05
+(PID.TID 0000.0001)  --> fc               = 0.301559232396262D+05
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.128988851582868D+04
-(PID.TID 0000.0001)  global fc =  0.301560280619972D+05
+(PID.TID 0000.0001)   local fc =  0.128986339262774D+04
+(PID.TID 0000.0001)  global fc =  0.301559232396262D+05
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   280.36439181864262
-(PID.TID 0000.0001)         System time:   15.121662355959415
-(PID.TID 0000.0001)     Wall clock time:   369.64586305618286
+(PID.TID 0000.0001)           User time:   192.42465613037348
+(PID.TID 0000.0001)         System time:   54.003030091524124
+(PID.TID 0000.0001)     Wall clock time:   292.58331894874573
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   9.3932588398456573
-(PID.TID 0000.0001)         System time:   3.3176709562540054
-(PID.TID 0000.0001)     Wall clock time:   47.926787137985229
+(PID.TID 0000.0001)           User time:   5.7922270186245441
+(PID.TID 0000.0001)         System time:   2.3971491008996964
+(PID.TID 0000.0001)     Wall clock time:   10.320887804031372
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   270.97102737426758
-(PID.TID 0000.0001)         System time:   11.803963422775269
-(PID.TID 0000.0001)     Wall clock time:   321.71899199485779
+(PID.TID 0000.0001)           User time:   186.63236904144287
+(PID.TID 0000.0001)         System time:   51.605838060379028
+(PID.TID 0000.0001)     Wall clock time:   282.26234793663025
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   19.418253898620605
-(PID.TID 0000.0001)         System time:   6.9382815361022949
-(PID.TID 0000.0001)     Wall clock time:   45.946469068527222
+(PID.TID 0000.0001)           User time:   23.607336521148682
+(PID.TID 0000.0001)         System time:   42.998184442520142
+(PID.TID 0000.0001)     Wall clock time:   96.644491910934448
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   251.55270576477051
-(PID.TID 0000.0001)         System time:   4.8656558990478516
-(PID.TID 0000.0001)     Wall clock time:   275.77245521545410
+(PID.TID 0000.0001)           User time:   163.02499580383301
+(PID.TID 0000.0001)         System time:   8.6076278686523438
+(PID.TID 0000.0001)     Wall clock time:   185.61780595779419
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1199531555175781
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.2487673759460449
+(PID.TID 0000.0001)           User time:   1.7545814514160156
+(PID.TID 0000.0001)         System time:   8.7852478027343750E-003
+(PID.TID 0000.0001)     Wall clock time:   2.0238733291625977
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   7.2422027587890625E-003
-(PID.TID 0000.0001)         System time:   2.0313262939453125E-004
-(PID.TID 0000.0001)     Wall clock time:   7.4307918548583984E-003
+(PID.TID 0000.0001)           User time:   5.5694580078125000E-003
+(PID.TID 0000.0001)         System time:   6.4086914062500000E-004
+(PID.TID 0000.0001)     Wall clock time:   6.2093734741210938E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   242.48047447204590
-(PID.TID 0000.0001)         System time:   3.8760261535644531
-(PID.TID 0000.0001)     Wall clock time:   264.32189345359802
+(PID.TID 0000.0001)           User time:   156.75225448608398
+(PID.TID 0000.0001)         System time:   5.7635650634765625
+(PID.TID 0000.0001)     Wall clock time:   167.63089489936829
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   242.48031425476074
-(PID.TID 0000.0001)         System time:   3.8760194778442383
-(PID.TID 0000.0001)     Wall clock time:   264.32170438766479
+(PID.TID 0000.0001)           User time:   156.75212287902832
+(PID.TID 0000.0001)         System time:   5.7635498046875000
+(PID.TID 0000.0001)     Wall clock time:   167.63074684143066
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2494468688964844
-(PID.TID 0000.0001)         System time:   2.3908615112304688E-003
-(PID.TID 0000.0001)     Wall clock time:   3.3487727642059326
+(PID.TID 0000.0001)           User time:   2.6170368194580078
+(PID.TID 0000.0001)         System time:   6.4086914062500000E-003
+(PID.TID 0000.0001)     Wall clock time:   2.6518123149871826
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4766368865966797
-(PID.TID 0000.0001)         System time:   7.4234008789062500E-002
-(PID.TID 0000.0001)     Wall clock time:   1.8133151531219482
+(PID.TID 0000.0001)           User time:   1.4427108764648438
+(PID.TID 0000.0001)         System time:   3.6468505859375000E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6289408206939697
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5061378479003906
-(PID.TID 0000.0001)         System time:   3.3741950988769531E-002
-(PID.TID 0000.0001)     Wall clock time:   3.0683457851409912
+(PID.TID 0000.0001)           User time:   1.6831016540527344
+(PID.TID 0000.0001)         System time:  0.21703720092773438
+(PID.TID 0000.0001)     Wall clock time:   3.4260177612304688
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   2.4702262878417969
-(PID.TID 0000.0001)         System time:   3.3699989318847656E-002
-(PID.TID 0000.0001)     Wall clock time:   3.0324168205261230
+(PID.TID 0000.0001)           User time:   1.6826496124267578
+(PID.TID 0000.0001)         System time:  0.21699905395507812
+(PID.TID 0000.0001)     Wall clock time:   3.4255392551422119
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.6403198242187500E-004
-(PID.TID 0000.0001)         System time:   3.0517578125000000E-005
-(PID.TID 0000.0001)     Wall clock time:   1.8405914306640625E-004
+(PID.TID 0000.0001)           User time:   1.2016296386718750E-004
+(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
+(PID.TID 0000.0001)     Wall clock time:   1.5425682067871094E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.29508781433105469
-(PID.TID 0000.0001)         System time:   2.0694732666015625E-004
-(PID.TID 0000.0001)     Wall clock time:  0.32565164566040039
+(PID.TID 0000.0001)           User time:  0.19026947021484375
+(PID.TID 0000.0001)         System time:   7.3509216308593750E-003
+(PID.TID 0000.0001)     Wall clock time:  0.43819952011108398
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14374160766601562
-(PID.TID 0000.0001)         System time:   1.3542175292968750E-004
-(PID.TID 0000.0001)     Wall clock time:  0.15996432304382324
+(PID.TID 0000.0001)           User time:   9.5878601074218750E-002
+(PID.TID 0000.0001)         System time:   1.7929077148437500E-004
+(PID.TID 0000.0001)     Wall clock time:   9.6321105957031250E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   59.113929748535156
-(PID.TID 0000.0001)         System time:  0.11674213409423828
-(PID.TID 0000.0001)     Wall clock time:   62.845994472503662
+(PID.TID 0000.0001)           User time:   31.620868682861328
+(PID.TID 0000.0001)         System time:  0.26361846923828125
+(PID.TID 0000.0001)     Wall clock time:   32.772032737731934
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   25.722764968872070
-(PID.TID 0000.0001)         System time:   3.5181045532226562E-002
-(PID.TID 0000.0001)     Wall clock time:   27.835830926895142
+(PID.TID 0000.0001)           User time:   10.798828125000000
+(PID.TID 0000.0001)         System time:   8.0821990966796875E-002
+(PID.TID 0000.0001)     Wall clock time:   11.128607988357544
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   24.692993164062500
-(PID.TID 0000.0001)         System time:   3.4386634826660156E-002
-(PID.TID 0000.0001)     Wall clock time:   26.730932235717773
+(PID.TID 0000.0001)           User time:   10.074234008789062
+(PID.TID 0000.0001)         System time:   7.4882507324218750E-002
+(PID.TID 0000.0001)     Wall clock time:   10.360017061233521
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   11.015956878662109
-(PID.TID 0000.0001)         System time:   3.0525207519531250E-002
-(PID.TID 0000.0001)     Wall clock time:   11.606991052627563
+(PID.TID 0000.0001)           User time:   5.8744697570800781
+(PID.TID 0000.0001)         System time:  0.10881042480468750
+(PID.TID 0000.0001)     Wall clock time:   6.5330054759979248
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   39.127735137939453
-(PID.TID 0000.0001)         System time:   3.7235260009765625E-002
-(PID.TID 0000.0001)     Wall clock time:   41.664861679077148
+(PID.TID 0000.0001)           User time:   28.310768127441406
+(PID.TID 0000.0001)         System time:   3.4511566162109375E-002
+(PID.TID 0000.0001)     Wall clock time:   28.841952800750732
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7287063598632812
-(PID.TID 0000.0001)         System time:   2.0503997802734375E-004
-(PID.TID 0000.0001)     Wall clock time:   3.9484841823577881
+(PID.TID 0000.0001)           User time:   1.9145927429199219
+(PID.TID 0000.0001)         System time:   5.6457519531250000E-004
+(PID.TID 0000.0001)     Wall clock time:   1.9405910968780518
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.090465545654297
-(PID.TID 0000.0001)         System time:   6.4573287963867188E-003
-(PID.TID 0000.0001)     Wall clock time:   13.036040782928467
+(PID.TID 0000.0001)           User time:   4.7038078308105469
+(PID.TID 0000.0001)         System time:   8.6212158203125000E-004
+(PID.TID 0000.0001)     Wall clock time:   4.7834656238555908
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.91400146484375000
-(PID.TID 0000.0001)         System time:   4.4631958007812500E-004
-(PID.TID 0000.0001)     Wall clock time:   1.0067205429077148
+(PID.TID 0000.0001)           User time:  0.56344223022460938
+(PID.TID 0000.0001)         System time:   4.6539306640625000E-004
+(PID.TID 0000.0001)     Wall clock time:  0.57146644592285156
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.1833953857421875
-(PID.TID 0000.0001)         System time:   2.0694732666015625E-004
-(PID.TID 0000.0001)     Wall clock time:   2.3181595802307129
+(PID.TID 0000.0001)           User time:   1.2236709594726562
+(PID.TID 0000.0001)         System time:   2.1324157714843750E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2347440719604492
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16819381713867188
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.18037581443786621
+(PID.TID 0000.0001)           User time:  0.10396575927734375
+(PID.TID 0000.0001)         System time:   5.7220458984375000E-005
+(PID.TID 0000.0001)     Wall clock time:  0.10407519340515137
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9882164001464844
-(PID.TID 0000.0001)         System time:   5.1716804504394531E-002
-(PID.TID 0000.0001)     Wall clock time:   2.2577390670776367
+(PID.TID 0000.0001)           User time:   1.3430900573730469
+(PID.TID 0000.0001)         System time:   3.8562774658203125E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4067502021789551
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   44.530139923095703
-(PID.TID 0000.0001)         System time:   3.4720420837402344E-002
-(PID.TID 0000.0001)     Wall clock time:   47.727813243865967
+(PID.TID 0000.0001)           User time:   30.723491668701172
+(PID.TID 0000.0001)         System time:   5.6011199951171875E-002
+(PID.TID 0000.0001)     Wall clock time:   31.209543943405151
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.4849853515625000E-005
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:   8.7022781372070312E-005
+(PID.TID 0000.0001)           User time:   5.3405761718750000E-005
+(PID.TID 0000.0001)         System time:   1.1444091796875000E-005
+(PID.TID 0000.0001)     Wall clock time:   9.5129013061523438E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   12.789226531982422
-(PID.TID 0000.0001)         System time:   7.6646804809570312E-003
-(PID.TID 0000.0001)     Wall clock time:   13.518999099731445
+(PID.TID 0000.0001)           User time:   6.5896339416503906
+(PID.TID 0000.0001)         System time:   3.3264160156250000E-003
+(PID.TID 0000.0001)     Wall clock time:   6.6583981513977051
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.5367431640625000E-005
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.0299682617187500E-004
+(PID.TID 0000.0001)           User time:   7.2479248046875000E-005
+(PID.TID 0000.0001)         System time:   1.1444091796875000E-005
+(PID.TID 0000.0001)     Wall clock time:   6.6518783569335938E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.425632476806641
-(PID.TID 0000.0001)         System time:   2.0149250030517578
-(PID.TID 0000.0001)     Wall clock time:   20.150168895721436
+(PID.TID 0000.0001)           User time:   7.0749588012695312
+(PID.TID 0000.0001)         System time:   2.6128349304199219
+(PID.TID 0000.0001)     Wall clock time:   10.321323871612549
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.1451301574707031
-(PID.TID 0000.0001)         System time:   1.4858770370483398
-(PID.TID 0000.0001)     Wall clock time:   7.2299754619598389
+(PID.TID 0000.0001)           User time:   2.3383598327636719
+(PID.TID 0000.0001)         System time:   2.4740676879882812
+(PID.TID 0000.0001)     Wall clock time:   5.0881698131561279
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0054931640625000
-(PID.TID 0000.0001)         System time:  0.13591480255126953
-(PID.TID 0000.0001)     Wall clock time:   1.3173520565032959
+(PID.TID 0000.0001)           User time:  0.63180541992187500
+(PID.TID 0000.0001)         System time:   1.1138381958007812
+(PID.TID 0000.0001)     Wall clock time:   1.7518250942230225
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.7983398437500000E-004
-(PID.TID 0000.0001)         System time:   2.9563903808593750E-005
-(PID.TID 0000.0001)     Wall clock time:   5.9986114501953125E-004
+(PID.TID 0000.0001)           User time:   9.0026855468750000E-004
+(PID.TID 0000.0001)         System time:   2.5177001953125000E-004
+(PID.TID 0000.0001)     Wall clock time:   1.1570453643798828E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5108337402343750
-(PID.TID 0000.0001)         System time:  0.77766799926757812
-(PID.TID 0000.0001)     Wall clock time:   7.3534719944000244
+(PID.TID 0000.0001)           User time:   3.8592987060546875
+(PID.TID 0000.0001)         System time:   1.7203445434570312
+(PID.TID 0000.0001)     Wall clock time:   14.183081150054932
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.7281188964843750
-(PID.TID 0000.0001)         System time:  0.64579772949218750
-(PID.TID 0000.0001)     Wall clock time:   5.3954479694366455
+(PID.TID 0000.0001)           User time:   2.9331970214843750
+(PID.TID 0000.0001)         System time:   1.3833274841308594
+(PID.TID 0000.0001)     Wall clock time:   10.368959903717041
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.7826538085937500
-(PID.TID 0000.0001)         System time:  0.13186740875244141
-(PID.TID 0000.0001)     Wall clock time:   1.9579799175262451
+(PID.TID 0000.0001)           User time:  0.92604064941406250
+(PID.TID 0000.0001)         System time:  0.33700180053710938
+(PID.TID 0000.0001)     Wall clock time:   3.8140730857849121
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.4088134765625000E-002
+(PID.TID 0000.0001)           User time:   1.5777587890625000E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.4097909927368164E-002
+(PID.TID 0000.0001)     Wall clock time:   1.5799999237060547E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6811,9 +6895,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          41194
+(PID.TID 0000.0001) //            No. barriers =          40996
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          41194
+(PID.TID 0000.0001) //     Total barrier spins =          40996
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecco_v4.txt
+++ b/global_oce_llc90/results/output_adm.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68i
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node143
-(PID.TID 0000.0001) // Build date:        Sun May  8 00:44:45 EDT 2022
+(PID.TID 0000.0001) // Build host:        node047
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 22:54:12 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node143
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node047
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -909,8 +909,6 @@
 (PID.TID 0000.0001) ># ECCO controlvariables
 (PID.TID 0000.0001) ># *********************
 (PID.TID 0000.0001) > &ctrl_nml
-(PID.TID 0000.0001) > ctrlSmoothCorrel2D=.TRUE.,
-(PID.TID 0000.0001) > ctrlSmoothCorrel3D=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># *********************
@@ -964,9 +962,9 @@
 (PID.TID 0000.0001) > mult_genarr3d(3) = 1.,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -1140,7 +1138,12 @@
 (PID.TID 0000.0001) > gencost_posproc_i(1,6)=300,
 (PID.TID 0000.0001) > gencost_outputlevel(6)=0,
 (PID.TID 0000.0001) > mult_gencost(6) = 0.,
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >#- To use cost_gencost_bpv4, needs to switch name to 'bpv4-grace':
+(PID.TID 0000.0001) ># gencost_name(6) = 'bpv4-grace',
+(PID.TID 0000.0001) >#- the hard-coded (before PR 693) values used in gencost_bpv4 for smooth_basic2D calls:
+(PID.TID 0000.0001) ># gencost_posproc_i(1,6)=3000,
+(PID.TID 0000.0001) ># gencost_posproc_r(1,6)=3.E+5,
+(PID.TID 0000.0001) >#---
 (PID.TID 0000.0001) > gencost_avgperiod(7)  = 'month',
 (PID.TID 0000.0001) > gencost_barfile(7) = 'm_theta_mon',
 (PID.TID 0000.0001) > gencost_datafile(7) = 'some_T_atlas.bin',
@@ -1566,22 +1569,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -2768,7 +2780,6 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
 (PID.TID 0000.0001)       weight     = wt_theta.data
@@ -2880,6 +2891,93 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3810,47 +3908,6 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -4684,15 +4741,17 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) whio : create lev 3 rec   9
 (PID.TID 0000.0001) whio : write lev 3 rec   1
 (PID.TID 0000.0001) whio : create lev 2 rec   9
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390895E+00  1.09179581247341E+00
 (PID.TID 0000.0001)      cg2d_init_res =   4.03338454629892E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      97
-(PID.TID 0000.0001)      cg2d_last_res =   6.87078516858847E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.87078516858648E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4706,28 +4765,28 @@
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0485872661593E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.0553130009468E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5138414332745E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1938704913505E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8162068131127E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1938706271773E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8162089070790E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4002289037858E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4479586117335E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1357185310131E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3993812045501E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9536013175838E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3993815895083E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9536088944519E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0928692735841E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2072774747459E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.2929024700903E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1049525379107E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.8305488432416E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2072774767037E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.2929024700858E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.1049524576692E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.8305540968644E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2641500127166E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0000537019659E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905919271772E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366217867300E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0901420304338E-04
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366217866803E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0901420941820E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711525591027E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8985762452912E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703661839E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856241011279E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6688845519313E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856241007837E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6688845226846E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7836615429034E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.3167369764867E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3136304203906E-01
@@ -4737,16 +4796,16 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.3443192107857E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   4.3851963240317E-04
 (PID.TID 0000.0001) %MON ke_max                       =   4.9603099464683E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1141381028800E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1141392810673E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973313513E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -3.1806217704399E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.6481652876127E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543433013478E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543433016348E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535764036E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239719919182E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5565857071167E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.3337700606829E-08
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239719928238E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.5565857078633E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   2.3337700514879E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4800,14 +4859,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.4837461086138E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.6313815521879E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -8.7180082412718E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   6.4398001629155E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8541553784507E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.6374921703679E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   6.4398001718987E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8541553786188E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.6374921699759E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0132889153431E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1874770648534E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.2227722113327E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0683180120337E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5255584727557E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.2227722123641E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0683180120757E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5255584726784E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   3.1023215152125E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.4405696746102E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0357432074842E+00
@@ -4825,14 +4884,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943211487414E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2977500525357E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.4123135704874E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8190457017898E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.9275281450121E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0864558876080E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8190457018743E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.9275281451482E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0864558875994E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2107236478332E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9745350550691E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3522315631731E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.9141040825253E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1514806614546E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3522315632762E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.9141040826424E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1514806596684E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.2382273106148E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6253943692965E-08
@@ -4861,66 +4920,66 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01041588518803E+00  1.09558808552461E+00
- cg2d: Sum(rhs),rhsMax =   3.00954214495678E+00  1.09443701612858E+00
- cg2d: Sum(rhs),rhsMax =   3.01016045548307E+00  1.08987441574900E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.28313853244510E-01
+ cg2d: Sum(rhs),rhsMax =   3.01041588455338E+00  1.09558808552451E+00
+ cg2d: Sum(rhs),rhsMax =   3.00955492404701E+00  1.09443701613900E+00
+ cg2d: Sum(rhs),rhsMax =   3.01017515177041E+00  1.08987441579349E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.28433394888047E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
-(PID.TID 0000.0001)      cg2d_last_res =   6.69589242718105E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.69395255437911E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471519900E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314453380228E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5364670798872E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4454859635475E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7483044092624E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760081215520E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988302432E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5186196026815E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978086573781E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6572910883629E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383032982322E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223637149867E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1562736794686E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960074962024E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7811177322450E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424525389838E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868898286E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.2796359635536E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260316692001E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3780612527926E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631424366E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0001593307136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009524674E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365928991210E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0869856999734E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2955471473709E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5314451675692E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5364745188151E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4454862256508E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.7483040043296E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.6760085607848E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.3644988639475E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5186196221702E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1978088933912E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6572961377100E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7383032983530E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4223637149982E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1562735035575E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3960082587200E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7811394465692E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.4424519501795E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2282868903466E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.2795064516674E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0260346799630E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.3781031289270E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631424367E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0001593307171E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906009526279E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365928987867E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0869858861727E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711518357459E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8961657805401E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703732382E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856092263039E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6509681471188E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976243324082E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3023530770518E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568857126E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646710482314E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2850688081869E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634433268E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453223216E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3811384773403E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.7437361581158E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1149709866981E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973281812E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391231229539E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.1981391008161E-05
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8961657805987E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703732443E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856092218325E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6509681251796E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7976238719351E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.3017571312468E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6285568912683E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.1646705954743E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.2844740085850E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6485634488559E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6592453278773E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3811384007784E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.7437361582132E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1149732473083E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973281789E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9391228804178E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.1980340448914E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543385089282E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535906620E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240318983698E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6369653701795E-08
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0629987063968E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543385096965E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535906659E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240318874746E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.6368474395210E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   3.0628959136750E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4931,29 +4990,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5746897425346E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884111829724E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1037699560989E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   5.5746908561041E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8884111860078E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.1037706303833E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0042403591585E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554120359320E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1520816267127E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.0042391010316E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9554120525163E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1520851979096E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430116064752E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998446341930E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7078119678145E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8235293926932E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9430116232561E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.7998446985035E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.7078084551227E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8235293926934E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3427463188406E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488306466057E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8581862618734E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4877998393472E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433312910719E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439874399427E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782653053489E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3427471600295E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0488308286006E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.8581857713966E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.4878000198988E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2433312905817E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1439874421479E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.3782652431216E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4972,16 +5031,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131724908E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438470898E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5585275592280E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3838433299774E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1623632180480E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031817552E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3990131724209E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113438470904E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.5585272869989E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3838433216934E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1623632215955E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862031817548E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660502970E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5928318761922E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7494025943926E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122954130253E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5928319049538E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7494025943979E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2122954161132E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -4998,15 +5057,15 @@
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3025509150153E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202665250796E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8163263051458E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8529297301467E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0830016067009E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804660962393E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282754932737E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3512195042496E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8088798089618E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9447970308801E-11
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.3202665266722E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8163263260548E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8529297391456E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0830016226132E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804660962389E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282754932705E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3512195071258E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8088798028344E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9447970330260E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -5035,66 +5094,66 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01200063669187E+00  1.08234533946216E+00
- cg2d: Sum(rhs),rhsMax =   3.01472254612810E+00  1.07091042398987E+00
- cg2d: Sum(rhs),rhsMax =   3.01809829994306E+00  1.05630803624323E+00
-(PID.TID 0000.0001)      cg2d_init_res =   3.10577667603013E-01
+ cg2d: Sum(rhs),rhsMax =   3.01200115353616E+00  1.08234533946652E+00
+ cg2d: Sum(rhs),rhsMax =   3.01470652906668E+00  1.07091042427190E+00
+ cg2d: Sum(rhs),rhsMax =   3.01807456298840E+00  1.05630803662867E+00
+(PID.TID 0000.0001)      cg2d_init_res =   3.10585108333722E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      87
-(PID.TID 0000.0001)      cg2d_last_res =   6.98950659140380E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.99099870098524E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1960827613616E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5071467484344E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5490360042334E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465016391178E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6912144995022E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6338723730793E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7727322626131E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5059288767272E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1921730031769E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5636753646186E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9153187863717E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3717331484434E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1842902708828E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3969194145897E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.6791245073499E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.8040704411649E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2472373322698E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1389886176946E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0616703710776E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4733644741153E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572923192288E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0002799766325E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906191489843E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366212955664E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0829853392940E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1960827299615E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.5071459437408E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5490239898973E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.4465014273052E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6912095589378E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.6338740423670E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7727323309370E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5059288909279E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1921732982945E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.5636788025862E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9153187885934E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3717331482499E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.1842892904149E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.3969198815351E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.6791479141813E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.8040635110125E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2472373302153E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1390459428748E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.0616750453930E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4734127888842E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572923192284E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0002799766434E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5906191486665E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366212956531E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0829858067926E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711512421697E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8938443354296E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703825885E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7855959458137E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6298644768592E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2644794637543E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5631199370068E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1527407007600E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.6144651787027E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4745366976973E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1746621186996E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1834290863850E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3751144238989E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.9236129755720E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1052828133987E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973239063E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0157338481083E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7485479722823E-05
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8938443356416E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703825786E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7855959435264E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6298646141573E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2644675694741E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5619868839552E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1527407316161E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.6144528552841E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.4733231030364E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1746621494080E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.1834291172414E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   4.3751144390086E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.9236129773102E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1052845057070E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349973239092E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0157313402849E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7483528049018E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543358204082E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535935403E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240650727152E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0997635804013E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.0638311642258E-08
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543358212404E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760535935356E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240650616575E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.0997726804689E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.0638616700842E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5105,29 +5164,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.2400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.1047015286811E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8737557820819E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0315888356367E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   6.1047007798704E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8737558008991E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.0315889618239E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.6323440433745E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9518149538341E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1002029734139E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -9.6323475146097E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9518149641288E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.1002071567533E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9459563649724E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8018559768940E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6294281504851E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8245688573655E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   3.9459534468308E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.8018554638895E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.6293950304457E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   3.8245688573658E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3443016615957E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0503045377249E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.7998536250706E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.8245670765162E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   5.3443003031204E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   3.0503046433251E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   2.7998471278699E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   8.8245675188422E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2396337276799E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1429006834743E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.2773039427013E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   5.2396337257822E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.1429006871103E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.2773037806512E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5136,36 +5195,36 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535095494346D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615610419077D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195230883554D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535109041791D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615517769326D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195192473018D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918150705913423D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150626811117D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010304439306D+06
-(PID.TID 0000.0001)  global fc =  0.918150705913423D+07
+(PID.TID 0000.0001)   local fc =  0.631010321876008D+06
+(PID.TID 0000.0001)  global fc =  0.918150626811117D+07
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588518803E+00  1.09558808552461E+00
- cg2d: Sum(rhs),rhsMax =   3.00954214495678E+00  1.09443701612858E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390895E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588455338E+00  1.09558808552451E+00
+ cg2d: Sum(rhs),rhsMax =   3.00955492404701E+00  1.09443701613900E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.01016045548307E+00  1.08987441574900E+00
- cg2d: Sum(rhs),rhsMax =   3.01200063669187E+00  1.08234533946216E+00
- cg2d: Sum(rhs),rhsMax =   3.01472254612810E+00  1.07091042398987E+00
- cg2d: Sum(rhs),rhsMax =   3.01809829994306E+00  1.05630803624323E+00
+ cg2d: Sum(rhs),rhsMax =   3.01017515177041E+00  1.08987441579349E+00
+ cg2d: Sum(rhs),rhsMax =   3.01200115353616E+00  1.08234533946652E+00
+ cg2d: Sum(rhs),rhsMax =   3.01470652906668E+00  1.07091042427190E+00
+ cg2d: Sum(rhs),rhsMax =   3.01807456298840E+00  1.05630803662867E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.01016045548307E+00  1.08987441574900E+00
- cg2d: Sum(rhs),rhsMax =   3.01200063669187E+00  1.08234533946216E+00
- cg2d: Sum(rhs),rhsMax =   3.01472254612810E+00  1.07091042398987E+00
- cg2d: Sum(rhs),rhsMax =   3.01809829994306E+00  1.05630803624323E+00
+ cg2d: Sum(rhs),rhsMax =   3.01017515177041E+00  1.08987441579349E+00
+ cg2d: Sum(rhs),rhsMax =   3.01200115353616E+00  1.08234533946652E+00
+ cg2d: Sum(rhs),rhsMax =   3.01470652906668E+00  1.07091042427190E+00
+ cg2d: Sum(rhs),rhsMax =   3.01807456298840E+00  1.05630803662867E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
@@ -5195,14 +5254,14 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.2819873046875E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -7.3560828993056E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.7787886780696E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.1126457750345E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.5527804289576E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.7787886705868E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.1126457743067E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.5527804264556E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.7382921006944E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.4160777452257E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.7968568719511E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.3155843341038E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.1954981877969E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.4158018663194E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.7968568987831E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.3155843257224E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.1954984207797E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5240,37 +5299,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -4.83825219471656E-18  1.83998478083479E-04
+ cg2d: Sum(rhs),rhsMax =   8.40256683676266E-19  1.83998485363834E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.8758899076575E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.6687258257338E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0738515480811E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0034051364115E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7911886735964E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2851323939449E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.2899845997103E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4325524309879E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8185245089395E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6464240843005E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4801456261814E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   6.8758786915628E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.6687697294081E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0738690859420E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0034196509218E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7912268034756E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2851438382575E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.2899766491967E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4332720653199E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8185243733581E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6464342055646E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4801456263609E-04
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4079817633290E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.8226351576354E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0664897132867E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2870936147529E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1079833603842E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.8431569785755E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6682919101472E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4392367813318E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1823452133833E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.9283368167650E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.8227128891844E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0664886512244E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2870939499486E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1079833507178E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.8431574966031E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6682976121186E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4392402373604E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1823515488799E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.9283368167847E-05
 (PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.3242899150089E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.4329942081556E-08
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.3732614063064E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.4516737638032E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.4332500670577E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.3732623701167E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.4516782168805E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5284,31 +5343,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9135930618102E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.6551970368458E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3895552762193E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544229312070E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4448086337136E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2879826184424E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4246599193513E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5577521598175E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2799629512132E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.2897170568780E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.1637903952238E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.6643211526486E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   7.3241361251457E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4515807854006E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2286868883083E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580719838208E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705323600902E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557545958149E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247710503070E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1000350673448E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475534218066E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752403227138E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5936296997725E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306503522510E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0380578674678E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9135930994330E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.6551970189127E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3895312828688E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544230096384E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4447980666768E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2879826214782E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4246599290851E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5577595534007E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2799627925133E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.2897223520080E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.1641386369467E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.6643309827781E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   7.3334090298968E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.4516072377424E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.2287289612061E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580719837725E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705323600901E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557547105017E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247710353034E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.1000344158092E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475534217813E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752403226399E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5936314160313E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306496274483E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0380398857649E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5346,37 +5405,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -8.99887803162969E-18  3.43198354435765E-04
+ cg2d: Sum(rhs),rhsMax =  -4.22838847269347E-18  3.43198759481512E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9995028882219E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1176522478164E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1377714544541E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9719156134790E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9228170609195E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4388953270509E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9384174747745E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6629103245047E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3362659320166E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4641769823869E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.9189952672961E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8072001486419E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.8429890691424E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4053262908036E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5588195400391E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1865934352013E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -5.7561083883119E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.2813928390379E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0840648398682E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3528772207589E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.7042498688252E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.2583960552396E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.6274967356742E-07
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.2517409436911E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.8358707330491E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.9995006775500E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1176513397582E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1378573014253E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9719459207596E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9229126429817E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4388973607474E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9384121336960E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6630984155655E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3362712848261E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4641776055018E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.9189952672798E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8072001362817E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.8431911091704E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4053260263036E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5588189958709E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1865934121386E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -5.7561095390872E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.2814055300704E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0840656232112E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3528894863791E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.7042498671043E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.2583960553196E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.6275592637441E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.2517412039127E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.8358838565283E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5390,31 +5449,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0667652357989E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3542603778305E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5750449081478E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8196315246697E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7875723463417E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255691930690E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2647771047350E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1391400871205E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6491562409717E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7707143479657E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.1022638346504E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -9.9682472557413E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.8201414943904E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4698082333183E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   7.6286861393463E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826306858859E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046795623368E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336343615860E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362557213211E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6406366627435E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211604918370E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164899185001E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902020131535E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9451818925280E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5556511147621E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0667654189664E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3542603796248E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5749077742001E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8196319404682E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7875728878721E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255691951334E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2647771058215E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1391439265307E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6491556945712E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7707153394149E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   2.1022715298231E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -9.9682458247649E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.8187335297974E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4698739373834E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   7.6288127048288E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826306858643E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046795623437E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336346068073E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362556800326E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6406347310965E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211604917847E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164899185101E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3902058094687E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9451797694820E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555794826471E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5452,37 +5511,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -8.23993651088983E-18  8.65047188136703E-04
+ cg2d: Sum(rhs),rhsMax =  -7.31836466427715E-18  8.65048887518439E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.6279083309074E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2237191421759E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0107787113928E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1604310066317E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9416584245012E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9189795372183E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0084405413430E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2474844452424E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0182171168287E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0469869358830E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0316555898360E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3197624099246E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.6684796466377E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0987064433777E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8188223226714E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2279701429822E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.7213238178917E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.8532385168634E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6216682737862E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5133726346400E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4335966940075E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8788364957191E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.2653259258585E-07
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8492611868251E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.1700670051735E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.6279038736706E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2237169311920E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0110066673032E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1604352727200E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9417372430226E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9189882603103E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0084291676313E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2477366030585E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0182182285998E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0469658890690E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0316555903557E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3197624075474E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.6685035370108E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0987061625390E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8188239681369E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2279701135778E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -8.7213254024692E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.8532566252853E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6216694031537E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5133907236186E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4335966934767E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8788364959743E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.2653990779398E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8492614735410E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.1700828929424E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5496,31 +5555,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4777667339951E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6379963644605E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7758014982246E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2388283067232E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3373516986264E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327176872168E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4171258591282E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3669394240789E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9848878315495E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3440476132433E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.7470324981638E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6633749718893E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.5009387413580E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.1286094501845E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3555815376248E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084958527220E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379699084896E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1115200817101E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4469809850042E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171616610675E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946318020047E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557085914917E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864639508826E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2591519379558E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721071045964E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4777667639071E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6379963632484E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7757787487199E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2388287756211E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3373516115444E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327176893534E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4171258582253E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3669387883444E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9848873702054E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3440499654144E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.7470780006049E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.6633786867383E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -9.4981511141490E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.1287430589092E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.3556027801222E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084958527058E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379699085102E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1115204929033E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4469808849979E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171609500451E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946318019366E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557085914996E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1864692742768E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2591481399678E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0719613708552E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5558,45 +5617,45 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   0.00000000000000E+00  1.48391651194492E-03
+ cg2d: Sum(rhs),rhsMax =   3.46944695195361E-18  1.48391616592307E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4797678376713E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5828917133581E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5330684282438E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8655548578669E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3543817778597E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.3070761858382E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7729336665856E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3828593714677E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6179167747900E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2159854555591E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3672268095262E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7578669897885E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6579729703391E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7881285077768E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0700771561278E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2107420050301E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.1734356275533E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0397899304915E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1564325750408E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6673068724897E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8831195676479E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.4946396874480E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   8.1645487131557E-07
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.4333949540593E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   5.4666639983233E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4797786972307E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5828893069275E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5334426020233E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8655599927892E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3543878683531E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.3070874565129E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7729184470458E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3830996474942E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6179186496292E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2159852473663E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3672268096165E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7578669857888E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.6579950469299E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7881283020476E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0700801828157E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2107419718522E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.1734357778384E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0397917480626E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1564336785028E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6673233743301E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8831195666614E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.4946396879527E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   8.1646181476786E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.4333952390466E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   5.4666727286302E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588518803E+00  1.09558808552461E+00
- cg2d: Sum(rhs),rhsMax =   3.00954214495678E+00  1.09443701612858E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390895E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588455338E+00  1.09558808552451E+00
+ cg2d: Sum(rhs),rhsMax =   3.00955492404701E+00  1.09443701613900E+00
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5607,31 +5666,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2469351312436E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2827671951645E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7078651517372E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1467055086878E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2121766725460E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6981950411676E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8501434450969E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0358558823424E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174224072855E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2709866074407E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.5883824733814E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.8625076598237E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.3886589922372E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.4340889854878E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.1162588300354E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332480671114E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703351749248E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893861396400E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5568871250654E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692310568705E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679408844964E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952061665152E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9823399123919E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572618291352E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5877246888917E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2469351529007E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2827671952271E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.7078350928140E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1467055243989E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2121755121012E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6981950420183E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8501434444714E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0358489633939E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174223824982E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2709891890505E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.5884633531999E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.8625057036830E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.3882564463349E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.4342941102434E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.1162877896268E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332480670865E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703351749453E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893868079810E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5568869515718E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692296974371E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679408844241E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952061665316E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9823466585715E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572612947517E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5875006655683E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5669,37 +5728,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.03576608295941E-17  2.12700108595391E-03
+ cg2d: Sum(rhs),rhsMax =   1.40946282423116E-18  2.12700381994475E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8600141650385E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0951001200105E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3456554003285E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6891297925196E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8470429506853E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2093533196941E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2255017928476E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859405430021E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3201761091927E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6647800025494E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6982575706644E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1949357770148E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.5859782808893E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4747508567817E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.3122109520600E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.1075160921686E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.4805373148873E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2912231244261E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6854309912788E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8094767350868E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.3195777501770E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.1061337237348E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.0888509770302E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.0066648431584E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.7249716469408E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8600259179099E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0950968662823E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3457053237085E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6891357180377E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8470446282183E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.2093656434837E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2254238847615E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859617751481E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3201765759104E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6647658870400E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6982575700277E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1949357730968E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.5859967208528E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4747507345327E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.3122183789611E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.1075404675534E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.4805374628750E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2912250395730E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6854320178838E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8094903374156E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.3195777487839E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.1061337244888E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.0888568485362E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.0066649995104E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.7249747625566E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5713,31 +5772,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0415629068531E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2587744983745E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6445725994890E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6328915747092E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3261128261828E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745029579459E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5167260162216E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0862951217712E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6057007649771E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4609071263937E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.8144904570473E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3089181203324E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.6809556004813E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3351696079157E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0254494148981E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567483817391E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017181539807E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6672169755442E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6659746682608E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202292878354E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410546850279E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349671575172E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777756090078E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885584217162E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1029198267800E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0415629124798E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2587745024500E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6445311535442E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6328915418525E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3261093516743E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745029567150E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5167260151530E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0862849978720E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6057007606555E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4609067484625E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   7.8145834963998E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3089136568145E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -4.6806357777079E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3351918865400E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.0254887620981E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567483816870E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017181540014E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6672179881126E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6659744099559E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202271640001E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410546848933E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349671575297E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0777764040918E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885577721012E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1026250193139E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5775,37 +5834,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.07913416985883E-17  2.73193076598066E-03
+ cg2d: Sum(rhs),rhsMax =  -2.71050543121376E-17  2.73193192797024E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0254693813273E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6475882265736E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7489072059280E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6057944884131E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3476559476950E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1433197978053E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3983877665873E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5460354143219E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1113165337201E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1332083720943E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0174887574318E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6308728303104E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3962373383300E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1583406159213E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5450427070765E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.6025636870657E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.7646974307352E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5401201974653E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2098958058177E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9408959284970E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7438981293599E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.7173574746337E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3273612879853E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.5674569159937E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.9352045954397E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0254705062426E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6475843996771E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7489657840397E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6058010131400E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3476596957871E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1433209902623E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3982816845162E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5460528805869E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1113175643465E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1332056282411E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0174887575782E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6308728269094E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.3962517126186E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1583405891683E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5450533432216E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.6025889584802E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.7646975621682E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5401219753613E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2098966798800E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9409072464031E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7438981276657E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.7173574759582E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3273657805834E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.5674569942457E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.9352026044374E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5819,31 +5878,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7943495662000E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5366733207773E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4567536098640E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1647452218326E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5956858570082E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190137568384E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3751268597287E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4180958870289E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1451313619578E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8168505099254E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0205317565148E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.9658936884314E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.0469248688268E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7840899563507E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0201487477414E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788639742147E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320716937157E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449660098879E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743073137429E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7702490120048E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139344091629E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749415578249E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572525557534E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6198390900503E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6182356442081E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7943495636493E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5366733336826E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4567067990525E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1647451859045E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5956826437965E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190137569232E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3751268675689E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4180676050965E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1451313840115E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8168530105637E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0205414076529E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.9658884690131E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.0467469809109E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7841012738930E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0201762515563E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788639741603E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320716937361E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449674144018E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743069671511E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7702460296972E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139344090221E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749415578331E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572534315222E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6198383942532E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6178915376414E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5881,37 +5940,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -4.90059381963448E-17  3.23776925565403E-03
+ cg2d: Sum(rhs),rhsMax =  -2.60208521396521E-18  3.23776901313303E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2507345615079E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.1084294945918E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1327365729784E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5947252437327E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8432475587106E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4724407338280E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4414078514585E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.8987699031115E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9779499208262E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6127899255360E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3321984981648E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0655626368953E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.4218849810301E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8370920473372E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7692026765444E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.1683477192082E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.0765888387645E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7809190809222E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7240878982006E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0293016242194E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1565635780975E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.2614531735139E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6136908841944E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.1030042906018E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   9.0404243686312E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2507356591407E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.1084252141939E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1327994888153E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5947324693102E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8432512820605E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4724418227632E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4413014936266E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.8987842644212E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9779512322255E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6127882910819E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3321984988805E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0655626335432E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.4218931233726E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8370921547022E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7692165573241E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.1683728348714E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.0765889700847E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7809207509668E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7240886309941E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0293112064081E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1565635762050E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.2614531747628E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6136929955345E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.1030041554537E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   9.0404143310231E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5925,31 +5984,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807636340517E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090809471090E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0355516806878E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7262275105983E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1952240594564E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926451207677E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3864965582450E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0908724885034E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7179522535356E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2249499369936E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.4587771632586E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.8540246601735E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2587996094387E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2932642578866E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.1235016218500E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994855294406E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613578318395E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2226213422454E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8819659638804E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0192668983799E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865369718717E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150565563763E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4366613156609E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8511194737704E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1340807091315E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807627343741E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090809492226E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0355055958698E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7262275051759E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1952236509560E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926451213255E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3864965757581E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0908678689433E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7179522458186E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2249502727975E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.4587890522014E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.8540205597001E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2588018569580E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2932630655505E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.1235086699405E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994855293850E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613578318594E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2226231012817E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8819655448161E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0192631537305E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865369717237E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150565563774E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4366621943913E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8511188160786E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1337302529464E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5987,37 +6046,37 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -2.73218947466347E-17  3.72672899397703E-03
+ cg2d: Sum(rhs),rhsMax =   3.77302356024956E-17  3.72672843157026E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4545959011220E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.3369319127401E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4643102346658E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6396674579405E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3271215220249E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7866585955473E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2469959860029E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2301160689270E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9071578757037E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0997066078693E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6583926568027E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4987111721187E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.3444568941994E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.5041939342083E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9872243377150E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.7860817744155E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4242589727449E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0093233281541E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2331028809906E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1338335946813E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.5573126015235E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.9006295755961E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.1417484298967E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5995239732386E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0122563112758E-07
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4545970354661E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.3369254060543E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4643775499805E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6396743199479E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3271216191474E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7866595894694E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2469276987395E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2301306437703E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9071591428165E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0996984307786E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6583926575298E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.4987111688138E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.3444596748472E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.5041941246446E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9872393735445E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.7861078372738E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4242591252150E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0093249704911E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2331035967887E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1338426488658E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.5573125994089E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.9006295770853E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.1417489598840E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5995237188530E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0122546828842E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -6056,6 +6115,8 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6066,31 +6127,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9937259928514E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982179269647E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6438649532530E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473986642839E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3980350433527E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936321848914E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1469867976705E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3128260899965E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140779665323E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4308824541794E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0565950779218E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5025335846713E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3778445660979E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1859472086342E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8584518277555E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185076523597E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895466651015E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0001120197961E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9890506804135E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2674787362160E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588118227172E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552271031954E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6159714472599E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0824151556443E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516877199612E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9937259461273E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982179309073E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6438279191410E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473986724333E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3980344521597E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936321848384E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1469868012062E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3128189311054E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140778806373E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4308825959532E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0566005878050E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5025093978391E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3778530358845E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1859478313215E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8584566100269E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185076523017E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895466651205E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0001136013006E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9890503066449E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2674754274943E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588118225591E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552271031857E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6159718769222E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0824150418125E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516093501846E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6147,12 +6208,27 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001)  nRecords =   6 ; filePrec =  64 ; fileIter =     17532
+(PID.TID 0000.0001)     nDims =   2 , dims:
+(PID.TID 0000.0001)    1:  90   1  90
+(PID.TID 0000.0001)    2:1170   11170
+(PID.TID 0000.0001)     nFlds =   6 , nFl3D =   0 , fields:
+(PID.TID 0000.0001)  >siTICE  < >siAREA  < >siHEFF  < >siHSNOW < >siUICE  < >siVICE  <
+(PID.TID 0000.0001) missingVal=  1.00000000000000E+00 ; nTimRec =   1 , timeList:
+(PID.TID 0000.0001)   6.311520000000E+07
+(PID.TID 0000.0001) READ_MFLDS_LEV_RL: read field: "siTICE  ", #   1 in fldList, rec=   1
+(PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siAREA  ", #   2 in fldList, rec=   2
+(PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siHEFF  ", #   3 in fldList, rec=   3
+(PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siHSNOW ", #   4 in fldList, rec=   4
+(PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
+(PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
+(PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
  ph-pack: packing ecco_cost
  ph-pack: packing ecco_ctrl
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18150705913423E+06
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18150626811117E+06
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -6193,38 +6269,40 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390894E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588508382E+00  1.09558808552458E+00
- cg2d: Sum(rhs),rhsMax =   3.00951752280685E+00  1.09443701612870E+00
- cg2d: Sum(rhs),rhsMax =   3.01013011414939E+00  1.08987441589456E+00
- cg2d: Sum(rhs),rhsMax =   3.01193776410066E+00  1.08234533862748E+00
- cg2d: Sum(rhs),rhsMax =   3.01464219689090E+00  1.07091042401446E+00
- cg2d: Sum(rhs),rhsMax =   3.01803528146205E+00  1.05630803676055E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390898E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588444878E+00  1.09558808552447E+00
+ cg2d: Sum(rhs),rhsMax =   3.00952680831645E+00  1.09443701613912E+00
+ cg2d: Sum(rhs),rhsMax =   3.01012507410290E+00  1.08987441608364E+00
+ cg2d: Sum(rhs),rhsMax =   3.01194016773209E+00  1.08234533915013E+00
+ cg2d: Sum(rhs),rhsMax =   3.01464997726187E+00  1.07091042416714E+00
+ cg2d: Sum(rhs),rhsMax =   3.01802234035680E+00  1.05630803597021E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535137047268D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615598755115D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195187567210D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535135755190D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615544888699D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195201906222D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150735812384D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150680653890D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010343222635D+06
-(PID.TID 0000.0001)  global fc =  0.918150735812384D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150735812384E+06
+(PID.TID 0000.0001)   local fc =  0.631010336595473D+06
+(PID.TID 0000.0001)  global fc =  0.918150680653890D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150680653890E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -6260,41 +6338,43 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390890E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588529224E+00  1.09558808552459E+00
- cg2d: Sum(rhs),rhsMax =   3.00953984851885E+00  1.09443701612842E+00
- cg2d: Sum(rhs),rhsMax =   3.01015464507458E+00  1.08987441584703E+00
- cg2d: Sum(rhs),rhsMax =   3.01196467522837E+00  1.08234533899706E+00
- cg2d: Sum(rhs),rhsMax =   3.01466735055031E+00  1.07091042415027E+00
- cg2d: Sum(rhs),rhsMax =   3.01804723400621E+00  1.05630803582882E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390891E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588465753E+00  1.09558808552448E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953174355370E+00  1.09443701613905E+00
+ cg2d: Sum(rhs),rhsMax =   3.01017396898712E+00  1.08987441572914E+00
+ cg2d: Sum(rhs),rhsMax =   3.01198825270500E+00  1.08234533906685E+00
+ cg2d: Sum(rhs),rhsMax =   3.01469607687926E+00  1.07091042389298E+00
+ cg2d: Sum(rhs),rhsMax =   3.01808048812014E+00  1.05630803637156E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535102899776D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615539820814D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195193090464D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535100027671D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615516790617D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195184528415D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150642730589D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150616828288D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010349544775D+06
-(PID.TID 0000.0001)  global fc =  0.918150642730589D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150642730589E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
+(PID.TID 0000.0001)   local fc =  0.631010333558357D+06
+(PID.TID 0000.0001)  global fc =  0.918150616828288D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150616828288E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150626811117E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  7.39217460155487E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  4.65408971533179E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.19128007628024E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -6333,6 +6413,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -6340,31 +6422,31 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
  cg2d: Sum(rhs),rhsMax =   3.01104374390898E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588508899E+00  1.09558808552457E+00
- cg2d: Sum(rhs),rhsMax =   3.00953625861827E+00  1.09443701612831E+00
- cg2d: Sum(rhs),rhsMax =   3.01013375110529E+00  1.08987441567121E+00
- cg2d: Sum(rhs),rhsMax =   3.01193109946800E+00  1.08234533916168E+00
- cg2d: Sum(rhs),rhsMax =   3.01462510362864E+00  1.07091042392201E+00
- cg2d: Sum(rhs),rhsMax =   3.01800852785854E+00  1.05630803638774E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588445426E+00  1.09558808552446E+00
+ cg2d: Sum(rhs),rhsMax =   3.00955430977715E+00  1.09443701613872E+00
+ cg2d: Sum(rhs),rhsMax =   3.01016804871852E+00  1.08987441574246E+00
+ cg2d: Sum(rhs),rhsMax =   3.01197246327908E+00  1.08234533929833E+00
+ cg2d: Sum(rhs),rhsMax =   3.01466668614909E+00  1.07091042368699E+00
+ cg2d: Sum(rhs),rhsMax =   3.01803259075476E+00  1.05630803614638E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535132313980D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615553631866D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195183530857D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535107915932D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615561465126D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195189922674D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150685955846D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150669391058D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010355285330D+06
-(PID.TID 0000.0001)  global fc =  0.918150685955846D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150685955846E+06
+(PID.TID 0000.0001)   local fc =  0.631010346675704D+06
+(PID.TID 0000.0001)  global fc =  0.918150669391058D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150669391058E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -6400,41 +6482,43 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390896E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588528689E+00  1.09558808552463E+00
- cg2d: Sum(rhs),rhsMax =   3.00956370849629E+00  1.09443701612863E+00
- cg2d: Sum(rhs),rhsMax =   3.01017948441832E+00  1.08987441575063E+00
- cg2d: Sum(rhs),rhsMax =   3.01201590965418E+00  1.08234533896412E+00
- cg2d: Sum(rhs),rhsMax =   3.01472948869790E+00  1.07091042416189E+00
- cg2d: Sum(rhs),rhsMax =   3.01812094548721E+00  1.05630803667633E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390895E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588465215E+00  1.09558808552448E+00
+ cg2d: Sum(rhs),rhsMax =   3.00956494027746E+00  1.09443701613908E+00
+ cg2d: Sum(rhs),rhsMax =   3.01021817454529E+00  1.08987441574563E+00
+ cg2d: Sum(rhs),rhsMax =   3.01203620699789E+00  1.08234533932798E+00
+ cg2d: Sum(rhs),rhsMax =   3.01473133955665E+00  1.07091042441667E+00
+ cg2d: Sum(rhs),rhsMax =   3.01810969769752E+00  1.05630803651727E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535076998973D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615623727998D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195250851929D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535090536876D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615578629704D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195203638591D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150700736972D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150669176580D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010352448524D+06
-(PID.TID 0000.0001)  global fc =  0.918150700736972D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150700736972E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
+(PID.TID 0000.0001)   local fc =  0.631010334700450D+06
+(PID.TID 0000.0001)  global fc =  0.918150669176580D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150669176580E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150626811117E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.85234367847443E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -7.39056272432208E+00
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.07239000499249E-01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -6473,38 +6557,40 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390877E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588509677E+00  1.09558808552458E+00
- cg2d: Sum(rhs),rhsMax =   3.00952812760866E+00  1.09443701612852E+00
- cg2d: Sum(rhs),rhsMax =   3.01013083125854E+00  1.08987441607465E+00
- cg2d: Sum(rhs),rhsMax =   3.01193511019707E+00  1.08234533838854E+00
- cg2d: Sum(rhs),rhsMax =   3.01464690104225E+00  1.07091042397858E+00
- cg2d: Sum(rhs),rhsMax =   3.01800403007922E+00  1.05630803645326E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390876E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588446188E+00  1.09558808552448E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953542346219E+00  1.09443701613900E+00
+ cg2d: Sum(rhs),rhsMax =   3.01014421383479E+00  1.08987441621538E+00
+ cg2d: Sum(rhs),rhsMax =   3.01194881975248E+00  1.08234533873229E+00
+ cg2d: Sum(rhs),rhsMax =   3.01465199647033E+00  1.07091042368139E+00
+ cg2d: Sum(rhs),rhsMax =   3.01803000253000E+00  1.05630803615290E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535135769318D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615549429926D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195169535500D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535131238080D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615555146820D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195207411019D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150685209243D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150686394901D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010342568546D+06
-(PID.TID 0000.0001)  global fc =  0.918150685209243D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150685209243E+06
+(PID.TID 0000.0001)   local fc =  0.631010328144485D+06
+(PID.TID 0000.0001)  global fc =  0.918150686394901D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150686394901E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -6540,6 +6626,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -6547,34 +6635,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
  cg2d: Sum(rhs),rhsMax =   3.01104374390917E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588527888E+00  1.09558808552458E+00
- cg2d: Sum(rhs),rhsMax =   3.00953911188996E+00  1.09443701612862E+00
- cg2d: Sum(rhs),rhsMax =   3.01015260995154E+00  1.08987441580691E+00
- cg2d: Sum(rhs),rhsMax =   3.01199616884082E+00  1.08234533845973E+00
- cg2d: Sum(rhs),rhsMax =   3.01470389433347E+00  1.07091042421148E+00
- cg2d: Sum(rhs),rhsMax =   3.01809920452894E+00  1.05630803617294E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588464424E+00  1.09558808552448E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953933644393E+00  1.09443701613910E+00
+ cg2d: Sum(rhs),rhsMax =   3.01014923028774E+00  1.08987441591218E+00
+ cg2d: Sum(rhs),rhsMax =   3.01196626980372E+00  1.08234533903657E+00
+ cg2d: Sum(rhs),rhsMax =   3.01468358453705E+00  1.07091042366639E+00
+ cg2d: Sum(rhs),rhsMax =   3.01806312186288E+00  1.05630803598773E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535116758025D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615608639676D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195217082258D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535115844776D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615576878911D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195225748111D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150725407700D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150692733688D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010343276011D+06
-(PID.TID 0000.0001)  global fc =  0.918150725407700D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150725407700E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
+(PID.TID 0000.0001)   local fc =  0.631010356463033D+06
+(PID.TID 0000.0001)  global fc =  0.918150692733688D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150692733688E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150626811117E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  6.19272172451019E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.00992285273969E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -3.16939363256097E+00
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -6613,38 +6701,40 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
- cg2d: Sum(rhs),rhsMax =   3.01104374390930E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588510694E+00  1.09558808552458E+00
- cg2d: Sum(rhs),rhsMax =   3.00954987233595E+00  1.09443701612861E+00
- cg2d: Sum(rhs),rhsMax =   3.01016990071168E+00  1.08987441589887E+00
- cg2d: Sum(rhs),rhsMax =   3.01199279721120E+00  1.08234533900488E+00
- cg2d: Sum(rhs),rhsMax =   3.01472784455805E+00  1.07091042415224E+00
- cg2d: Sum(rhs),rhsMax =   3.01811513863563E+00  1.05630803650977E+00
+ cg2d: Sum(rhs),rhsMax =   3.01104374390929E+00  1.09179581247341E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588447215E+00  1.09558808552448E+00
+ cg2d: Sum(rhs),rhsMax =   3.00954055068769E+00  1.09443701613901E+00
+ cg2d: Sum(rhs),rhsMax =   3.01018718910398E+00  1.08987441584318E+00
+ cg2d: Sum(rhs),rhsMax =   3.01201038574605E+00  1.08234533932712E+00
+ cg2d: Sum(rhs),rhsMax =   3.01474035337199E+00  1.07091042368460E+00
+ cg2d: Sum(rhs),rhsMax =   3.01812736372988E+00  1.05630803626717E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535094648053D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615633268504D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195251974674D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535090008313D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615542452780D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195184157185D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150727926557D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150632471093D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010342896798D+06
-(PID.TID 0000.0001)  global fc =  0.918150727926557D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150727926557E+06
+(PID.TID 0000.0001)   local fc =  0.631010304063943D+06
+(PID.TID 0000.0001)  global fc =  0.918150632471093D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18150632471093E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -6680,6 +6770,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siUICE  ", #   5 in fldList, rec=   5
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "siVICE  ", #   6 in fldList, rec=   6
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup_seaice.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -6687,34 +6779,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.01093895386309E+00  1.08516765831944E+00
  cg2d: Sum(rhs),rhsMax =   3.01104374390904E+00  1.09179581247341E+00
- cg2d: Sum(rhs),rhsMax =   3.01041588526909E+00  1.09558808552460E+00
- cg2d: Sum(rhs),rhsMax =   3.00953609478396E+00  1.09443701612853E+00
- cg2d: Sum(rhs),rhsMax =   3.01013479879541E+00  1.08987441597024E+00
- cg2d: Sum(rhs),rhsMax =   3.01195168098912E+00  1.08234533909442E+00
- cg2d: Sum(rhs),rhsMax =   3.01466061125088E+00  1.07091042418912E+00
- cg2d: Sum(rhs),rhsMax =   3.01802596354605E+00  1.05630803660810E+00
+ cg2d: Sum(rhs),rhsMax =   3.01041588463426E+00  1.09558808552450E+00
+ cg2d: Sum(rhs),rhsMax =   3.00953571046107E+00  1.09443701613906E+00
+ cg2d: Sum(rhs),rhsMax =   3.01016733507580E+00  1.08987441589159E+00
+ cg2d: Sum(rhs),rhsMax =   3.01198157327185E+00  1.08234533919392E+00
+ cg2d: Sum(rhs),rhsMax =   3.01470630977939E+00  1.07091042391516E+00
+ cg2d: Sum(rhs),rhsMax =   3.01808794290280E+00  1.05630803659227E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427535134973469D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490615563384765D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101195191659270D+0617
+(PID.TID 0000.0001)  --> f_gencost = 0.427535112634594D+07 7
+(PID.TID 0000.0001)  --> f_gencost = 0.490615569564891D+07 8
+(PID.TID 0000.0001)  --> f_gencost = 0.101195207701506D+0617
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 3
-(PID.TID 0000.0001)  --> fc               = 0.918150698368234D+07
+(PID.TID 0000.0001)  --> fc               = 0.918150682209484D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.631010337230496D+06
-(PID.TID 0000.0001)  global fc =  0.918150698368234D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150698368234E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150705913423E+06
+(PID.TID 0000.0001)   local fc =  0.631010294465309D+06
+(PID.TID 0000.0001)  global fc =  0.918150682209484D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18150682209484E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18150626811117E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.45455992221832E-01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.47791613824666E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       = -2.48691958375275E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6728,271 +6820,271 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1815070591342E+06  9.1815073581238E+06  9.1815064273059E+06
-(PID.TID 0000.0001) grdchk output (g):   1     4.6540897153318E+01  7.3921746015549E-01 -6.1959683262255E+01
+(PID.TID 0000.0001) grdchk output (c):   1  9.1815062681112E+06  9.1815068065389E+06  9.1815061682829E+06
+(PID.TID 0000.0001) grdchk output (g):   1     3.1912800762802E+01  7.3921746015549E-01 -4.2171059238901E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   2  9.1815070591342E+06  9.1815068595585E+06  9.1815070073697E+06
-(PID.TID 0000.0001) grdchk output (g):   2    -7.3905627243221E+00  6.8523436784744E-01  1.1785452497863E+01
+(PID.TID 0000.0001) grdchk output (c):   2  9.1815062681112E+06  9.1815066939106E+06  9.1815066917658E+06
+(PID.TID 0000.0001) grdchk output (g):   2     1.0723900049925E-01  6.8523436784744E-01  8.4350025986565E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1815070591342E+06  9.1815068520924E+06  9.1815072540770E+06
-(PID.TID 0000.0001) grdchk output (g):   3    -2.0099228527397E+01  6.1927217245102E-01  3.3456211374469E+01
+(PID.TID 0000.0001) grdchk output (c):   3  9.1815062681112E+06  9.1815068639490E+06  9.1815069273369E+06
+(PID.TID 0000.0001) grdchk output (g):   3    -3.1693936325610E+00  6.1927217245102E-01  6.1179332344562E+00
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   4  9.1815070591342E+06  9.1815072792656E+06  9.1815069836823E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.4779161382467E+01  5.4545599222183E-01 -2.6095057334077E+01
+(PID.TID 0000.0001) grdchk output (c):   4  9.1815062681112E+06  9.1815063247109E+06  9.1815068220948E+06
+(PID.TID 0000.0001) grdchk output (g):   4    -2.4869195837528E+01  5.4545599222183E-01  4.6593404769882E+01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.8007135308190E+01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  3.1573264818239E+01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4114.6382327377796
-(PID.TID 0000.0001)         System time:   11.644455373287201
-(PID.TID 0000.0001)     Wall clock time:   4146.5505251884460
+(PID.TID 0000.0001)           User time:   4089.8786029815674
+(PID.TID 0000.0001)         System time:   21.088952571153641
+(PID.TID 0000.0001)     Wall clock time:   4136.1855981349945
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   11.024121433496475
-(PID.TID 0000.0001)         System time:  0.75727805495262146
-(PID.TID 0000.0001)     Wall clock time:   13.739370107650757
+(PID.TID 0000.0001)           User time:   10.826444625854492
+(PID.TID 0000.0001)         System time:  0.81520804762840271
+(PID.TID 0000.0001)     Wall clock time:   13.504619836807251
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1708.5532817840576
-(PID.TID 0000.0001)         System time:   4.5195938348770142
-(PID.TID 0000.0001)     Wall clock time:   1725.0967710018158
+(PID.TID 0000.0001)           User time:   1691.0143499374390
+(PID.TID 0000.0001)         System time:   8.4216926097869873
+(PID.TID 0000.0001)     Wall clock time:   1718.0951001644135
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   423.34573364257812
-(PID.TID 0000.0001)         System time:  0.73385119438171387
-(PID.TID 0000.0001)     Wall clock time:   426.22882413864136
+(PID.TID 0000.0001)           User time:   417.85992431640625
+(PID.TID 0000.0001)         System time:   1.5365686416625977
+(PID.TID 0000.0001)     Wall clock time:   423.99617147445679
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.1393432617187500
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   6.1398909091949463
+(PID.TID 0000.0001)           User time:   6.1145935058593750
+(PID.TID 0000.0001)         System time:   1.3029575347900391E-002
+(PID.TID 0000.0001)     Wall clock time:   6.1356265544891357
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.1010437011718750
-(PID.TID 0000.0001)         System time:   9.9002599716186523E-002
-(PID.TID 0000.0001)     Wall clock time:   6.3533687591552734
+(PID.TID 0000.0001)           User time:   5.0983886718750000
+(PID.TID 0000.0001)         System time:  0.14395093917846680
+(PID.TID 0000.0001)     Wall clock time:   7.2600202560424805
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.4201049804687500
-(PID.TID 0000.0001)         System time:   6.2055826187133789E-002
-(PID.TID 0000.0001)     Wall clock time:   5.5862576961517334
+(PID.TID 0000.0001)           User time:   4.4090270996093750
+(PID.TID 0000.0001)         System time:  0.10395312309265137
+(PID.TID 0000.0001)     Wall clock time:   6.5058279037475586
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.4931640625000000E-004
-(PID.TID 0000.0001)         System time:   9.9396705627441406E-004
-(PID.TID 0000.0001)     Wall clock time:   8.8763236999511719E-004
+(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
+(PID.TID 0000.0001)         System time:   1.6689300537109375E-005
+(PID.TID 0000.0001)     Wall clock time:   9.2601776123046875E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.47528076171875000
-(PID.TID 0000.0001)         System time:   1.0206699371337891E-003
-(PID.TID 0000.0001)     Wall clock time:  0.47573447227478027
+(PID.TID 0000.0001)           User time:  0.46478271484375000
+(PID.TID 0000.0001)         System time:   1.9850730895996094E-003
+(PID.TID 0000.0001)     Wall clock time:  0.46813154220581055
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21295166015625000
-(PID.TID 0000.0001)         System time:   1.7166137695312500E-005
-(PID.TID 0000.0001)     Wall clock time:  0.21383857727050781
+(PID.TID 0000.0001)           User time:  0.21063232421875000
+(PID.TID 0000.0001)         System time:   1.0051727294921875E-003
+(PID.TID 0000.0001)     Wall clock time:  0.21027207374572754
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   102.81030273437500
-(PID.TID 0000.0001)         System time:   5.2913427352905273E-002
-(PID.TID 0000.0001)     Wall clock time:   103.06543326377869
+(PID.TID 0000.0001)           User time:   95.946563720703125
+(PID.TID 0000.0001)         System time:  0.22476506233215332
+(PID.TID 0000.0001)     Wall clock time:   96.632555246353149
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   31.618591308593750
-(PID.TID 0000.0001)         System time:   3.1926155090332031E-002
-(PID.TID 0000.0001)     Wall clock time:   31.804975986480713
+(PID.TID 0000.0001)           User time:   31.744995117187500
+(PID.TID 0000.0001)         System time:   6.8977832794189453E-002
+(PID.TID 0000.0001)     Wall clock time:   32.145899295806885
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   29.668762207031250
-(PID.TID 0000.0001)         System time:   2.8908491134643555E-002
-(PID.TID 0000.0001)     Wall clock time:   29.839739799499512
+(PID.TID 0000.0001)           User time:   29.781402587890625
+(PID.TID 0000.0001)         System time:   6.0988664627075195E-002
+(PID.TID 0000.0001)     Wall clock time:   30.139138936996460
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   26.139862060546875
-(PID.TID 0000.0001)         System time:   1.0159015655517578E-003
-(PID.TID 0000.0001)     Wall clock time:   26.154661893844604
+(PID.TID 0000.0001)           User time:   20.374359130859375
+(PID.TID 0000.0001)         System time:   4.8985004425048828E-002
+(PID.TID 0000.0001)     Wall clock time:   20.464431047439575
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   90.273468017578125
-(PID.TID 0000.0001)         System time:   4.9848556518554688E-003
-(PID.TID 0000.0001)     Wall clock time:   90.332365512847900
+(PID.TID 0000.0001)           User time:   90.728027343750000
+(PID.TID 0000.0001)         System time:  0.17270469665527344
+(PID.TID 0000.0001)     Wall clock time:   90.993949174880981
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2960205078125000
-(PID.TID 0000.0001)         System time:   1.0013580322265625E-005
-(PID.TID 0000.0001)     Wall clock time:   2.2984681129455566
+(PID.TID 0000.0001)           User time:   1.2208862304687500
+(PID.TID 0000.0001)         System time:   1.0201930999755859E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2228825092315674
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.376800537109375
-(PID.TID 0000.0001)         System time:   6.0062408447265625E-003
-(PID.TID 0000.0001)     Wall clock time:   11.391686677932739
+(PID.TID 0000.0001)           User time:   11.043731689453125
+(PID.TID 0000.0001)         System time:   2.7978420257568359E-002
+(PID.TID 0000.0001)     Wall clock time:   11.079273939132690
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0982666015625000
-(PID.TID 0000.0001)         System time:   9.2077255249023438E-004
-(PID.TID 0000.0001)     Wall clock time:   2.1059541702270508
+(PID.TID 0000.0001)           User time:   2.1045837402343750
+(PID.TID 0000.0001)         System time:   3.0202865600585938E-003
+(PID.TID 0000.0001)     Wall clock time:   2.1087505817413330
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8683776855468750
-(PID.TID 0000.0001)         System time:   8.3446502685546875E-006
-(PID.TID 0000.0001)     Wall clock time:   3.8687660694122314
+(PID.TID 0000.0001)           User time:   3.8733520507812500
+(PID.TID 0000.0001)         System time:   4.9893856048583984E-003
+(PID.TID 0000.0001)     Wall clock time:   3.8825895786285400
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.23242187500000000
-(PID.TID 0000.0001)         System time:   1.0027885437011719E-003
-(PID.TID 0000.0001)     Wall clock time:  0.23317146301269531
+(PID.TID 0000.0001)           User time:  0.42233276367187500
+(PID.TID 0000.0001)         System time:   3.9973258972167969E-003
+(PID.TID 0000.0001)     Wall clock time:  0.42551350593566895
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0113525390625000
-(PID.TID 0000.0001)         System time:   1.0968923568725586E-002
-(PID.TID 0000.0001)     Wall clock time:   5.0261392593383789
+(PID.TID 0000.0001)           User time:   4.9962463378906250
+(PID.TID 0000.0001)         System time:   1.6012668609619141E-002
+(PID.TID 0000.0001)     Wall clock time:   5.0172791481018066
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   93.981201171875000
-(PID.TID 0000.0001)         System time:   3.0117034912109375E-003
-(PID.TID 0000.0001)     Wall clock time:   94.243011713027954
+(PID.TID 0000.0001)           User time:   94.256591796875000
+(PID.TID 0000.0001)         System time:  0.20061421394348145
+(PID.TID 0000.0001)     Wall clock time:   94.532943964004517
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8310546875000000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9025497436523438E-004
+(PID.TID 0000.0001)           User time:   1.0986328125000000E-003
+(PID.TID 0000.0001)         System time:   9.7751617431640625E-006
+(PID.TID 0000.0001)     Wall clock time:   9.3102455139160156E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.97308349609375000
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:  0.97355818748474121
+(PID.TID 0000.0001)           User time:  0.91369628906250000
+(PID.TID 0000.0001)         System time:   2.0155906677246094E-003
+(PID.TID 0000.0001)     Wall clock time:  0.91615867614746094
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.8500976562500000E-004
+(PID.TID 0000.0001)           User time:   1.2512207031250000E-003
+(PID.TID 0000.0001)         System time:   1.1920928955078125E-005
+(PID.TID 0000.0001)     Wall clock time:   8.9859962463378906E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2129516601562500
-(PID.TID 0000.0001)         System time:  0.13499402999877930
-(PID.TID 0000.0001)     Wall clock time:   2.6465494632720947
+(PID.TID 0000.0001)           User time:   2.1909484863281250
+(PID.TID 0000.0001)         System time:  0.15276455879211426
+(PID.TID 0000.0001)     Wall clock time:   2.7052199840545654
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6830749511718750
-(PID.TID 0000.0001)         System time:  0.41498398780822754
-(PID.TID 0000.0001)     Wall clock time:   3.7166821956634521
+(PID.TID 0000.0001)           User time:   2.7078552246093750
+(PID.TID 0000.0001)         System time:  0.43755221366882324
+(PID.TID 0000.0001)     Wall clock time:   3.9768092632293701
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   26.352630615234375
-(PID.TID 0000.0001)         System time:  0.90589570999145508
-(PID.TID 0000.0001)     Wall clock time:   28.170173406600952
+(PID.TID 0000.0001)           User time:   26.700042724609375
+(PID.TID 0000.0001)         System time:   1.1171021461486816
+(PID.TID 0000.0001)     Wall clock time:   29.355527162551880
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   6.8895568847656250
-(PID.TID 0000.0001)         System time:  0.15595579147338867
-(PID.TID 0000.0001)     Wall clock time:   7.0693445205688477
+(PID.TID 0000.0001)           User time:   7.0177001953125000
+(PID.TID 0000.0001)         System time:  0.21384501457214355
+(PID.TID 0000.0001)     Wall clock time:   7.2689542770385742
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.0594482421875000
-(PID.TID 0000.0001)         System time:  0.11097717285156250
-(PID.TID 0000.0001)     Wall clock time:   3.2303359508514404
+(PID.TID 0000.0001)           User time:   3.0891113281250000
+(PID.TID 0000.0001)         System time:  0.14391040802001953
+(PID.TID 0000.0001)     Wall clock time:   3.3546750545501709
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.0375976562500000
-(PID.TID 0000.0001)         System time:  0.10700511932373047
-(PID.TID 0000.0001)     Wall clock time:   3.2450160980224609
+(PID.TID 0000.0001)           User time:   3.0812988281250000
+(PID.TID 0000.0001)         System time:  0.13292694091796875
+(PID.TID 0000.0001)     Wall clock time:   3.2552669048309326
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2388.9636230468750
-(PID.TID 0000.0001)         System time:   6.1495852470397949
-(PID.TID 0000.0001)     Wall clock time:   2401.2389218807220
+(PID.TID 0000.0001)           User time:   2381.8673095703125
+(PID.TID 0000.0001)         System time:   11.575209617614746
+(PID.TID 0000.0001)     Wall clock time:   2397.9758019447327
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2010.9022216796875
-(PID.TID 0000.0001)         System time:   4.2689809799194336
-(PID.TID 0000.0001)     Wall clock time:   2018.6668810844421
+(PID.TID 0000.0001)           User time:   2006.1965332031250
+(PID.TID 0000.0001)         System time:   8.7814073562622070
+(PID.TID 0000.0001)     Wall clock time:   2017.6213846206665
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   368.83483886718750
-(PID.TID 0000.0001)         System time:   1.4116501808166504
-(PID.TID 0000.0001)     Wall clock time:   372.10676431655884
+(PID.TID 0000.0001)           User time:   366.32055664062500
+(PID.TID 0000.0001)         System time:   2.2821445465087891
+(PID.TID 0000.0001)     Wall clock time:   370.08102583885193
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   4.0777587890625000
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   4.0806746482849121
+(PID.TID 0000.0001)           User time:   4.2835693359375000
+(PID.TID 0000.0001)         System time:   1.0060310363769531E-002
+(PID.TID 0000.0001)     Wall clock time:   4.2977740764617920
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7211914062500000E-002
-(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.6993761062622070E-002
+(PID.TID 0000.0001)           User time:   1.7089843750000000E-002
+(PID.TID 0000.0001)         System time:   8.5830688476562500E-006
+(PID.TID 0000.0001)     Wall clock time:   1.7186880111694336E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   329.80883789062500
-(PID.TID 0000.0001)         System time:  0.13584518432617188
-(PID.TID 0000.0001)     Wall clock time:   330.25045990943909
+(PID.TID 0000.0001)           User time:   326.72924804687500
+(PID.TID 0000.0001)         System time:  0.71626758575439453
+(PID.TID 0000.0001)     Wall clock time:   327.82971262931824
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.3073730468750000
-(PID.TID 0000.0001)         System time:  0.35691404342651367
-(PID.TID 0000.0001)     Wall clock time:   6.3964741230010986
+(PID.TID 0000.0001)           User time:   5.2525634765625000
+(PID.TID 0000.0001)         System time:  0.38366699218750000
+(PID.TID 0000.0001)     Wall clock time:   6.1763601303100586
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.1560192108154297E-003
+(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
+(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
+(PID.TID 0000.0001)     Wall clock time:   2.1657943725585938E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   29.557495117187500
-(PID.TID 0000.0001)         System time:  0.91487741470336914
-(PID.TID 0000.0001)     Wall clock time:   31.285812854766846
+(PID.TID 0000.0001)           User time:   29.975952148437500
+(PID.TID 0000.0001)         System time:   1.1681270599365234
+(PID.TID 0000.0001)     Wall clock time:   31.687940597534180
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.6855468750000000E-002
-(PID.TID 0000.0001)         System time:   3.9982795715332031E-003
-(PID.TID 0000.0001)     Wall clock time:   3.7813901901245117E-002
+(PID.TID 0000.0001)           User time:   2.3315429687500000E-002
+(PID.TID 0000.0001)         System time:   3.9930343627929688E-003
+(PID.TID 0000.0001)     Wall clock time:   3.3021688461303711E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -7032,9 +7124,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =        1019342
+(PID.TID 0000.0001) //            No. barriers =        1017042
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =        1019342
+(PID.TID 0000.0001) //     Total barrier spins =        1017042
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output_adm.ecmwf.txt
+++ b/global_oce_llc90/results/output_adm.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68i
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
 (PID.TID 0000.0001) // Build user:        jm_c
-(PID.TID 0000.0001) // Build host:        node143
-(PID.TID 0000.0001) // Build date:        Sun May  8 00:44:45 EDT 2022
+(PID.TID 0000.0001) // Build host:        node047
+(PID.TID 0000.0001) // Build date:        Fri Jun  9 22:54:12 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -59,7 +59,7 @@
 (PID.TID 0000.0001) maxLengthPrt1D=   65 /* maxLength of 1D array printed to StdOut */
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ======= Starting MPI parallel Run =========
-(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node143
+(PID.TID 0000.0001)  My Processor Name (len:  7 ) = node047
 (PID.TID 0000.0001)  Located at (  0,  0) on processor grid (0: 31,0:  0)
 (PID.TID 0000.0001)  Origin at  (     1,     1) on global grid (1:  2880,1:    30)
 (PID.TID 0000.0001)  North neighbor = processor 0000
@@ -834,8 +834,6 @@
 (PID.TID 0000.0001) ># ECCO controlvariables
 (PID.TID 0000.0001) ># *********************
 (PID.TID 0000.0001) > &ctrl_nml
-(PID.TID 0000.0001) > ctrlSmoothCorrel2D=.TRUE.,
-(PID.TID 0000.0001) > ctrlSmoothCorrel3D=.TRUE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) ># *********************
@@ -889,9 +887,9 @@
 (PID.TID 0000.0001) > mult_genarr3d(3) = 1.,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) CTRL_READPARMS: finished reading data.ctrl
+(PID.TID 0000.0001) read-write ctrl files from current run directory
 (PID.TID 0000.0001) COST_READPARMS: opening data.cost
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.cost
 (PID.TID 0000.0001) // =======================================================
@@ -1316,22 +1314,31 @@
 (PID.TID 0000.0001) sstExtrapol = /* extrapolation coeff from lev. 1 & 2 to surf [-] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_1 = /* coef used in drag calculation [m/s] */
 (PID.TID 0000.0001)                 2.700000000000000E-03
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_2 = /* coef used in drag calculation [-] */
 (PID.TID 0000.0001)                 1.420000000000000E-04
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [?] */
+(PID.TID 0000.0001) cDrag_3 = /* coef used in drag calculation [s/m] */
 (PID.TID 0000.0001)                 7.640000000000000E-05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cDrag_8 = /* coef used in drag calculation [(s/m)^6] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cDragMax = /* maximum drag (Large and Yeager, 2009) [-] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) umax = /* at maximum wind (Large and Yeager, 2009) [m/s] */
+(PID.TID 0000.0001)                 1.234567000000000E+05
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cStanton_1 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 3.270000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [?] */
+(PID.TID 0000.0001) cStanton_2 = /* coef used in Stanton number calculation [-] */
 (PID.TID 0000.0001)                 1.800000000000000E-02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cDalton = /* coef used in Dalton number calculation [?] */
+(PID.TID 0000.0001) cDalton = /* Dalton number [-] */
 (PID.TID 0000.0001)                 3.460000000000000E-02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) exf_scal_BulkCdn= /* Drag coefficient scaling factor [-] */
@@ -2033,7 +2040,6 @@
 (PID.TID 0000.0001)  Settings of generic controls:
 (PID.TID 0000.0001)  -----------------------------
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  ctrlUseGen  =     T /* use generic controls */
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_theta
 (PID.TID 0000.0001)       weight     = wt_theta.data
@@ -2145,6 +2151,93 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    50 @  3.450000000000000E+01              /* K =  1: 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.023577603477196E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.023620777136617E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.023663941036695E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.023991015718490E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.024034306669897E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.024077587828753E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.024397096508654E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.024708673329142E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.024752319822224E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.025056259681613E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.025352644399205E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.025398957600777E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.025691882161156E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.025982177516916E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.026047240518975E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.026352942626987E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.026669770198047E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.027003315092154E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.027358849068998E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.027740686384669E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028324553331053E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028593221231610E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.029064475561974E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.029563084816846E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.030085114878761E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.030486089114683E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.031048075107123E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.031484375801639E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.032065171983561E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.032517922992319E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.032973670366665E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.033565488723493E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.034036918499537E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.034530048673366E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.035193531658509E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.035792065871340E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.036470923617515E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.037242016518006E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.038247118431009E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.039220297575330E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.040291819497536E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.041460110377147E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.042723334638967E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.044079512399653E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.045526523812687E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.047062113733185E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.048683896693754E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.050389362181617E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.052175880206080E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.054040707144287E+03       /* K = 50 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
+(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
+(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
+(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
+(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
+(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
+(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
+(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
+(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
+(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
+(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
+(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
+(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
+(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
+(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
+(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
+(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
+(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
+(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
+(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
+(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
+(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
+(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
+(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
+(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
+(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -3075,47 +3168,6 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    51 @  1.000000000000000E+00              /* K =  1: 51 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K =  1:  3 */
-(PID.TID 0000.0001)                 2.706065538651213E-04,      /* K =  4 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K =  5:  6 */
-(PID.TID 0000.0001)                 2.632794562663490E-04,      /* K =  7 */
-(PID.TID 0000.0001)                 2.554318021231947E-04,      /* K =  8 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K =  9 */
-(PID.TID 0000.0001)                 2.461524232360561E-04,      /* K = 10 */
-(PID.TID 0000.0001)                 2.348694431245364E-04,      /* K = 11 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 12 */
-(PID.TID 0000.0001)                 2.056847859884566E-04,      /* K = 13 */
-(PID.TID 0000.0001)                 1.777764506003336E-04,      /* K = 14 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 15 */
-(PID.TID 0000.0001)                 1.203533867077665E-04,      /* K = 16 */
-(PID.TID 0000.0001)                 9.288540355629585E-05,      /* K = 17 */
-(PID.TID 0000.0001)                 7.115862770365155E-05,      /* K = 18 */
-(PID.TID 0000.0001)                 5.484365820533800E-05,      /* K = 19 */
-(PID.TID 0000.0001)                 4.290935507113214E-05,      /* K = 20 */
-(PID.TID 0000.0001)                 6.658747741703880E-05,      /* K = 21 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 22 */
-(PID.TID 0000.0001)                 2.323718420342036E-05,      /* K = 23 */
-(PID.TID 0000.0001)                 1.974682037962757E-05,      /* K = 24 */
-(PID.TID 0000.0001)                 1.709468932536602E-05,      /* K = 25 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 26 */
-(PID.TID 0000.0001)                 1.455436545977052E-05,      /* K = 27 */
-(PID.TID 0000.0001)                 0.000000000000000E+00,      /* K = 28 */
-(PID.TID 0000.0001)                 1.315287111980149E-05,      /* K = 29 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 30: 31 */
-(PID.TID 0000.0001)                 1.240968507885233E-05,      /* K = 32 */
-(PID.TID 0000.0001)     2 @  0.000000000000000E+00,             /* K = 33: 34 */
-(PID.TID 0000.0001)                 1.045141607964570E-05,      /* K = 35 */
-(PID.TID 0000.0001)     3 @  0.000000000000000E+00,             /* K = 36: 38 */
-(PID.TID 0000.0001)                 6.628797113709505E-06,      /* K = 39 */
-(PID.TID 0000.0001)    11 @  0.000000000000000E+00              /* K = 40: 50 */
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -3933,6 +3985,8 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) whio : create lev 3 rec   9
 (PID.TID 0000.0001) whio : write lev 3 rec   1
 (PID.TID 0000.0001) whio : create lev 2 rec   9
@@ -3941,7 +3995,7 @@
  cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102262E-01
 (PID.TID 0000.0001)      cg2d_init_res =   8.42110689873385E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     125
-(PID.TID 0000.0001)      cg2d_last_res =   6.70544114698682E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70544114977426E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3951,32 +4005,32 @@
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.4507813074373E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.3142741714339E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.8461459688189E-05
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.8461459688195E-05
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.8797644960057E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1160439696315E+00
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8751337429322E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2190340363191E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8512012012932E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2190341677167E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8512032024993E-05
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4002265931068E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4479589694191E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2403446032099E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4169966714680E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9784363149058E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4169970412431E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.9784437648109E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9624667885988E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6818167057291E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1065996557453E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4782655426664E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6585889998857E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.1065996557456E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4782654453766E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6585932066160E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2641500109445E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0837168093599E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905873652831E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366297440438E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0901476869958E-04
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366297439940E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0901477515390E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711525590917E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8986867148382E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725703936814E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856242679817E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6683325249527E-05
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856242676309E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6683325150549E-05
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.2235859012255E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.3387263389651E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.2627341169968E-01
@@ -3986,16 +4040,16 @@
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2934217435174E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   7.0372471314428E-04
 (PID.TID 0000.0001) %MON ke_max                       =   6.0292135639696E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2156927573042E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2156939004559E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -4.9777678244283E-05
 (PID.TID 0000.0001) %MON vort_r_max                   =   3.6406368761810E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543464585813E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543464588465E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760536808383E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240340252767E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2459520079948E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0803504892748E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240340261067E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.2459520078176E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.0803504884033E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4016,14 +4070,14 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.4837461086138E-05
 (PID.TID 0000.0001) %MON exf_hflux_max                =   1.6271552992104E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -8.7180089318438E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   6.3985037556269E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8531896892753E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.6335905829110E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   6.3985037136350E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8531896884260E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.6335905790336E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0132892122181E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1874770617645E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.2176102718092E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0680723598451E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5254875240817E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   4.2176102664658E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0680723597334E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5254875239415E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   3.1023215152125E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.4405696746102E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0357432074842E+00
@@ -4041,14 +4095,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943211487414E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2938163787052E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.4036395030286E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8184251118022E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.9252191497807E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0858173790745E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8184251110419E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.9252191477567E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0858173787019E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2107237304748E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9745229099669E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3517153692207E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.9139239989279E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1489852993023E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3517153686864E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.9139239990895E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1489852955245E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.2382273106148E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6253943692965E-08
@@ -4082,66 +4136,66 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75680295093998E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.72004253669273E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088548885E-01
-(PID.TID 0000.0001)      cg2d_init_res =   3.34761256353173E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.75680295093998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.72004252609935E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.71227086100210E-01
+(PID.TID 0000.0001)      cg2d_init_res =   3.34761387674508E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     109
-(PID.TID 0000.0001)      cg2d_last_res =   6.43504631911896E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.43504352282410E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1089342565207E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.0078054205180E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440443E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1936304069615E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4458768155103E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0538836472927E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2469002500124E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9653854733048E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2596291192028E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7157648766726E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7380273224435E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0157968120473E+00
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2903700616301E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4270112535699E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8417784097865E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5800017674627E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.1500698781053E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0611169146924E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4589737990720E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6294186805597E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631074310E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.2040245943350E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905860659333E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366146688522E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0870646857508E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1089343103632E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -4.0078053629806E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440442E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1936304117268E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.4458875408536E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0538833677456E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2469037253890E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.9653854529784E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2596294438472E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.7157702985327E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7380273225711E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0157967767264E+00
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2903698757765E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4270120199866E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.8418001812375E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.5800024141984E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.1500698361140E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0611167785021E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.4589764658660E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.6294459551391E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2605631074308E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.2040242118434E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905860659335E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366146686870E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0870649385319E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711518357434E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8971662933436E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704105270E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856085911718E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6508313468791E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3868630070024E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8016088266072E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0932707836913E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.7477754653196E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.9042391111018E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0818167582000E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2517963197744E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.8070138911450E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.0778256388465E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.3290226046554E-04
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8971662934120E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704105271E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856085890693E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6508314761148E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3868604107110E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.8010150009054E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0932714904798E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.7477728796802E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.9042388014865E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0818174931816E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2517970953040E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.8070139001634E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.0778614234375E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.3290251033530E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -5.0252935543686E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.2887940187670E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -5.0252933623841E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.2887890389762E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543496593048E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543496600383E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538363189E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240916499122E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.3347217873098E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.8200551906177E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7240916459053E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.3347219968522E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.8200590908857E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4160,16 +4214,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3923581989141E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113393975170E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.6410514359328E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3814530395102E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1538111967890E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862175167607E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3923581987979E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.0113393975181E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.6410516666395E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3814530337178E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1538111897270E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0862175167608E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5668660324038E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5827541159356E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7489072545658E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2121523017964E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.5827540839303E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7489072539045E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2121523015796E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -4185,16 +4239,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1021338187955E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2941478464813E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2998408828165E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8150750928003E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8479428897580E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0816630288013E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804804312448E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282188107383E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502117282240E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8085513761440E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9401664772067E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2941478464812E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2998408841686E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8150750895183E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8479428817068E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0816630281616E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2804804312450E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2282188107356E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.3502117250234E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8085513750007E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9401664680728E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -4228,66 +4282,66 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.70388041848922E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69565508449131E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262228492439E-01
-(PID.TID 0000.0001)      cg2d_init_res =   2.70895734274696E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411904E+00  1.70388040359727E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.69565509986635E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.69262232652982E-01
+(PID.TID 0000.0001)      cg2d_init_res =   2.70895852756711E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     114
-(PID.TID 0000.0001)      cg2d_last_res =   6.46303427977811E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.46303045337810E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   3.2400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1076397176587E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.7812866121939E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440444E-03
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1407775354485E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3301204545299E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1019485877665E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2585814055103E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8613320267765E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2682542001095E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6559089597575E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9151821355824E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3722141322324E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.4300783975655E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4342560175021E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7780966273192E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0141778617732E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.9574225248649E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.4311483020813E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6192511591609E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.2196145549760E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572926072597E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.3182564470805E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905933126927E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366562289445E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0833228875666E-04
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1076397176589E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.7812865400211E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.5203064440442E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   7.1407775677925E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   9.3301526737783E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1019457616358E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2585944403367E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.8613317983819E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2682545978099E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.6559141158048E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.9151821376721E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3722141322314E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.4300773000583E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.4342565502753E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.7781213982072E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.0141820134428E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.9574236454886E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.4311830076522E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6192528605895E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   5.2196354765439E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.2572926072595E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.3182564481641E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5905933126951E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366562286709E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   1.0833233229310E-04
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0711512422108E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8953921620771E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8953921622814E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725704028967E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856075211583E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6327643869938E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8470949650411E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2680706755461E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0716197929286E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0192346598666E-01
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.3848303134036E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0717082192142E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2304867405088E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.7073571221351E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.4040232032548E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.3647486660769E-04
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.7856075170662E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.6327645712770E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8470686809708E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.2668422838745E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0716284749920E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0192320458695E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   7.3835985771079E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.0717171722145E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2304961930136E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.7073571828966E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.4042222142551E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.3647507675253E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349973326485E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.8223652630791E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.8392055176722E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.8223628727387E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.8391944279393E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543514203517E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538882723E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7241655236501E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.8793922796397E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.0225215843036E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4543514212119E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760538882726E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7241655386328E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -1.8793944826974E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.0225309092640E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4296,35 +4350,35 @@
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501486285394D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417743207D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501485224402D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372297208D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388904028601D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388857521610D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677266326D+06
-(PID.TID 0000.0001)  global fc =  0.918388904028601D+07
+(PID.TID 0000.0001)   local fc =  0.630760677777804D+06
+(PID.TID 0000.0001)  global fc =  0.918388857521610D+07
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.73784634267033E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102262E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75680295093998E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.72004253669273E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.75680295093998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.72004252609935E-01
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088548885E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.70388041848922E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69565508449131E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262228492439E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.71227086100210E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411904E+00  1.70388040359727E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.69565509986635E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.69262232652982E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088548885E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411951E+00  1.70388041848922E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.69565508449131E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262228492439E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.71227086100210E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411904E+00  1.70388040359727E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.69565509986635E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.69262232652982E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) // =======================================================
@@ -4354,49 +4408,49 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   4.2819859483507E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -7.3560828993056E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.7787034236461E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.1126560554668E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.5527648291877E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.7787034245919E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   1.1126560546885E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.5527648256841E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.7382921006944E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.4161235894097E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.7969152316143E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.3155724463310E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.1952815679066E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -4.4158479817708E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.7969152244742E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.3155724433538E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   5.1952815627432E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -2.57498015965307E-19  1.83696260959917E-04
+ cg2d: Sum(rhs),rhsMax =  -1.16551733542192E-18  1.83696260986522E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     8
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537871773959E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928199495158E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716868341096E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500892941E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893610936467E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271185790375E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135524458471E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006102106675E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168948266407E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434093715693E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4491391571296E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4213901650299E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.4232914061078E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0607201288077E-05
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2806591451429E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644813438E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276834041E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859457646732E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619307439589E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917372366872E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.0537776378691E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5928191982191E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.0716872284459E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.0021500147337E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.7893612914731E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.0271183937430E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -8.1135517030024E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.4006002325290E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.8168938646752E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6434068778835E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.4491391573182E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -4.4213899012899E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.4232916635689E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   7.0607200889046E-05
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.2806591409911E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.1093644817473E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.9869276696551E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.6859455844742E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   5.4619305287396E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.1917371598319E-01
 (PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.9283278405307E-05
 (PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -6.3243304408083E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.1496778126279E-08
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.3720577578596E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.4422291393815E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   7.1497319361800E-08
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   6.3720587096189E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.4422402454542E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4410,66 +4464,66 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161605875621E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383870038178E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787142119801E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089950894E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551181129050E-05
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880495608004E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226718296323E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448805013237E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162972656E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022802285963E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028925456922E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878694530949E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3153546888347E-05
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5160664112783E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6792285046444E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856724E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325210143E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557379819771E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920632748E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999421185709E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129456E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440441361E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937450960255E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306043983826E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379946804461E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.9161605918172E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.7383833581862E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.3787146510200E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.3544089621778E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   6.4551097222870E-05
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   4.2880495614042E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -4.4226718250052E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -3.5448809323717E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.2801162349589E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   6.3022796912551E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.2028879378647E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5878704713914E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =   6.3319359234682E-05
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.5164379912177E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.6788422221857E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   8.5580815856507E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -1.4705325210130E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -1.5557380399441E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   2.2247920485274E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   5.0999412834916E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.5475521129238E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.7752440442171E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.5937463426129E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   4.6306036782546E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.0379763243437E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   1.95156391047391E-18  3.43370715556454E-04
+ cg2d: Sum(rhs),rhsMax =  -7.29125960996502E-18  3.43370725837032E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     7
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496063701560E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121848421018E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330076349572E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662139307042E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122668315775E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702613560E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005571766039E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556256104014E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319937856383E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522250369461E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221540489E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296551151300E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261607471404E-07
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176724902E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910556876E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256865653E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029910929E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171355218371E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204555204E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715177002332E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.7041562727298E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.2583967664088E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.5676042304190E-07
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.2511477540409E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.8155213810896E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.0496035960185E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -1.1121849426067E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -3.1330077023365E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.9662132832606E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   4.9122641973024E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4916702598066E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.9005573507168E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.6556222727120E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   5.3319905337874E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   4.4522158726024E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   6.8505221561101E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -8.8296550997709E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0261671153232E-07
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   1.4042176685303E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   2.5464910786638E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   2.1889256861166E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -6.0015029188045E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -5.3171349879687E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.0886204016508E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   2.3715174826477E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.7041562727867E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.2583967664062E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.5676121650426E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.2511478809214E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   2.8155363760657E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4483,66 +4537,66 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685044238624E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822480379E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327706804405E-03
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959335172E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894625187110E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255786511446E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329541350E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383167635417E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495837255054E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006643331E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268756908567E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543240898546E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6140798209024E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6126978376035E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4079083293455E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328844543E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799215174E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336113363806E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362871274426E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404098905066E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612457E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682741E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903702052535E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450810694833E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555790264043E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   8.0685044221397E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3545822060754E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   9.5327715192808E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.8193959045490E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.7894608934194E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.2255786509292E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.2642329522171E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.1383169971849E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.6495836745559E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.7731006613927E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   3.5268899959140E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.1543328640468E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.6116579694667E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.6130438056002E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   8.4077913410502E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.2826328844494E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.2046799215087E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -2.3336114702732E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.3362870860720E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   7.6404073569963E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   2.3211575612089E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.3164923682866E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   5.3903731269490E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   6.9450789440534E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   1.5555065752236E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -6.99310401253150E-18  8.65060080320657E-04
+ cg2d: Sum(rhs),rhsMax =   9.54097911787244E-18  8.65060074709178E-04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     6
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267281482780E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124326437179E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021973085776E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590718213872E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168902563370E-04
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238427764434E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646479531038E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398903174747E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173617759140E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157464307212E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184580090E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510912542E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461523621109E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976424487E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010256828624E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866200788E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593105083664E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066366124441E+01
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283962193339E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377312604495E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4335742768267E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8788314445495E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.1754564229002E-07
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8478450474066E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.1384607543013E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   3.7267241959422E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.2124328206905E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -6.0021945495903E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.1590715946113E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   8.9168837616764E-04
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.9238429383593E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9646478831257E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   5.2398833319460E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.0173613958959E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   8.0157383732685E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.0210184581341E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.3224510875153E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -1.5461532838412E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.0970976402160E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.8010257107484E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   3.2307866181383E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.0593103895247E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -7.9066360630797E+01
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.6283961366275E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.5377308305240E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.4335742768481E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.8788314445391E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   5.1754633243193E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   1.8478451457168E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   4.1384730114941E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4556,74 +4610,74 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897347496E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381511732457E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686563339762E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380743065105E-01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398580919954E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327709305746E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160262773308E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684349592601E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852118238792E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467134318462E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005168456048E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201926302156E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1324681122516E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3335575807941E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484545776402E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990350258E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704099775E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114861866742E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4470273742516E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171764059902E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275751743E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595538E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866882549306E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589880773818E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0721285296025E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.4774897544418E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -2.6381511704641E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   1.7686561227127E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   7.2380742652262E-01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   3.3398564034905E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   2.3327709295366E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -2.4160262766867E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -2.3684354144748E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   6.9852118840980E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   3.3467136332305E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.4005231954629E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -1.8201969287517E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.1321720972287E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   6.3336883868226E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   1.4484609523187E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   1.7084990349987E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -2.9379704099731E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.1114864156655E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   4.4470273046997E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.0171759740593E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.0946275751126E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -1.7557153595646E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   7.1866928924389E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   9.2589843014555E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.0719820376100E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   1.24683249835833E-17  1.48333987422958E-03
+ cg2d: Sum(rhs),rhsMax =  -2.89481980053630E-17  1.48333992315229E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     5
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641270494238E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655501055503E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181325870953E-03
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632916303440E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505693150459E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981237607666E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342746093E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781612809438E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165976450921E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116041917181E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632468255E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272602725E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892253152558E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628349418E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105032427E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558791146E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070828320E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703481716E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649980618154E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944893218498E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8830810335290E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.4946287563705E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   8.0245045836867E-07
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.4309663312696E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   5.4217376982225E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   5.4641271767447E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -3.5655499364160E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.5181246104647E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.8632912683222E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.3505681066087E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   5.2981227507322E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.7519342039080E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   8.3781513420298E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   1.6165974525896E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.2116047242776E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.3533632469220E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -1.7607272560239E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -2.4892264035031E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.7860628362529E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   5.0468105468225E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   4.2137558700843E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.2180070758312E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.0464703743656E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.1649979881734E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   4.6944883702708E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.8830810335637E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -2.4946287563522E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   8.0245086317291E-07
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   2.4309663486918E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   5.4217420305906E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411950E+00  1.73784634267033E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102262E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.75680295093998E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.72004253669273E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.75680295093998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.72004252609935E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4634,66 +4688,66 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474017935966E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829545842661E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975525367682E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041342076E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146996523210E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982026467014E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483495298166E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417920361790E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430271081E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735854257611E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451455846449E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839512522070E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7077780072038E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6614825483641E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2101973075824E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517544647E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357647463E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893440285770E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5569455531401E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692764136442E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679359019109E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952179668851E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9826126718925E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572376244729E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5878588699914E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   2.2474018217784E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -4.2829545809479E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   2.6975516614563E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.1466041255753E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   5.2146983375351E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   3.6982026463995E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -3.8483495297769E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -4.0417927302103E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.1174430598137E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   5.2735859578414E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   9.0451574203839E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -2.7839466401044E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -2.7074263178623E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   9.6616540613591E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.2102144782592E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.1332517544229E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.6703357647421E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -3.8893443799636E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   5.5569454576616E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.2692758216078E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   3.8679359018429E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.1952179668951E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   8.9826189756956E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.1572370962108E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.5876335880914E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.15502832193282E-17  2.12603553815238E-03
+ cg2d: Sum(rhs),rhsMax =   2.29850860566927E-17  2.12603568608330E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     4
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517551433459E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705417797663E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426042507601E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859436249807E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409800090410E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842633953395E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926763571855E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859540989069E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186630265742E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586394487273E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956337895E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329158149E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654938814183E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675375623E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841112879217E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406373862E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395103915E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989634819558E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026995617E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362835669189E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.3195220125798E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.1061181700466E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.0681523909145E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.0029906172601E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.6682216104744E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   7.8517551960995E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -5.0705412639062E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.3426027083840E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.6859432218743E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   1.8409784526526E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1842629722344E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -4.2926731856351E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.1859535576315E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3186627630454E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   1.6586403091939E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.6823956339463E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.1978329116161E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -3.3654953389717E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   3.4722675417944E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   6.2841113411485E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   5.0867406204334E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5082395029856E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2989636144869E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   2.6959026649766E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   5.8362821854046E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.3195220126046E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.1061181700332E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.0681525243345E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.0029905140346E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   6.6682144034075E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4707,66 +4761,66 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425157928490E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589438264772E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340967502097E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802151677E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285753203237E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745262096085E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151328280322E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968623032768E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789124628E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634371041903E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626403716690E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529937456188E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1210938472533E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3541913736981E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1121971926691E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522227130E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187745948E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671810637321E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6660388588786E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202407687807E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410493733251E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107084E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778046108007E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885253164362E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1031787554184E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.0425158174076E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -6.2589438227121E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   3.6340948340978E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   1.6327802042753E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   7.3285738408868E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   5.2745262093015E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -5.5151328288546E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -6.0968634450616E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   1.6056789772087E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   7.4634377813523E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0626410163525E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -4.3529914821413E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -5.1207598832455E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.3542116090327E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   3.1122260070758E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.5567522227088E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -4.4017187745909E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.6671816501951E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.6660387007983E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.5202395376711E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   4.6410493731951E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -2.6349832107177E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.0778053809154E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3885246770940E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.1028829567864E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   5.63785129692462E-18  2.73282977988839E-03
+ cg2d: Sum(rhs),rhsMax =   3.38271077815477E-17  2.73282993501916E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     3
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399173882E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139804382041E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435049083823E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021557018076E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413277655963E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387090934935E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3685395713295E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476273670063E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095668850405E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264289737979E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730846802E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337449287E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260392207903E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830781175E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723210602E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863594725E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389039756E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490660751110E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936315344E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666513492118E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7438231662645E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.7173404560976E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3000341574633E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.5630492300752E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.8665817224901E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.0253399320765E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -6.6139812608179E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -1.7435029802461E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   3.6021553423801E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3413258829353E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.1387090961037E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -5.3684153224322E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.5476274264829E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.1095665697529E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.1264304778000E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.0072730850319E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.6339337406947E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.1260406620424E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.1554830897984E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   7.5135723591997E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   6.5434863237034E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.8133389001310E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.5490662738443E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.2226936345863E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   6.9666497909009E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   2.7438231662622E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -3.7173404561282E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.3000339805307E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   3.5630490271376E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   7.8665655990815E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4780,66 +4834,66 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944541570523E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368255978464E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518046962971E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646488055997E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993209289209E-04
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190315531134E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736976228290E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351317556963E-02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450614294973E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199121998450E-04
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6055197018545E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809638800384E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4505859889419E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923726351253E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132686160753E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678504466E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723191991E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449499479067E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743774001907E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701806423301E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289839030E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599958659E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572883346419E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197963359242E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6184664193647E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   3.7944542008414E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -8.5368255947479E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   4.4518019134797E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.1646488014635E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   9.5993190207355E-04
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   7.0190315526936E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -7.3736976245662E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -8.4351329483563E-02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.1450615254722E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   9.8199131998946E-04
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   8.6054887108632E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.6809471859430E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -8.4503928784182E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   1.7923825756158E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0132888628244E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   2.9788678504713E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.1320723191955E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -5.4449508458810E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   7.7743771615314E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   1.7701785403871E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   5.4139289837681E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.0749599958748E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.2572891958020E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.6197956559364E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   3.6181232566700E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -8.32667268468867E-17  3.23836977129979E-03
+ cg2d: Sum(rhs),rhsMax =  -4.33680868994202E-19  3.23836983531998E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     2
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517218699400E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678952813710E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247835175209E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911028109480E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377118046557E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700416334E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4147066854521E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024551923222E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767108850006E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078122596984E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481062708E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197074381E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285380577588E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336767736253E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355518069507E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560460288464E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039946872590E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905896340907E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825565450E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619274028972E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1564765704629E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.2614335375642E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.5875840177814E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.0994250524546E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   8.9774588754660E-08
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.2517218872441E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -8.0678979829608E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.1247812246911E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   4.5911024996243E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.8377097564970E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.4666700560830E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -6.4145816953160E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9024554444373E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   3.9767105844800E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.6078141749201E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.3278481066933E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.0692197032615E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -5.1285396011632E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   4.8336768039783E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.7355519140877E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   8.2560459783854E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.1039947010533E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.7905898927397E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.7379825948080E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   8.0619257738687E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.1564765704318E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.2614335376012E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.5875833872386E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.0994247618491E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   8.9774344542315E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4853,66 +4907,66 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5806997643971E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950554824E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429221594464E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288625924E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956650077018E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926618768951E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852189060678E+01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928991306402E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178823853386E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254888320395E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436499049722E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034401681946E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766167583972E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926051343342E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493699649990E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894380676E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584524030E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225890454827E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8820574723958E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0191745259736E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865315024191E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755531759E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367080723637E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510742379176E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1343528779764E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.5807000461347E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1090950551583E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.0429184012529E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.7261288691808E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.1956647305704E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   8.8926618763974E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -9.3852189068684E+01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.0928992418888E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   2.7178824701978E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.2254889322279E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.0436455198823E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5034378210205E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.2766160056552E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.2926030101632E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   5.0493695061383E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.3994894381133E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -5.8613584523995E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -6.2225902324469E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   8.8820571694018E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.0191716610887E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.1865315022816E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.5150755531849E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.4367089434169E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.8510735962452E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.1340028509126E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -4.55364912443912E-18  3.71563950466507E-03
+ cg2d: Sum(rhs),rhsMax =   8.67361737988404E-19  3.71563945986806E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON ad_exf_tsnumber              =                     1
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597026809424E+01
-(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972454547201E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553298234798E-02
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362076385702E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200115339135E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935276491E+01
-(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2312398298978E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366634391387E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064316681014E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926862935591E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991067514E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380595801E-03
-(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601240566216E-06
-(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138088726E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467884987764E-07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705832239644E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963112913E+03
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202170689764E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483056204439E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696127902497E-01
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.5572291753488E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.9006090860186E-04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.1267582375862E-06
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5971486359799E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0072708890915E-07
+(PID.TID 0000.0001) %MON ad_exf_adfu_max              =   1.4597026972616E+01
+(PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2972485802536E+00
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -2.4553267285434E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   5.6362074071914E-01
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   3.3200096501513E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_max              =   1.7812935470011E+01
+(PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -7.2311510392651E+00
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   2.2366646117532E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   4.9064314540297E-01
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   3.0926877036329E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   2.6515991072214E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.5026380554599E-03
+(PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.0601254939514E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   5.4997138350919E-04
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   9.9467886019283E-07
+(PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   9.9705831672413E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -2.4343963450130E+03
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -2.0202174083824E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   4.2483057218541E+02
+(PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   9.1696114569141E-01
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   3.5572291752778E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.9006090860955E-04
+(PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   2.1267576283239E-06
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   4.5971483073797E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.0072681717250E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -4936,6 +4990,8 @@
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4946,31 +5002,31 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_mean        =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_sd          =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907301833600E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318639644E+02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618150700200E-02
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498469560E+00
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984703510532E-03
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936336807384E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736166978E+02
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154478542848E-01
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748802108E+00
-(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449455200E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358410359088E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053703509103E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797663358196E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892583917816E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976333779129E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116370384E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472781772E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000453875432E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891644633170E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673756983588E-02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063324529E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452479510E+03
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160350960833E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823662134588E+02
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6517502560277E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   4.9907302569371E+01
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.3982318633998E+02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =   5.6618119011597E-02
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   3.2473498407855E+00
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   1.3984699255938E-03
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.0936336806889E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_min        =  -1.1468736164450E+02
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_mean       =  -1.3154478409081E-01
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_sd         =   3.2140748823559E+00
+(PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   1.4315449452014E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   1.3358366248703E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -7.5053338878418E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -1.3797682384481E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   2.1892571797438E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.8976337821298E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.8185116370994E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -6.5895472781739E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -7.0000464356524E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   9.9891642031621E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.2673733423298E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   6.9588063323142E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -3.9552452479613E+03
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.6160355164490E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   2.0823661155503E+02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   4.6516724225291E-02
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4999,7 +5055,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient-check starts (grdchk_main)
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18388904028601E+06
+(PID.TID 0000.0001) grdchk reference fc: fcref       =  9.18388857521610E+06
 grad-res -------------------------------
  grad-res  proc    #    i    j    k   bi   bj iobc       fc ref            fc + eps           fc - eps
  grad-res  proc    #    i    j    k   bi   bj iobc      adj grad            fd grad          1 - fd/adj
@@ -5025,6 +5081,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -5032,30 +5090,30 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.73784634267103E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.78451867102415E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411916E+00  1.75680295094349E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.72004253670258E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.71227088551040E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411906E+00  1.70388041852481E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.69565508452685E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411907E+00  1.69262228492462E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.75680295094318E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411956E+00  1.72004252610940E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.71227086102233E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.70388040363077E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.69565509990394E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.69262232652782E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501500399538D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417775250D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501499337716D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372310572D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388918184787D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388871658288D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677266851D+06
-(PID.TID 0000.0001)  global fc =  0.918388918184787D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388918184787E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777911D+06
+(PID.TID 0000.0001)  global fc =  0.918388871658288D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388871658288E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5076,6 +5134,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -5083,33 +5143,33 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411933E+00  1.73784634266963E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.78451867102115E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.75680295093677E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.72004253668278E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.71227088546664E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.70388041845342E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.69565508445302E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.69262228492688E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.75680295093677E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411891E+00  1.72004252608815E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.71227086098034E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.70388040356102E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.69565509983117E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.69262232653083E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501472189601D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417647979D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501471124390D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372189348D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388889847580D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388843323738D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265576D+06
-(PID.TID 0000.0001)  global fc =  0.918388889847580D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889847580E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777646D+06
+(PID.TID 0000.0001)  global fc =  0.918388843323738D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388843323738E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388857521610E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.26981954574585E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.41686035320163E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.41672747209668E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5133,6 +5193,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -5140,30 +5202,30 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.73784634267100E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411935E+00  1.78451867102413E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.75680295094280E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.72004253670322E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411964E+00  1.71227088550966E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.70388041852254E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.69565508452347E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.69262228492235E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411934E+00  1.75680295094156E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.72004252610890E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411946E+00  1.71227086102293E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.70388040362998E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.69565509989964E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.69262232652437E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501500874861D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417778489D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501499812468D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372313811D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388918663349D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388872136279D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677266851D+06
-(PID.TID 0000.0001)  global fc =  0.918388918663349D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388918663349E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777911D+06
+(PID.TID 0000.0001)  global fc =  0.918388872136279D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388872136279E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5184,6 +5246,8 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
@@ -5191,33 +5255,33 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.73784634266966E-01
  cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78451867102070E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.75680295093794E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411953E+00  1.72004253668379E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.71227088546889E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.70388041845545E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.69565508445620E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411941E+00  1.69262228492951E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411908E+00  1.75680295093744E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.72004252608926E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411911E+00  1.71227086098173E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.70388040356316E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.69565509983532E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411936E+00  1.69262232653420E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501471715097D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417668789D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501470649998D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372210158D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388889393886D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388842870156D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265615D+06
-(PID.TID 0000.0001)  global fc =  0.918388889393886D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388889393886E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777646D+06
+(PID.TID 0000.0001)  global fc =  0.918388842870156D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388842870156E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388857521610E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.31621408462524E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.46347315981984E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.46330613642931E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5241,37 +5305,39 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.73784634267096E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411942E+00  1.78451867102424E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411955E+00  1.75680295094193E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411944E+00  1.72004253670213E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.71227088550856E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411912E+00  1.70388041851916E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.69565508452064E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.69262228492059E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411943E+00  1.78451867102424E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.75680295094196E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.72004252610829E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411910E+00  1.71227086102045E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.70388040362776E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411901E+00  1.69565509989706E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.69262232652527E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501501996853D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417823651D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501500932720D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372358974D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388919830504D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388873301693D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677266193D+06
-(PID.TID 0000.0001)  global fc =  0.918388919830504D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388919830504E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777911D+06
+(PID.TID 0000.0001)  global fc =  0.918388873301693D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388873301693E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5292,40 +5358,42 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411939E+00  1.73784634266969E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.78451867102085E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411899E+00  1.75680295093651E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411901E+00  1.72004253668364E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.71227088546872E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.70388041845847E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411945E+00  1.69565508445839E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411928E+00  1.69262228493025E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.78451867102085E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.75680295093651E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.72004252609020E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411954E+00  1.71227086098285E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411920E+00  1.70388040356494E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411909E+00  1.69565509983736E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411924E+00  1.69262232653534E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501470598156D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417707705D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501469533161D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372249074D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388888315861D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388841792235D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265848D+06
-(PID.TID 0000.0001)  global fc =  0.918388888315861D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388888315861E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777992D+06
+(PID.TID 0000.0001)  global fc =  0.918388841792235D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388841792235E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388857521610E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.43534650802612E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.57573214732111E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.57547291368246E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
 (PID.TID 0000.0001) grdchk pos: i,j,k=    0    0    1 ; bi,bj=   0   0 ; iobc=  0 ; rec=   1
@@ -5349,37 +5417,39 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.73784634267093E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.78451867102418E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.75680295094226E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411931E+00  1.72004253670027E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411955E+00  1.71227088550874E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.70388041851833E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411927E+00  1.69565508451929E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411899E+00  1.69262228491992E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411915E+00  1.78451867102418E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411938E+00  1.75680295094227E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411948E+00  1.72004252610762E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.71227086102015E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411914E+00  1.70388040362428E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69565509989420E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411930E+00  1.69262232652397E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501504513324D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417949201D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501503450758D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372506888D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388922472525D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388875967645D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677266193D+06
-(PID.TID 0000.0001)  global fc =  0.918388922472525D+07
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388922472525E+06
+(PID.TID 0000.0001)   local fc =  0.630760677777252D+06
+(PID.TID 0000.0001)  global fc =  0.918388875967645D+07
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  9.18388875967645E+06
 (PID.TID 0000.0001)  nRecords = 403 ; filePrec =  64 ; fileIter =     26280
 (PID.TID 0000.0001)     nDims =   2 , dims:
 (PID.TID 0000.0001)    1:  90   1  90
@@ -5400,40 +5470,42 @@ grad-res -------------------------------
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "dEtaHdt ", #  10 in fldList, rec= 402
 (PID.TID 0000.0001) READ_MFLDS_3D_RL: read field: "EtaH    ", #  11 in fldList, rec= 403
 (PID.TID 0000.0001) READ_MFLDS_CHECK: - normal end ; reset MFLDS file-name: pickup.0000000001
+(PID.TID 0000.0001) ECCO_READ_PICKUP: pickup_ecco.0000000001 and pickup_ecco.0000000001.data not provided.
+(PID.TID 0000.0001) ECCO_READ_PICKUP: sterGloH is referenced to its value at time step:         1
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   3.00377993411940E+00  1.73784634266973E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411925E+00  1.78451867102144E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.75680295093737E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411932E+00  1.72004253668397E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411947E+00  1.71227088547076E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411917E+00  1.70388041845983E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.69565508446168E-01
- cg2d: Sum(rhs),rhsMax =   3.00377993411926E+00  1.69262228493201E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411922E+00  1.78451867102144E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411918E+00  1.75680295093737E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411952E+00  1.72004252609050E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411923E+00  1.71227086098331E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411929E+00  1.70388040356594E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411921E+00  1.69565509983847E-01
+ cg2d: Sum(rhs),rhsMax =   3.00377993411937E+00  1.69262232653560E-01
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == cost_profiles: begin ==
 (PID.TID 0000.0001) == cost_profiles: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427501468075198D+07 1
-(PID.TID 0000.0001)  --> f_gencost = 0.490887417751557D+07 2
+(PID.TID 0000.0001)  --> f_gencost = 0.427501467010026D+07 1
+(PID.TID 0000.0001)  --> f_gencost = 0.490887372292926D+07 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
 (PID.TID 0000.0001)  --> f_genarr3d = 0.999999955296517D-04 1
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
 (PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918388885836755D+07
+(PID.TID 0000.0001)  --> fc               = 0.918388839312952D+07
 (PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.630760677265888D+06
-(PID.TID 0000.0001)  global fc =  0.918388885836755D+07
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388885836755E+06
-(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388904028601E+06
+(PID.TID 0000.0001)   local fc =  0.630760677778003D+06
+(PID.TID 0000.0001)  global fc =  0.918388839312952D+07
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  9.18388839312952E+06
+(PID.TID 0000.0001)  ADM  ref_cost_function      =  9.18388857521610E+06
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  1.70237884521484E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.83178845793009E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.83273463509977E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -5447,259 +5519,259 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output h.g:  Id     FC1-FC2/(2*EPS)      ADJ GRAD(FC)         1-FDGRD/ADGRD
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   1  9.1838890402860E+06  9.1838891818479E+06  9.1838888984758E+06
-(PID.TID 0000.0001) grdchk output (g):   1     1.4168603532016E+01  1.2698195457458E+01 -1.1579661688812E-01
+(PID.TID 0000.0001) grdchk output (c):   1  9.1838885752161E+06  9.1838887165829E+06  9.1838884332374E+06
+(PID.TID 0000.0001) grdchk output (g):   1     1.4167274720967E+01  1.2698195457458E+01 -1.1569197122773E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   2  9.1838890402860E+06  9.1838891866335E+06  9.1838888939389E+06
-(PID.TID 0000.0001) grdchk output (g):   2     1.4634731598198E+01  1.3162140846252E+01 -1.1188079273329E-01
+(PID.TID 0000.0001) grdchk output (c):   2  9.1838885752161E+06  9.1838887213628E+06  9.1838884287016E+06
+(PID.TID 0000.0001) grdchk output (g):   2     1.4633061364293E+01  1.3162140846252E+01 -1.1175389590664E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   3  9.1838890402860E+06  9.1838891983050E+06  9.1838888831586E+06
-(PID.TID 0000.0001) grdchk output (g):   3     1.5757321473211E+01  1.4353465080261E+01 -9.7806096653302E-02
+(PID.TID 0000.0001) grdchk output (c):   3  9.1838885752161E+06  9.1838887330169E+06  9.1838884179224E+06
+(PID.TID 0000.0001) grdchk output (g):   3     1.5754729136825E+01  1.4353465080261E+01 -9.7625489645032E-02
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     0     0     1    0    0   0.000000000E+00  0.000000000E+00
-(PID.TID 0000.0001) grdchk output (c):   4  9.1838890402860E+06  9.1838892247252E+06  9.1838888583676E+06
-(PID.TID 0000.0001) grdchk output (g):   4     1.8317884579301E+01  1.7023788452148E+01 -7.6016929533046E-02
+(PID.TID 0000.0001) grdchk output (c):   4  9.1838885752161E+06  9.1838887596764E+06  9.1838883931295E+06
+(PID.TID 0000.0001) grdchk output (g):   4     1.8327346350998E+01  1.7023788452148E+01 -7.6572726600391E-02
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.0157604833763E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  1.0157224540237E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4066.2582962512970
-(PID.TID 0000.0001)         System time:   11.224529206752777
-(PID.TID 0000.0001)     Wall clock time:   4100.3916988372803
+(PID.TID 0000.0001)           User time:   4046.4346787929535
+(PID.TID 0000.0001)         System time:   20.962842941284180
+(PID.TID 0000.0001)     Wall clock time:   4085.4143481254578
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   10.669492423534393
-(PID.TID 0000.0001)         System time:  0.80924999713897705
-(PID.TID 0000.0001)     Wall clock time:   13.554706811904907
+(PID.TID 0000.0001)           User time:   10.613414883613586
+(PID.TID 0000.0001)         System time:  0.83788794279098511
+(PID.TID 0000.0001)     Wall clock time:   13.903563976287842
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   1692.3285083770752
-(PID.TID 0000.0001)         System time:   4.2483478784561157
-(PID.TID 0000.0001)     Wall clock time:   1709.3201689720154
+(PID.TID 0000.0001)           User time:   1678.5533924102783
+(PID.TID 0000.0001)         System time:   7.9421120882034302
+(PID.TID 0000.0001)     Wall clock time:   1695.3111810684204
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   392.35034179687500
-(PID.TID 0000.0001)         System time:  0.71745157241821289
-(PID.TID 0000.0001)     Wall clock time:   395.35362768173218
+(PID.TID 0000.0001)           User time:   388.14944458007812
+(PID.TID 0000.0001)         System time:   1.6187095642089844
+(PID.TID 0000.0001)     Wall clock time:   392.40404605865479
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.1436157226562500
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.1480123996734619
+(PID.TID 0000.0001)           User time:   6.1046752929687500
+(PID.TID 0000.0001)         System time:   2.2706508636474609E-002
+(PID.TID 0000.0001)     Wall clock time:   6.1459939479827881
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6816711425781250
-(PID.TID 0000.0001)         System time:  0.11590003967285156
-(PID.TID 0000.0001)     Wall clock time:   7.9565670490264893
+(PID.TID 0000.0001)           User time:   5.3605957031250000
+(PID.TID 0000.0001)         System time:  0.15787506103515625
+(PID.TID 0000.0001)     Wall clock time:   5.8510503768920898
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.9977111816406250
-(PID.TID 0000.0001)         System time:   7.8006267547607422E-002
-(PID.TID 0000.0001)     Wall clock time:   7.1881442070007324
+(PID.TID 0000.0001)           User time:   4.6671142578125000
+(PID.TID 0000.0001)         System time:  0.11895012855529785
+(PID.TID 0000.0001)     Wall clock time:   5.0929226875305176
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.2724609375000000E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   8.7833404541015625E-004
+(PID.TID 0000.0001)           User time:   1.0070800781250000E-003
+(PID.TID 0000.0001)         System time:   7.6293945312500000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.2983245849609375E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.48220825195312500
-(PID.TID 0000.0001)         System time:   2.0277500152587891E-003
-(PID.TID 0000.0001)     Wall clock time:  0.48432922363281250
+(PID.TID 0000.0001)           User time:  0.43859863281250000
+(PID.TID 0000.0001)         System time:   3.0372142791748047E-003
+(PID.TID 0000.0001)     Wall clock time:  0.44270372390747070
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21401977539062500
-(PID.TID 0000.0001)         System time:   1.5497207641601562E-005
-(PID.TID 0000.0001)     Wall clock time:  0.21522760391235352
+(PID.TID 0000.0001)           User time:  0.20803833007812500
+(PID.TID 0000.0001)         System time:   1.1444091796875000E-005
+(PID.TID 0000.0001)     Wall clock time:  0.20886754989624023
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   67.578552246093750
-(PID.TID 0000.0001)         System time:   2.0950317382812500E-002
-(PID.TID 0000.0001)     Wall clock time:   67.820104122161865
+(PID.TID 0000.0001)           User time:   62.120971679687500
+(PID.TID 0000.0001)         System time:  0.19455265998840332
+(PID.TID 0000.0001)     Wall clock time:   62.425617694854736
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   26.167633056640625
-(PID.TID 0000.0001)         System time:   2.0167827606201172E-003
-(PID.TID 0000.0001)     Wall clock time:   26.322521209716797
+(PID.TID 0000.0001)           User time:   20.391662597656250
+(PID.TID 0000.0001)         System time:   6.9837808609008789E-002
+(PID.TID 0000.0001)     Wall clock time:   20.497528314590454
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   90.331542968750000
-(PID.TID 0000.0001)         System time:   1.0056495666503906E-003
-(PID.TID 0000.0001)     Wall clock time:   91.274230718612671
+(PID.TID 0000.0001)           User time:   90.712066650390625
+(PID.TID 0000.0001)         System time:  0.17936801910400391
+(PID.TID 0000.0001)     Wall clock time:   91.675324916839600
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8663635253906250
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   1.8731336593627930
+(PID.TID 0000.0001)           User time:   1.1988525390625000
+(PID.TID 0000.0001)         System time:   9.9503993988037109E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2121648788452148
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   15.039276123046875
-(PID.TID 0000.0001)         System time:   1.2958049774169922E-002
-(PID.TID 0000.0001)     Wall clock time:   15.071886301040649
+(PID.TID 0000.0001)           User time:   15.420288085937500
+(PID.TID 0000.0001)         System time:   3.8920879364013672E-002
+(PID.TID 0000.0001)     Wall clock time:   15.477190017700195
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.1010742187500000
-(PID.TID 0000.0001)         System time:   8.1062316894531250E-006
-(PID.TID 0000.0001)     Wall clock time:   2.1134395599365234
+(PID.TID 0000.0001)           User time:   2.1025085449218750
+(PID.TID 0000.0001)         System time:   5.0497055053710938E-003
+(PID.TID 0000.0001)     Wall clock time:   2.1109757423400879
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8611755371093750
-(PID.TID 0000.0001)         System time:   9.9611282348632812E-004
-(PID.TID 0000.0001)     Wall clock time:   3.8671965599060059
+(PID.TID 0000.0001)           User time:   3.8716735839843750
+(PID.TID 0000.0001)         System time:   7.9979896545410156E-003
+(PID.TID 0000.0001)     Wall clock time:   3.8960900306701660
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25765991210937500
-(PID.TID 0000.0001)         System time:   1.0051727294921875E-003
-(PID.TID 0000.0001)     Wall clock time:  0.25989127159118652
+(PID.TID 0000.0001)           User time:  0.24392700195312500
+(PID.TID 0000.0001)         System time:   1.9311904907226562E-005
+(PID.TID 0000.0001)     Wall clock time:  0.24399065971374512
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.7389221191406250
-(PID.TID 0000.0001)         System time:   1.3891458511352539E-002
-(PID.TID 0000.0001)     Wall clock time:   5.7632095813751221
+(PID.TID 0000.0001)           User time:   5.4982604980468750
+(PID.TID 0000.0001)         System time:   1.8065929412841797E-002
+(PID.TID 0000.0001)     Wall clock time:   5.5229885578155518
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   92.710174560546875
-(PID.TID 0000.0001)         System time:   9.9587440490722656E-004
-(PID.TID 0000.0001)     Wall clock time:   92.836520910263062
+(PID.TID 0000.0001)           User time:   93.411529541015625
+(PID.TID 0000.0001)         System time:  0.20656228065490723
+(PID.TID 0000.0001)     Wall clock time:   93.725756883621216
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6621093750000000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9144706726074219E-004
+(PID.TID 0000.0001)           User time:   4.5776367187500000E-004
+(PID.TID 0000.0001)         System time:   2.8610229492187500E-006
+(PID.TID 0000.0001)     Wall clock time:   9.4628334045410156E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.78945922851562500
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.78864669799804688
+(PID.TID 0000.0001)           User time:  0.86315917968750000
+(PID.TID 0000.0001)         System time:   1.9879341125488281E-003
+(PID.TID 0000.0001)     Wall clock time:   1.0978293418884277
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5258789062500000E-004
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   8.6903572082519531E-004
+(PID.TID 0000.0001)           User time:   9.4604492187500000E-004
+(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
+(PID.TID 0000.0001)     Wall clock time:   9.0074539184570312E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8537597656250000
-(PID.TID 0000.0001)         System time:  0.14990973472595215
-(PID.TID 0000.0001)     Wall clock time:   2.2378172874450684
+(PID.TID 0000.0001)           User time:   1.8641052246093750
+(PID.TID 0000.0001)         System time:  0.14192700386047363
+(PID.TID 0000.0001)     Wall clock time:   2.2331058979034424
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6652832031250000
-(PID.TID 0000.0001)         System time:  0.38885688781738281
-(PID.TID 0000.0001)     Wall clock time:   3.4767146110534668
+(PID.TID 0000.0001)           User time:   2.6614379882812500
+(PID.TID 0000.0001)         System time:  0.43661355972290039
+(PID.TID 0000.0001)     Wall clock time:   3.7661452293395996
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   19.137878417968750
-(PID.TID 0000.0001)         System time:  0.69974112510681152
-(PID.TID 0000.0001)     Wall clock time:   20.695022583007812
+(PID.TID 0000.0001)           User time:   19.409515380859375
+(PID.TID 0000.0001)         System time:  0.86337208747863770
+(PID.TID 0000.0001)     Wall clock time:   21.250953435897827
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   6.8879089355468750
-(PID.TID 0000.0001)         System time:  0.15394544601440430
-(PID.TID 0000.0001)     Wall clock time:   7.0777497291564941
+(PID.TID 0000.0001)           User time:   7.0270690917968750
+(PID.TID 0000.0001)         System time:  0.21682310104370117
+(PID.TID 0000.0001)     Wall clock time:   7.2831325531005859
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.0649414062500000
-(PID.TID 0000.0001)         System time:   8.9978218078613281E-002
-(PID.TID 0000.0001)     Wall clock time:   3.2590529918670654
+(PID.TID 0000.0001)           User time:   3.1125488281250000
+(PID.TID 0000.0001)         System time:  0.13890075683593750
+(PID.TID 0000.0001)     Wall clock time:   3.3598968982696533
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   3.0552978515625000
-(PID.TID 0000.0001)         System time:   8.7960720062255859E-002
-(PID.TID 0000.0001)     Wall clock time:   3.2460501194000244
+(PID.TID 0000.0001)           User time:   3.0947265625000000
+(PID.TID 0000.0001)         System time:  0.11992454528808594
+(PID.TID 0000.0001)     Wall clock time:   3.2898888587951660
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2357.1400146484375
-(PID.TID 0000.0001)         System time:   5.9889793395996094
-(PID.TID 0000.0001)     Wall clock time:   2371.0116178989410
+(PID.TID 0000.0001)           User time:   2351.0604248046875
+(PID.TID 0000.0001)         System time:   11.924004554748535
+(PID.TID 0000.0001)     Wall clock time:   2369.5497069358826
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2010.3614501953125
-(PID.TID 0000.0001)         System time:   4.3147134780883789
-(PID.TID 0000.0001)     Wall clock time:   2019.8368494510651
+(PID.TID 0000.0001)           User time:   2006.6348876953125
+(PID.TID 0000.0001)         System time:   9.2293167114257812
+(PID.TID 0000.0001)     Wall clock time:   2020.0063982009888
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   337.50866699218750
-(PID.TID 0000.0001)         System time:   1.2374382019042969
-(PID.TID 0000.0001)     Wall clock time:   340.76504778862000
+(PID.TID 0000.0001)           User time:   335.08618164062500
+(PID.TID 0000.0001)         System time:   2.1530122756958008
+(PID.TID 0000.0001)     Wall clock time:   339.08450675010681
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   4.0101318359375000
-(PID.TID 0000.0001)         System time:   1.1920928955078125E-005
-(PID.TID 0000.0001)     Wall clock time:   4.0173218250274658
+(PID.TID 0000.0001)           User time:   4.2587890625000000
+(PID.TID 0000.0001)         System time:   1.5024185180664062E-002
+(PID.TID 0000.0001)     Wall clock time:   4.2769188880920410
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7333984375000000E-002
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:   1.7010450363159180E-002
+(PID.TID 0000.0001)           User time:   1.7578125000000000E-002
+(PID.TID 0000.0001)         System time:   2.9468536376953125E-004
+(PID.TID 0000.0001)     Wall clock time:   1.7195463180541992E-002
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   304.94946289062500
-(PID.TID 0000.0001)         System time:  0.14079856872558594
-(PID.TID 0000.0001)     Wall clock time:   305.66043210029602
+(PID.TID 0000.0001)           User time:   301.95373535156250
+(PID.TID 0000.0001)         System time:  0.83251285552978516
+(PID.TID 0000.0001)     Wall clock time:   303.28434801101685
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.3232421875000000
-(PID.TID 0000.0001)         System time:  0.35486364364624023
-(PID.TID 0000.0001)     Wall clock time:   6.2857165336608887
+(PID.TID 0000.0001)           User time:   5.2827148437500000
+(PID.TID 0000.0001)         System time:  0.35883998870849609
+(PID.TID 0000.0001)     Wall clock time:   6.2353699207305908
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.1972656250000000E-003
-(PID.TID 0000.0001)         System time:   6.6757202148437500E-006
-(PID.TID 0000.0001)     Wall clock time:   2.1343231201171875E-003
+(PID.TID 0000.0001)           User time:   1.9531250000000000E-003
+(PID.TID 0000.0001)         System time:   5.7220458984375000E-006
+(PID.TID 0000.0001)     Wall clock time:   2.1328926086425781E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   23.142944335937500
-(PID.TID 0000.0001)         System time:  0.73973846435546875
-(PID.TID 0000.0001)     Wall clock time:   24.709894657135010
+(PID.TID 0000.0001)           User time:   23.510742187500000
+(PID.TID 0000.0001)         System time:  0.94428920745849609
+(PID.TID 0000.0001)     Wall clock time:   25.199677228927612
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.8564453125000000E-002
-(PID.TID 0000.0001)         System time:   2.0060539245605469E-003
-(PID.TID 0000.0001)     Wall clock time:   3.6079883575439453E-002
+(PID.TID 0000.0001)           User time:   2.4291992187500000E-002
+(PID.TID 0000.0001)         System time:   2.0036697387695312E-003
+(PID.TID 0000.0001)     Wall clock time:   3.2124996185302734E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -5739,9 +5811,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         903306
+(PID.TID 0000.0001) //            No. barriers =         900958
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         903306
+(PID.TID 0000.0001) //     Total barrier spins =         900958
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally


### PR DESCRIPTION
Update reference output of experiments `global_oce_cs32` and `global_oce_llc90` following bug fixed in `pkg/ggl90`, main repos PR https://github.com/MITgcm/MITgcm/pull/714

Update both Fwd & Adm ref. output, except the 2 AD tests in llc90 that do not use pkg/gg90 (primary + core2), after bug fixed (related to missing hFac) in pkg/ggl90.

Note: Since none of these tests uses IDEMIX, could have preserved the same results
by defining CCP option "GGL90_MISSING_HFAC_BUG" in GGL90_OPTIONS.h

To merge only after main repos PR https://github.com/MITgcm/MITgcm/pull/714 has been merged in.