### PR TITLE
renaming ctrl_dummy.h update

### DIFF
--- a/global_oce_cs32/code/CTRL_OPTIONS.h
+++ b/global_oce_cs32/code/CTRL_OPTIONS.h
@@ -54,8 +54,6 @@ C     involves many new dependencies that we would like to avoid in general.
 #ifdef ALLOW_DEPTH_CONTROL
 C   Only relevant within DEPTH_CONTROL code:
 # define USE_SMOOTH_MIN
-# undef ALLOW_HFACC_CONTROL
-# undef ALLOW_HFACC3D_CONTROL
 #endif /* ALLOW_DEPTH_CONTROL */
 
 C       >>> Generic Control.

--- a/global_oce_llc90/code/CTRL_OPTIONS.h
+++ b/global_oce_llc90/code/CTRL_OPTIONS.h
@@ -54,8 +54,6 @@ C     involves many new dependencies that we would like to avoid in general.
 #ifdef ALLOW_DEPTH_CONTROL
 C   Only relevant within DEPTH_CONTROL code:
 # define USE_SMOOTH_MIN
-# undef ALLOW_HFACC_CONTROL
-# undef ALLOW_HFACC3D_CONTROL
 #endif /* ALLOW_DEPTH_CONTROL */
 
 C       >>> Generic Control.

--- a/shelfice_remeshing/code/shelfice_thermodynamics.F
+++ b/shelfice_remeshing/code/shelfice_thermodynamics.F
@@ -38,12 +38,11 @@ C     === Global variables ===
 #ifdef ALLOW_AUTODIFF
 # include "CTRL_SIZE.h"
 # include "CTRL.h"
-# include "ctrl_dummy.h"
+# include "CTRL_DUMMY.h"
 #endif /* ALLOW_AUTODIFF */
 #ifdef ALLOW_AUTODIFF_TAMC
 # ifdef SHI_ALLOW_GAMMAFRICT
 #  include "tamc.h"
-#  include "tamc_keys.h"
 # endif /* SHI_ALLOW_GAMMAFRICT */
 #endif /* ALLOW_AUTODIFF_TAMC */
 #ifdef ALLOW_STREAMICE


### PR DESCRIPTION
following main MITgcm code PR https://github.com/MITgcm/MITgcm/pull/768 
rename "ctrl_dummy.h" to "CTRL_DUMMY.h" and remove 2 obsolete pkg/ctrl CPP options.