### PR TITLE
Post pr769 output update

### DIFF
--- a/global_ocean.gm_k3d/results/output.txt
+++ b/global_ocean.gm_k3d/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67v
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68s
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Feb 23 12:12:20 EST 2021
+(PID.TID 0000.0001) // Build date:        Wed Oct 18 15:30:50 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -225,17 +225,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># GM+Redi package parameters:
 (PID.TID 0000.0001) >
-(PID.TID 0000.0001) >#-from MOM :
-(PID.TID 0000.0001) ># GM_background_K: 	G & Mc.W  diffusion coefficient
-(PID.TID 0000.0001) ># GM_maxSlope    :	max slope of isopycnals
-(PID.TID 0000.0001) ># GM_Scrit       :	transition for scaling diffusion coefficient
-(PID.TID 0000.0001) ># GM_Sd          :	half width scaling for diffusion coefficient
-(PID.TID 0000.0001) ># GM_taper_scheme:	slope clipping or one of the tapering schemes
-(PID.TID 0000.0001) ># GM_Kmin_horiz  :	horizontal diffusion minimum value
+(PID.TID 0000.0001) ># GM_background_K:: G & Mc.W  diffusion coefficient
+(PID.TID 0000.0001) ># GM_maxSlope    :: max slope of isopycnals
+(PID.TID 0000.0001) ># GM_Scrit       :: transition for scaling diffusion coefficient
+(PID.TID 0000.0001) ># GM_Sd          :: half width scaling for diffusion coefficient
+(PID.TID 0000.0001) ># GM_taper_scheme:: slope clipping or one of the tapering schemes
+(PID.TID 0000.0001) ># GM_Kmin_horiz  :: horizontal diffusion minimum value
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) >#-Option parameters (needs to "define" options in GMREDI_OPTIONS.h")
-(PID.TID 0000.0001) ># GM_isopycK     :	isopycnal diffusion coefficient (default=GM_background_K)
-(PID.TID 0000.0001) ># GM_AdvForm     :	turn on GM Advective form       (default=Skew flux form)
+(PID.TID 0000.0001) ># GM_isopycK     :: isopycnal diffusion coefficient (default=GM_background_K)
+(PID.TID 0000.0001) ># GM_AdvForm     :: turn on GM Advective form       (default=Skew flux form)
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &GM_PARM01
 (PID.TID 0000.0001) >  GM_AdvForm         = .TRUE.,
@@ -243,32 +242,32 @@
 (PID.TID 0000.0001) >  GM_background_K    = 0.0,
 (PID.TID 0000.0001) >  GM_isopycK         = 0.0,
 (PID.TID 0000.0001) >  GM_taper_scheme    = 'gkw91',
-(PID.TID 0000.0001) >  GM_maxSlope        = 1.e-2,
+(PID.TID 0000.0001) >  GM_maxSlope        = 1.E-2,
 (PID.TID 0000.0001) >  GM_Kmin_horiz      = 50.,
-(PID.TID 0000.0001) >  GM_Scrit           = 4.e-3,
-(PID.TID 0000.0001) >  GM_Sd              = 1.e-3,
-(PID.TID 0000.0001) >  GM_K3D_gamma       = 0.35,
-(PID.TID 0000.0001) >  GM_K3D_b1          = 4,
-(PID.TID 0000.0001) >  GM_K3D_EadyMaxDepth= 1000.0,
-(PID.TID 0000.0001) >  GM_K3D_EadyMinDepth= 50.0,
-(PID.TID 0000.0001) >  GM_K3D_smallK      = 0.1D+3,
-(PID.TID 0000.0001) >  GM_K3D_maxC        =-0.15,
-(PID.TID 0000.0001) >  GM_maxK3D          = 2.0D+3,
-(PID.TID 0000.0001) >  GM_K3D_Lambda      = 4.0,
-(PID.TID 0000.0001) >  GM_useK3D          = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_use_constK  = .FALSE.,
-(PID.TID 0000.0001) >  GM_K3D_ThickSheet  = .FALSE.,
-(PID.TID 0000.0001) >  GM_K3D_smooth      = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_constK      = 1000.0,
-(PID.TID 0000.0001) >  GM_K3D_Rmax        = 75.0D+03,
-(PID.TID 0000.0001) >  GM_K3D_Rmin        = 30.0D+03,
-(PID.TID 0000.0001) >  GM_K3D_minCori     = 1.52D-5,
-(PID.TID 0000.0001) >  GM_K3D_minN2       = 1.0D-7,
-(PID.TID 0000.0001) >  GM_K3D_surfMinDepth= 0.0,
-(PID.TID 0000.0001) >  GM_K3D_vecFreq     = 2592000,
+(PID.TID 0000.0001) >  GM_Scrit           = 4.E-3,
+(PID.TID 0000.0001) >  GM_Sd              = 1.E-3,
 (PID.TID 0000.0001) >  GM_InMomAsStress   = .FALSE.,
-(PID.TID 0000.0001) >  GM_K3D_surfK       = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_constRedi   = .FALSE.,
+(PID.TID 0000.0001) >  GM_useBatesK3d     = .TRUE.,
+(PID.TID 0000.0001) >  GM_Bates_gamma       = 0.35,
+(PID.TID 0000.0001) >  GM_Bates_b1          = 4.,
+(PID.TID 0000.0001) >  GM_Bates_EadyMaxDepth= 1000.0,
+(PID.TID 0000.0001) >  GM_Bates_EadyMinDepth= 50.0,
+(PID.TID 0000.0001) >  GM_Bates_smallK      = 0.1E+3,
+(PID.TID 0000.0001) >  GM_Bates_maxC        =-0.15,
+(PID.TID 0000.0001) >  GM_Bates_maxK        = 2.0E+3,
+(PID.TID 0000.0001) >  GM_Bates_Lambda      = 4.0,
+(PID.TID 0000.0001) >  GM_Bates_use_constK  = .FALSE.,
+(PID.TID 0000.0001) >  GM_Bates_ThickSheet  = .FALSE.,
+(PID.TID 0000.0001) >  GM_Bates_smooth      = .TRUE.,
+(PID.TID 0000.0001) >  GM_Bates_constK      = 1000.0,
+(PID.TID 0000.0001) >  GM_Bates_Rmax        = 75.0E+03,
+(PID.TID 0000.0001) >  GM_Bates_Rmin        = 30.0E+03,
+(PID.TID 0000.0001) >  GM_Bates_minCori     = 1.52E-5,
+(PID.TID 0000.0001) >  GM_Bates_minN2       = 1.0E-7,
+(PID.TID 0000.0001) >  GM_Bates_surfMinDepth= 0.0,
+(PID.TID 0000.0001) >  GM_Bates_vecFreq     = 2592000.,
+(PID.TID 0000.0001) >  GM_Bates_surfK       = .TRUE.,
+(PID.TID 0000.0001) >  GM_Bates_constRedi   = .FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
@@ -782,8 +781,28 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.024871553740665E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.025131853965179E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.025500122698715E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.026019055456198E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.026730727023644E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.027654834729768E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.028788857592232E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.030129714500301E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.031673780307277E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.033416904722807E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.035354433881450E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.037481234443614E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.039791720064872E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.042279880049878E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.044939309988095E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -939,17 +958,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 5.000000000000000E-02
@@ -957,10 +979,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -982,7 +1004,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -991,7 +1013,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1166,8 +1188,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -1182,6 +1204,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -1517,15 +1542,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -1897,16 +1913,19 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_ExtraDiag =   /* Tensor Extra Diag (line 1&2) non 0 */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 5.000000000000000E+01
@@ -1962,10 +1981,10 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_useK3D =     /* if TRUE => use K3D for diffusivity */
+(PID.TID 0000.0001) GM_useBatesK3d = /* if TRUE => use BatesK3d for GM diffusivity */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_K3D_NModes = /* Number of modes for expansion */
+(PID.TID 0000.0001) GM_Bates_NModes = /* Number of modes for expansion */
 (PID.TID 0000.0001)                       6
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
@@ -2190,16 +2209,16 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6955545785831E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4877872181906E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2517961305325E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9727846238202E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9002003759406E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9728054875999E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9001762389149E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197724302515E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171127043226E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6106444331336E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7462071235778E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754895309543E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171732187342E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6178760109057E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7463731105160E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754801130016E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005931612E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613040484006E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0129996334597E-03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613653999259E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0134714574705E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2589080810547E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8702698516846E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6700205338390E+01
@@ -2242,51 +2261,51 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604246321620E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655725552E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162541671689E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1144349274607E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7416990246787E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1146570946742E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7416746440331E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.23143674319682E-03  2.62871826285151E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.71016562818688E-01
+ cg2d: Sum(rhs),rhsMax =   7.19824186312956E-03  2.64084066567303E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.69554327123605E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.44179059320920E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.40096816183781E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0241303990167E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158211969346E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248844E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4259975233385E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5884830845481E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1565903465634E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2646663818193E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3937623148597E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3841560537884E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3833801561301E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5610441198593E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.2886623782510E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2472133325878E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.1935378902032E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.3735946623178E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0664208920472E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6357590858581E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9092337390590E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1766506945356E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6740699728739E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9721893777139E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9008605424673E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197819173950E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4168927572518E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5784304443791E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7450144264662E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755744670981E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518209E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606680953194E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0172924604267E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0285855867950E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158555567357E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248845E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4264819776323E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5958585789729E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1597165812308E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2721567753622E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3944237129519E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3860906776214E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3931286271120E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5653208439293E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.2923270938792E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2472802982222E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.1952192651173E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.3814021855052E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0695551245843E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6487158050696E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9115318953491E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1783455167384E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6783366768201E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722308005702E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9008346573785E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197819091101E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170122129282E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5917248130378E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7452028229035E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755557241746E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518206E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9607905899772E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0181103879290E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2693899536133E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8655982259115E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6687693382567E+01
@@ -2312,68 +2331,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2915731155564E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5261152700224E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4588571962377E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.0350471553543E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7465638782618E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1103846822596E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0787791575930E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.3321831821899E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3231493168664E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9170994977908E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5067070264391E-04
-(PID.TID 0000.0001) %MON ke_max                       =   8.8790095187195E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1181430938528E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.0375272919735E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7498083766322E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1157889881859E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0815673763508E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.3393031369056E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3869367200762E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9922876946649E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5072558072876E-04
+(PID.TID 0000.0001) %MON ke_max                       =   8.8892753580871E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1192011852104E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782213082E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7624348712946E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4424901273843E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807287122E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604184711149E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642652839E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162947612555E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8467307941363E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9395699253734E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7624393898787E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4426470977407E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807287184E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604184698675E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642652918E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162947583969E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8472317992664E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9396412983158E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.20257556889298E-02  2.38591222805679E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.02553793424193E-01
+ cg2d: Sum(rhs),rhsMax =   1.19283869484093E-02  2.40538789309102E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.88220013995103E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.26712078780864E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.20129636285750E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9396931613914E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5797230816683E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231134E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2997656271079E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4327834373657E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9945393137865E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.6365753253838E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2245757620177E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4689467074603E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6570533193842E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0472824416429E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.1986475189151E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1325711143129E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.7694317921413E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1330630354886E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4682484425225E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2763101027838E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9215283188978E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6116218731806E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2646003329411E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9715429146768E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9015207012293E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198503764373E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4167795016356E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5155683423697E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7441151138120E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755894091184E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004666640E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9604421761631E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0143848415408E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9400806269462E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5798403757555E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231130E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3005182337299E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4443367949570E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0030273173681E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.6559298561136E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2257652153469E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4733425309193E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6797456554622E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0583333902776E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2109575558593E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1325823962766E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.7735640851030E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1519046695087E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4752643292296E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2795150759033E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9383245156908E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6155366927860E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2738711102079E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716044173787E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9014896836854E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198503546259E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169559785271E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5351759996237E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7443438306178E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755613726605E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004666549E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606240316603E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0157025366165E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2798718261719E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8609266001383E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6675181426744E+01
@@ -2399,68 +2418,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2178105886956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5379778517573E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.6013891323037E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7666010230290E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6463721489025E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6413872620667E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2042977985712E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.5751900059169E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.1765340085672E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5941367992018E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0536120668288E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1094281661530E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.5916638539381E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7669022795310E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6479695493555E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6451734887751E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2066894413202E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.5982103655036E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2025784810338E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5951576605136E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.0576664464422E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1129660784435E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781986628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3766243634023E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0005208399008E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209470E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604169478535E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640495892E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163345343232E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3820417159293E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2632356801453E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3766780911043E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0010725963208E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209482E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604169458268E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640488223E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163345285209E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3824488720338E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2633907191561E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.75443264042620E-02  2.19411333207644E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96158677583093E-01
+ cg2d: Sum(rhs),rhsMax =   1.73511265539675E-02  2.21854415885629E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.78154868559106E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.31456612958773E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.18599366430738E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7380645073917E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6005564984330E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451986E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5717446179891E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3355402720433E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9918905345807E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8241171080327E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4724078482375E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6233099652712E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7084318787732E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2357847871439E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8050949061560E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6184581358311E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2036017304269E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6231442972437E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.7897339924016E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5122907414753E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.2402359869247E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9652495667370E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7142474632774E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9709600745555E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9021686776813E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199346677320E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4167063437817E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4424746428277E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433442686505E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755243701017E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005975705E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9603493037245E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0124422847685E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7452684587046E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6006971544695E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451990E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5727120235969E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3508030184768E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0071937348665E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8578845582734E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4741226723404E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6303081493818E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7452565026647E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2556296920411E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8278411545787E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6183744695476E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2110122664686E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6561569583175E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8015611624962E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5177480137856E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.9742590067866E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9719244270197E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7294389479347E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9710411433299E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9021344497034E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199346327544E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169382742829E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4677794573327E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435891681762E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754870761039E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005975710E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605894617121E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0139208330756E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2903536987305E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8562549743652E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6662669470921E+01
@@ -2486,68 +2505,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1440480618348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.2842568613977E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2331806837760E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1446306747659E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2621994902384E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5164047615935E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.6023988330894E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.3389469389556E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9724983413977E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5865031634416E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3475388787460E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6510809416035E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1831791793885E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5819370324460E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2695655884255E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5208239928561E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.6415591775249E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.3832525072064E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9738779272179E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.5960769920979E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.3552893627394E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6078924665633E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2148938274259E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807116958E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185083200E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649846246E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163575796847E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0524735734648E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2041897463481E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6081521606623E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2158678826405E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807117001E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185055845E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649830954E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163575667269E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0526453706598E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2056812335894E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.43569073237546E-02  1.98772930972416E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.59224069422513E-01
+ cg2d: Sum(rhs),rhsMax =   2.40181507944756E-02  2.01576461884639E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.38116340694593E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.95467300373602E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.81547749455509E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8749683987969E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5495198767890E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911403E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5655596374140E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2452045736314E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0303779879271E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7791736281360E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8557839979726E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8619449082207E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5348749382685E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3352166839268E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.1860669476201E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6777392739004E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.3918536708254E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8039299171560E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0129629821496E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6637864378615E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   7.9805427457183E-12
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2270249464528E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0095533248123E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9704985059217E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028472867347E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200164832083E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4166507271007E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3634615223574E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7428286784850E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753985411465E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007493881E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9602867874018E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0098273923145E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8761459228581E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5497031628780E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911402E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5667298857627E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2640954486002E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0539158168804E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8296466446528E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8577823056758E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8715013538903E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5879343753791E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3638630907844E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.2145845008607E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6778237036573E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4031408911984E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8540740151901E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0297372661958E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6716444506730E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6766491253412E-12
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2365164291482E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0312131861976E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9705984790108E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028099963173E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200164354285E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169360980727E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3936557925468E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7430985245439E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753520150718E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007495300E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605799692826E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0116531605948E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3008355712891E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8515833485921E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6650157515098E+01
@@ -2573,68 +2592,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1963113185773E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.1539133940451E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.8039972697842E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8820497539900E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7847054811212E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.3442398262591E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.1784761546841E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9636843905522E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3696420420016E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.7473174541937E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5182524902451E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.6611988106844E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5110553834955E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8934724104636E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7902459843493E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4004778096035E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.2421044582851E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9653514218738E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.3873465862690E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.7609349283604E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5043565481899E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.1269231656152E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807042577E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217470123E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661335593E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163652312754E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1132021589801E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0244095888932E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5048490269060E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.1282849934173E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807042198E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217446064E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661310853E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163652165584E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1163957093681E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0236758928935E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.30747488200570E-02  1.76734499829913E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.10879448287311E-01
+ cg2d: Sum(rhs),rhsMax =   3.25259823795894E-02  1.79716299464722E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.68467196838569E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.86766775465879E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.60697861579319E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0320923349703E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5010404568214E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0322556456152E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5012496599892E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609404E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4675058438299E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1547211630819E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1016213681757E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4986070562912E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8039080507187E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1636608857097E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.1622991047566E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2142255558564E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0289750180636E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.0586423409731E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.2932401258513E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6570647403341E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1277751506900E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7225965441455E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6292689639645E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3934341338833E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1527489373715E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701395031882E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035501777690E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200910159133E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4166001980070E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2840377110379E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7425878661418E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9752396884628E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008700702E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9602404168178E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0078372605530E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4688933204061E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1755153121988E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1048932828576E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.5638651213784E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8061135803988E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1752719312028E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2283112340879E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2533755809608E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0329413262862E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2373706770142E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3086419118443E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.7240005418242E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1490337624441E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7327745072023E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6463678234462E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4053077924816E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1794111228656E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9702575955406E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035096112554E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200909616189E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169364539521E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3182807371533E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7429259802022E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751839461958E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008703397E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605836871481E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0099188021775E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3113174438477E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8469117228190E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6637645559275E+01
@@ -2660,68 +2679,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9965230081132E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5694062143202E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9584369949913E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6578935095081E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5377168761703E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9991334323453E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8967149911111E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8028440014146E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8252514049921E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.2967708476681E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.2192140924784E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6960764354126E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6968532129347E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0167288901682E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5396775582561E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0068393331025E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9611376805517E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8757255433277E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8271931010586E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.3249783077519E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.2396499651788E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3968329660796E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0959823672680E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806999737E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257540058E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668390582E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163639437998E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0688335351071E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1895113244920E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3982398327786E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0978421875217E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806999812E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257512686E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668362887E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163639262630E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0673715604640E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1889566755307E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.44560032753996E-02  1.54338886443047E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.23897036633637E+00
+ cg2d: Sum(rhs),rhsMax =   4.36100013893281E-02  1.57332947091255E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.28600911626996E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.21985479323610E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.38563906440047E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0915183556910E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4651145203689E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545968E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3600171476095E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0619262127649E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2871661932850E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.9615259514295E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5902284574485E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.4916064372816E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.6289007348716E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8194516428529E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1014260540729E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9249500165580E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9035404608701E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0185815323951E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1433695426613E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7970751042104E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8001630694655E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4673688579648E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1606572603469E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9698435752515E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042873467983E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201590182655E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165510046201E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2076997858703E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7424799915428E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750776735354E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009480822E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601929180949E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0061653164514E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0917306898126E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4653892813964E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545966E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3616333678086E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0863164840790E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2914049742637E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.0416242449303E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5926093446021E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.5051118418188E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.7082165233282E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8694251091007E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1065715296614E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9247033221178E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9232423570130E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0269979037802E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1665192647474E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8007131592003E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8124352346940E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4815143921838E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1938034853182E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699789946443E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042468620250E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201589330980E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169368195670E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2457076624578E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7428440751353E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750127304290E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009485146E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605935232739E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0085111425769E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164062E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8422400970459E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6625133603452E+01
@@ -2747,68 +2766,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9227604812524E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5372778511734E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0573616661583E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5177974671015E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0055214224746E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1398941755621E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2337880616025E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1842772131238E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6763253494411E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.2667877127656E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   7.6839048320028E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5428261471424E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0780179283847E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5233506267686E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0143034554910E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1498910093955E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3112555742873E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2719178436617E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6785427462724E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3073304016956E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.7118755936426E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5109617161929E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2590573683775E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807004774E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298834835E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669476551E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163594703642E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7374769787380E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9857631556324E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5131623880930E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2614941772689E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807004568E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298811512E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669448647E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163594451975E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7355445731956E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9855957798938E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.93586546730505E-02  1.32904232014372E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.15969046839452E+00
+ cg2d: Sum(rhs),rhsMax =   5.81048037411143E-02  1.35772189299144E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.17340260294000E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.51471795899749E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.56583043054020E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0692512581933E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4349678167736E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721104E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2802894452365E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9649167519611E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4532763696255E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1670607490609E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.2844497650562E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8036872236544E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9638096715906E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1518161868300E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1346893599129E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9448557987145E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0235463080457E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0409209210175E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1560997765236E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8934548485622E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1327784540819E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4579054319834E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0408994395812E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695900836394E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050606949647E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202227262679E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165052605535E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1367659944858E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7423238778527E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749378677863E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009927022E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601662152135E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0051881306123E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0695119071568E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4352421265092E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721100E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2821196062772E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9895636941463E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4584911175158E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2621209719035E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.3080932931421E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8186456634188E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0505723849939E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2124181000822E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1415858609817E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9446404137476E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0259292104907E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0508436450610E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1821186527504E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8975877507481E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1464209341079E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4733331710191E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0771658265326E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697420233150E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050226316197E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202226169865E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169372807813E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1778134593685E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7427126537622E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748637444170E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009933985E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606148768783E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0077081393541E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3322811889648E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8375684712728E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6612621647628E+01
@@ -2834,68 +2853,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1188657319977E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1313546288958E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3609744911650E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4095603319057E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2045194440164E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3321806779501E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2956762373065E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5677726263037E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1186850487196E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   9.0738489236163E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2901865223541E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1389432607016E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5254857610810E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4358913718381E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2179182395273E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.4200566587095E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.3950935446143E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5702462494843E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.1240843688464E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   9.1091094023645E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9192942792244E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.4490586374896E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807049542E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336527106E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665710523E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550425311E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2627731018025E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5011728440784E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9407421326669E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.4551336506605E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807049325E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336510427E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665671744E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550098998E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2614455506114E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5009076146937E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.09734945337948E-02  1.25802292290124E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.01715226730099E-01
+ cg2d: Sum(rhs),rhsMax =   6.90430904826673E-02  1.29319650116630E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.76394069166657E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.03907775559674E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.82457400168641E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8794535779039E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4072287016798E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134808E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2465417890215E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8831148383208E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5947008362394E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.1786119181262E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5175182957589E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1058054855736E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2238828084843E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2206254919485E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1558891340569E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1263845737976E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0317090748433E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0374047055930E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1015984626126E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9352108175458E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1305114802916E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3821320807015E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8340595242776E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9693801471938E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9094741500506E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202839555410E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164656008136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0749257258288E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7421370403561E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748371975122E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010178649E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601508027191E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0046730129369E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8825072514207E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4075384562417E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134810E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2485699330130E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9086470495925E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6008644410025E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2865044227247E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5152221862889E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1074296738773E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.3136344585597E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2912502202158E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1653729732031E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1262282635885E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0344726650475E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0485432338140E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1296409044361E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9396833465223E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1314446050671E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3979202485261E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8708646894339E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695477956133E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9116489222056E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202837954352E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169413241731E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1182449666938E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7425493656240E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9747539220671E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010187582E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606444862254E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0072349852916E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3427630615234E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8328968454997E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6600109691805E+01
@@ -2921,68 +2940,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4230715338667E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5754250486253E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3652289932205E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7336181835394E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2457072051432E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.2187502829441E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.1674217586199E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5223144668864E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.2977893773821E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0339489386570E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7073705927011E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6252784692877E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.6302284455572E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7648939319466E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2641327835794E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3147312134609E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2760103572886E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5250382160683E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.3045653371621E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0381452181614E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3150520670578E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6470059174604E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807118275E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367332823E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658705840E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518730363E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3340926688955E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6114652967107E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3438298320797E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6547539324193E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807118005E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367324589E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658662851E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518318062E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3324391833282E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6111805631451E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   8.75632178576957E-02  1.13976232941195E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.47106204337716E-01
+ cg2d: Sum(rhs),rhsMax =   8.51565955181952E-02  1.17197331045202E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.21079353132107E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.73903253850862E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.52663149918248E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7913928325839E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3831732002078E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787091E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2620642348123E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8153601991956E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7072697560531E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5482618030531E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1501243178309E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2214578559985E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4424213091712E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2340161228926E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1439171676768E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013120257133E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0191454584766E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0138569713469E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.9860005175566E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9224362203585E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4909172629448E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2591060738350E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5738799112862E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9692275456364E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9126646128593E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203439485971E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164323552420E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0215432204057E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7421214360396E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9747839031067E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010368756E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601407918330E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0045025195568E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7942544718851E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3835118220314E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787087E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2642506748513E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8414094708889E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7143204927278E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5766195783696E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1480348761495E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2232025246373E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5311888420439E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.3333248323417E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1549093168113E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7012165914170E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0222351591285E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0258155602910E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0148317754004E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9270690818353E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4921926987445E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2742350492033E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6087906450107E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694100674406E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9129086131433E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203437430433E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169491440813E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0670121315615E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7424225890537E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9746915112430E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010380920E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606750981259E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0070936076174E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3532449340820E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8282252197266E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6587597735982E+01
@@ -3008,25 +3027,25 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.8718566161637E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3055808467527E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.3519576394434E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9491225357587E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2224475945393E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9073291790505E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8151510956846E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5431888100801E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.4576318646582E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1448969998272E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9002360978858E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3592695292239E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.8453942310846E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9794746616406E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2438035773788E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0077412020167E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.9287547984109E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5461338772180E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.4657332036848E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1496656965508E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6423883779834E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8355065101862E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807182702E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389885733E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649899831E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163500444933E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1232145588311E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7854695762269E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6791416277665E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8549509887023E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807182305E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389889761E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649853956E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163499951727E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1224124657517E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7849750297558E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3055,159 +3074,159 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.633345791604370
-(PID.TID 0000.0001)         System time:  0.39606700232252479
-(PID.TID 0000.0001)     Wall clock time:   16.397298097610474
+(PID.TID 0000.0001)           User time:   15.163372689392418
+(PID.TID 0000.0001)         System time:  0.34001099457964301
+(PID.TID 0000.0001)     Wall clock time:   15.630686998367310
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.21049400628544390
-(PID.TID 0000.0001)         System time:   6.8917999276891351E-002
-(PID.TID 0000.0001)     Wall clock time:  0.29262804985046387
+(PID.TID 0000.0001)           User time:  0.13631499558687210
+(PID.TID 0000.0001)         System time:   8.4128998219966888E-002
+(PID.TID 0000.0001)     Wall clock time:  0.23538589477539062
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.422812119126320
-(PID.TID 0000.0001)         System time:  0.32712600380182266
-(PID.TID 0000.0001)     Wall clock time:   16.104622840881348
+(PID.TID 0000.0001)           User time:   15.027025014162064
+(PID.TID 0000.0001)         System time:  0.25585701316595078
+(PID.TID 0000.0001)     Wall clock time:   15.395258903503418
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.88581405580043793
-(PID.TID 0000.0001)         System time:  0.14245000481605530
-(PID.TID 0000.0001)     Wall clock time:   1.3227539062500000
+(PID.TID 0000.0001)           User time:  0.69827499985694885
+(PID.TID 0000.0001)         System time:   8.9116007089614868E-002
+(PID.TID 0000.0001)     Wall clock time:  0.83624196052551270
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.536968469619751
-(PID.TID 0000.0001)         System time:  0.18466798961162567
-(PID.TID 0000.0001)     Wall clock time:   14.781835079193115
+(PID.TID 0000.0001)           User time:   14.328725337982178
+(PID.TID 0000.0001)         System time:  0.16673500835895538
+(PID.TID 0000.0001)     Wall clock time:   14.558988094329834
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.536875367164612
-(PID.TID 0000.0001)         System time:  0.18466699123382568
-(PID.TID 0000.0001)     Wall clock time:   14.781735897064209
+(PID.TID 0000.0001)           User time:   14.328653693199158
+(PID.TID 0000.0001)         System time:  0.16672500967979431
+(PID.TID 0000.0001)     Wall clock time:   14.558902502059937
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   14.536718606948853
-(PID.TID 0000.0001)         System time:  0.18466299772262573
-(PID.TID 0000.0001)     Wall clock time:   14.781579256057739
+(PID.TID 0000.0001)           User time:   14.328501999378204
+(PID.TID 0000.0001)         System time:  0.16670501232147217
+(PID.TID 0000.0001)     Wall clock time:   14.558735847473145
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32389879226684570
-(PID.TID 0000.0001)         System time:   6.5982341766357422E-005
-(PID.TID 0000.0001)     Wall clock time:  0.32450532913208008
+(PID.TID 0000.0001)           User time:  0.29756152629852295
+(PID.TID 0000.0001)         System time:   3.2580047845840454E-003
+(PID.TID 0000.0001)     Wall clock time:  0.30087971687316895
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.29888427257537842
-(PID.TID 0000.0001)         System time:   3.8370192050933838E-003
-(PID.TID 0000.0001)     Wall clock time:  0.30322480201721191
+(PID.TID 0000.0001)           User time:  0.26358032226562500
+(PID.TID 0000.0001)         System time:   3.9429962635040283E-003
+(PID.TID 0000.0001)     Wall clock time:  0.26756215095520020
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7266035079956055E-002
-(PID.TID 0000.0001)         System time:   1.6055002808570862E-002
-(PID.TID 0000.0001)     Wall clock time:   3.8122415542602539E-002
+(PID.TID 0000.0001)           User time:   1.7867267131805420E-002
+(PID.TID 0000.0001)         System time:   4.3230056762695312E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5809288024902344E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7076373100280762E-002
-(PID.TID 0000.0001)         System time:   1.6051009297370911E-002
-(PID.TID 0000.0001)     Wall clock time:   3.7934303283691406E-002
+(PID.TID 0000.0001)           User time:   1.7695903778076172E-002
+(PID.TID 0000.0001)         System time:   4.3179988861083984E-003
+(PID.TID 0000.0001)     Wall clock time:   2.5636434555053711E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.5936317443847656E-005
-(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
-(PID.TID 0000.0001)     Wall clock time:   7.7009201049804688E-005
+(PID.TID 0000.0001)           User time:   7.7784061431884766E-005
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
+(PID.TID 0000.0001)     Wall clock time:   7.8678131103515625E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.6837918758392334
-(PID.TID 0000.0001)         System time:   2.8633996844291687E-002
-(PID.TID 0000.0001)     Wall clock time:   4.7639827728271484
+(PID.TID 0000.0001)           User time:   4.6169438958168030
+(PID.TID 0000.0001)         System time:   3.9340004324913025E-002
+(PID.TID 0000.0001)     Wall clock time:   4.7158522605895996
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
-(PID.TID 0000.0001)   Seconds in section "GMREDI_K3D      [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.2789925336837769
-(PID.TID 0000.0001)         System time:   2.8453037142753601E-002
-(PID.TID 0000.0001)     Wall clock time:   3.3586397171020508
+(PID.TID 0000.0001)   Seconds in section "GMREDI_CALC_BATES_K [GMREDI_CALC_TENSOR]":
+(PID.TID 0000.0001)           User time:   3.1666583418846130
+(PID.TID 0000.0001)         System time:   3.8543015718460083E-002
+(PID.TID 0000.0001)     Wall clock time:   3.2646999359130859
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4579827785491943
+(PID.TID 0000.0001)           User time:   2.7343857288360596
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.4581987857818604
+(PID.TID 0000.0001)     Wall clock time:   2.7344331741333008
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7936480045318604
-(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
-(PID.TID 0000.0001)     Wall clock time:   3.7941207885742188
+(PID.TID 0000.0001)           User time:   3.6270654201507568
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6271636486053467
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1279077529907227E-002
-(PID.TID 0000.0001)         System time:   7.8530013561248779E-003
-(PID.TID 0000.0001)     Wall clock time:   4.9139738082885742E-002
+(PID.TID 0000.0001)           User time:   4.7568082809448242E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.7579765319824219E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5150001049041748
-(PID.TID 0000.0001)         System time:   6.9975852966308594E-005
-(PID.TID 0000.0001)     Wall clock time:   1.5166797637939453
+(PID.TID 0000.0001)           User time:   1.4127354621887207
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.4127690792083740
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.1698646545410156E-002
-(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
-(PID.TID 0000.0001)     Wall clock time:   9.1719150543212891E-002
+(PID.TID 0000.0001)           User time:   8.9592218399047852E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.9618206024169922E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13556599617004395
+(PID.TID 0000.0001)           User time:  0.12697291374206543
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.13559007644653320
+(PID.TID 0000.0001)     Wall clock time:  0.12698888778686523
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3052206039428711E-002
-(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
-(PID.TID 0000.0001)     Wall clock time:   3.3075094223022461E-002
+(PID.TID 0000.0001)           User time:   3.2109022140502930E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.2119035720825195E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6069107055664062E-005
+(PID.TID 0000.0001)           User time:   9.5129013061523438E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9168548583984375E-005
+(PID.TID 0000.0001)     Wall clock time:   9.7036361694335938E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.34493684768676758
-(PID.TID 0000.0001)         System time:   8.0059766769409180E-003
-(PID.TID 0000.0001)     Wall clock time:  0.35296320915222168
+(PID.TID 0000.0001)           User time:  0.33742499351501465
+(PID.TID 0000.0001)         System time:   3.6139935255050659E-003
+(PID.TID 0000.0001)     Wall clock time:  0.34107494354248047
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.60165905952453613
-(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
-(PID.TID 0000.0001)     Wall clock time:  0.60179305076599121
+(PID.TID 0000.0001)           User time:  0.57836461067199707
+(PID.TID 0000.0001)         System time:   6.1988830566406250E-005
+(PID.TID 0000.0001)     Wall clock time:  0.57846260070800781
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6256980895996094E-002
-(PID.TID 0000.0001)         System time:   8.0016970634460449E-002
-(PID.TID 0000.0001)     Wall clock time:  0.16663575172424316
+(PID.TID 0000.0001)           User time:   6.0855865478515625E-002
+(PID.TID 0000.0001)         System time:   5.6000009179115295E-002
+(PID.TID 0000.0001)     Wall clock time:  0.11694526672363281
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10884213447570801
-(PID.TID 0000.0001)         System time:   4.0012001991271973E-002
-(PID.TID 0000.0001)     Wall clock time:  0.14907121658325195
+(PID.TID 0000.0001)           User time:   8.2698822021484375E-002
+(PID.TID 0000.0001)         System time:   5.6012019515037537E-002
+(PID.TID 0000.0001)     Wall clock time:  0.13879203796386719
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -3610,9 +3629,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          17436
+(PID.TID 0000.0001) //            No. barriers =          17448
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          17436
+(PID.TID 0000.0001) //     Total barrier spins =          17448
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_ocean.gm_res/results/output.txt
+++ b/global_ocean.gm_res/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67v
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68s
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Feb 23 12:14:11 EST 2021
+(PID.TID 0000.0001) // Build date:        Wed Oct 18 15:32:48 EDT 2023
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -226,16 +226,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># GM+Redi package parameters:
 (PID.TID 0000.0001) >
-(PID.TID 0000.0001) ># GM_background_K: 	G & Mc.W  diffusion coefficient
-(PID.TID 0000.0001) ># GM_maxSlope    :	max slope of isopycnals
-(PID.TID 0000.0001) ># GM_Scrit       :	transition for scaling diffusion coefficient
-(PID.TID 0000.0001) ># GM_Sd          :	half width scaling for diffusion coefficient
-(PID.TID 0000.0001) ># GM_taper_scheme:	slope clipping or one of the tapering schemes
-(PID.TID 0000.0001) ># GM_Kmin_horiz  :	horizontal diffusion minimum value
+(PID.TID 0000.0001) ># GM_background_K:: G & Mc.W  diffusion coefficient
+(PID.TID 0000.0001) ># GM_maxSlope    :: max slope of isopycnals
+(PID.TID 0000.0001) ># GM_Scrit       :: transition for scaling diffusion coefficient
+(PID.TID 0000.0001) ># GM_Sd          :: half width scaling for diffusion coefficient
+(PID.TID 0000.0001) ># GM_taper_scheme:: slope clipping or one of the tapering schemes
+(PID.TID 0000.0001) ># GM_Kmin_horiz  :: horizontal diffusion minimum value
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) >#-Option parameters (needs to "define" options in GMREDI_OPTIONS.h")
-(PID.TID 0000.0001) ># GM_isopycK     :	isopycnal diffusion coefficient (default=GM_background_K)
-(PID.TID 0000.0001) ># GM_AdvForm     :	turn on GM Advective form       (default=Skew flux form)
+(PID.TID 0000.0001) ># GM_isopycK     :: isopycnal diffusion coefficient (default=GM_background_K)
+(PID.TID 0000.0001) ># GM_AdvForm     :: turn on GM Advective form       (default=Skew flux form)
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &GM_PARM01
 (PID.TID 0000.0001) >  GM_AdvForm         = .TRUE.,
@@ -243,32 +243,32 @@
 (PID.TID 0000.0001) >  GM_background_K    = 0.0,
 (PID.TID 0000.0001) >  GM_isopycK         = 0.0,
 (PID.TID 0000.0001) >  GM_taper_scheme    = 'gkw91',
-(PID.TID 0000.0001) >  GM_maxSlope        = 1.e-2,
+(PID.TID 0000.0001) >  GM_maxSlope        = 1.E-2,
 (PID.TID 0000.0001) >  GM_Kmin_horiz      = 50.,
-(PID.TID 0000.0001) >  GM_Scrit           = 4.e-3,
-(PID.TID 0000.0001) >  GM_Sd              = 1.e-3,
-(PID.TID 0000.0001) >  GM_K3D_gamma       = 0.35,
-(PID.TID 0000.0001) >  GM_K3D_b1          = 4,
-(PID.TID 0000.0001) >  GM_K3D_EadyMaxDepth= 1000.0,
-(PID.TID 0000.0001) >  GM_K3D_EadyMinDepth= 50.0,
-(PID.TID 0000.0001) >  GM_K3D_smallK      = 0.1D+3,
-(PID.TID 0000.0001) >  GM_K3D_maxC        =-0.15,
-(PID.TID 0000.0001) >  GM_maxK3D          = 2.0D+3,
-(PID.TID 0000.0001) >  GM_K3D_Lambda      = 4.0,
-(PID.TID 0000.0001) >  GM_useK3D          = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_use_constK  = .FALSE.,
-(PID.TID 0000.0001) >  GM_K3D_ThickSheet  = .FALSE.,
-(PID.TID 0000.0001) >  GM_K3D_smooth      = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_constK      = 1000.0,
-(PID.TID 0000.0001) >  GM_K3D_Rmax        = 75.0D+03,
-(PID.TID 0000.0001) >  GM_K3D_Rmin        = 30.0D+03,
-(PID.TID 0000.0001) >  GM_K3D_minCori     = 1.52D-5,
-(PID.TID 0000.0001) >  GM_K3D_minN2       = 1.0D-7,
-(PID.TID 0000.0001) >  GM_K3D_surfMinDepth= 0.0,
-(PID.TID 0000.0001) >  GM_K3D_vecFreq     = 2592000,
+(PID.TID 0000.0001) >  GM_Scrit           = 4.E-3,
+(PID.TID 0000.0001) >  GM_Sd              = 1.E-3,
 (PID.TID 0000.0001) >  GM_InMomAsStress   = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_surfK       = .TRUE.,
-(PID.TID 0000.0001) >  GM_K3D_constRedi   = .FALSE.,
+(PID.TID 0000.0001) >  GM_useBatesK3d     = .TRUE.,
+(PID.TID 0000.0001) >  GM_Bates_gamma       = 0.35,
+(PID.TID 0000.0001) >  GM_Bates_b1          = 4.,
+(PID.TID 0000.0001) >  GM_Bates_EadyMaxDepth= 1000.0,
+(PID.TID 0000.0001) >  GM_Bates_EadyMinDepth= 50.0,
+(PID.TID 0000.0001) >  GM_Bates_smallK      = 0.1E+3,
+(PID.TID 0000.0001) >  GM_Bates_maxC        =-0.15,
+(PID.TID 0000.0001) >  GM_Bates_maxK        = 2.0E+3,
+(PID.TID 0000.0001) >  GM_Bates_Lambda      = 4.0,
+(PID.TID 0000.0001) >  GM_Bates_use_constK  = .FALSE.,
+(PID.TID 0000.0001) >  GM_Bates_ThickSheet  = .FALSE.,
+(PID.TID 0000.0001) >  GM_Bates_smooth      = .TRUE.,
+(PID.TID 0000.0001) >  GM_Bates_constK      = 1000.0,
+(PID.TID 0000.0001) >  GM_Bates_Rmax        = 75.0E+03,
+(PID.TID 0000.0001) >  GM_Bates_Rmin        = 30.0E+03,
+(PID.TID 0000.0001) >  GM_Bates_minCori     = 1.52E-5,
+(PID.TID 0000.0001) >  GM_Bates_minN2       = 1.0E-7,
+(PID.TID 0000.0001) >  GM_Bates_surfMinDepth= 0.0,
+(PID.TID 0000.0001) >  GM_Bates_vecFreq     = 2592000.,
+(PID.TID 0000.0001) >  GM_Bates_surfK       = .TRUE.,
+(PID.TID 0000.0001) >  GM_Bates_constRedi   = .FALSE.,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
@@ -782,8 +782,28 @@
 (PID.TID 0000.0001) tRef =   /* Reference temperature profile ( oC or K ) */
 (PID.TID 0000.0001)    15 @  2.000000000000000E+01              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( psu ) */
+(PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    15 @  3.500000000000000E+01              /* K =  1: 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.024871553740665E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.025131853965179E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.025500122698715E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.026019055456198E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.026730727023644E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.027654834729768E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.028788857592232E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.030129714500301E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.031673780307277E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.033416904722807E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.035354433881450E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.037481234443614E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.039791720064872E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.042279880049878E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.044939309988095E+03       /* K = 15 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -939,17 +959,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 5.000000000000000E-02
@@ -957,10 +980,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -982,7 +1005,7 @@
 (PID.TID 0000.0001) temp_EvPrRn = /* Temp. of Evap/Prec/R (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_EvPrRn = /* Salin. of Evap/Prec/R (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectAddFluid = /* option for mass source/sink of fluid (=0: off) */
@@ -991,7 +1014,7 @@
 (PID.TID 0000.0001) temp_addMass = /* Temp. of addMass array (UNSET=use local T)(oC)*/
 (PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(psu)*/
+(PID.TID 0000.0001) salt_addMass = /* Salin. of addMass array (UNSET=use local S)(g/kg)*/
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) use3Dsolver = /* use 3-D pressure solver on/off flag */
@@ -1166,8 +1189,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     500
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -1182,6 +1205,9 @@
 (PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
@@ -1517,15 +1543,6 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    16 @  1.000000000000000E+00              /* K =  1: 16 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)    15 @  0.000000000000000E+00              /* K =  1: 15 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
@@ -1897,16 +1914,19 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_ExtraDiag =   /* Tensor Extra Diag (line 1&2) non 0 */
-(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 5.000000000000000E+01
@@ -1962,10 +1982,10 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_useK3D =     /* if TRUE => use K3D for diffusivity */
+(PID.TID 0000.0001) GM_useBatesK3d = /* if TRUE => use BatesK3d for GM diffusivity */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_K3D_NModes = /* Number of modes for expansion */
+(PID.TID 0000.0001) GM_Bates_NModes = /* Number of modes for expansion */
 (PID.TID 0000.0001)                       6
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
@@ -2190,16 +2210,16 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6947689214721E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.5029438102793E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2636831152799E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9728050610312E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9003460844361E+00
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9728259248109E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9003219474105E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197724302515E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171121385692E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6153912939247E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7462125554443E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754725755996E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171727219657E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6226606639741E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7463785423825E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754631576469E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005931612E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613023234380E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0132355292408E-03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613638387481E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0137115524298E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2589080810547E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8702698516846E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6700205338390E+01
@@ -2242,51 +2262,51 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604246649079E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655729977E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162543798019E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1143966576494E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7418309150460E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1146188128188E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7418065146031E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.20105170697860E-03  2.63981021203451E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.62477520481604E-01
+ cg2d: Sum(rhs),rhsMax =   7.16813586183551E-03  2.65193213408884E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.62251143887446E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.32198249842894E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.29535289397693E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0268334580360E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152444704755E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248848E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4260892007711E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5959472152083E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1619027110699E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2710042598445E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3920346530214E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4045790768332E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6172173583263E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.3106101622334E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.1717269869998E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2475349551489E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2863969560558E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.5985151296448E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0803557023619E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6925214928717E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9075118110869E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1870746798785E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6910260392476E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722407113785E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9010309865361E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197821400033E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4168886449932E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5941297149470E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7451510425562E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755451076570E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518369E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606632352842E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0178531155343E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0313201408371E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152821062703E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248849E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4265808301676E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6033374482507E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1664573940932E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2003689709766E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3926681502034E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4071060586250E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6260695392005E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.4702328464518E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2565812532143E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2476234507487E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2882366226146E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.6111561563683E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0838722036122E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.7054720510930E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9097292626887E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1888749135362E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6952041823942E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722816655378E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9010069650174E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197821317186E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170085998133E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6080536285734E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7453385091336E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755263556884E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518366E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9607864241114E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0186906304573E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2693899536133E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8655982259115E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6687693382567E+01
@@ -2315,65 +2335,65 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0253748153421E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.1326311151428E-03
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.9022012496607E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1343383365941E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.1990675709735E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3878494822509E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9933635800783E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5068108723285E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0552064899227E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1579274348584E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1490965811346E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2155533940001E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4534769865458E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.0707207610498E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5073677929865E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.1119128307457E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1591935896751E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782213082E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2626447074182E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6230322620484E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807293106E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185659491E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642660483E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162954511392E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8463761229331E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9401861374103E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3204015592220E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6241279600299E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807293205E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185644270E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642660608E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162954556151E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8469057147529E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9402714072754E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.18796489446772E-02  2.41525635003442E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.93472727325549E-01
+ cg2d: Sum(rhs),rhsMax =   1.17830971018648E-02  2.43504719530063E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.74158928933647E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.45955549167620E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.29799732860208E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9378701473966E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5754117247190E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231135E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2998879652829E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4539601812796E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8737420890064E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4601558487825E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2236489934308E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4170570985827E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8738667558191E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0967857539844E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.4154642374793E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324026100015E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8933564455617E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3203673200983E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4712670365302E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2866766659303E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9441869106175E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6291272117083E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2894914731653E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716232297187E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9016104497880E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198511554021E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4167817971158E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5374600458134E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7441651585912E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755587447759E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004659672E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605139955819E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0159429942164E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9383638884377E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5755398538757E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231129E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3006725219829E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4661520897884E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8819984395924E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4824963420169E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2249255683459E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4223061941524E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8970017687484E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1072234500326E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5144972751232E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324755498483E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8973489920508E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3393106937557E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4780776993987E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2899001972708E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9627102466070E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6334715487077E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2999222912990E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716839455832E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9015825644587E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198511413005E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169590004215E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5576057777667E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7443915425368E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755307001402E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004659929E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606903388482E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0170705870311E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2798718261719E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8609266001383E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6675181426744E+01
@@ -2399,68 +2419,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2178105886956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5379778517573E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1347137413781E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.2925335621268E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.5060079007766E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5385567873841E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2464218096661E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6307800213699E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2391886856415E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5943027330117E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0605949308474E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1580722560780E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1494745817187E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3103044368273E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.5102648237831E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5651585597840E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2656623405813E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6553699851867E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2670077079646E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5953669602714E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.0646860629351E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1618279046175E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781986628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6676666545078E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9188158311692E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807223896E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604170387934E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640527640E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163353031084E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3809574564479E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2639819561686E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6819334208268E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.9720973430816E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807223761E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604170361375E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640520201E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163353116466E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3814008265202E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2641651292485E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.73192181660686E-02  2.22263153548671E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.41965258018700E-01
+ cg2d: Sum(rhs),rhsMax =   1.71255172881747E-02  2.24777096178169E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.26389685583531E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   8.72195886026120E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.60239701461040E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7516700506906E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5953833277408E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451985E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5713688213057E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3594947288493E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8522475792041E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7320227471201E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4738381297774E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.4971847429929E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9807683833009E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3146267325299E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.1176921415684E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6179185552363E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.4068010096486E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8591066180183E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8006078538948E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5278737063014E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.1059621950294E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9950068862130E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7558791827647E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9710632503336E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9022244197635E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199360846371E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4167093056771E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4650222407425E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435530881079E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754920512899E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005961994E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9604081912156E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0132697411275E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7595040433693E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5955625143174E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451983E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5723845201053E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3754605817638E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8673071741663E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7714050814428E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4753443364421E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.5101794348536E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0215473437167E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3336425282422E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.0976990335269E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6179613730282E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.4080034639009E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8884021844702E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8124870852026E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5333789675501E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.0823877662633E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0011931367908E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7737123713159E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9711432913690E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9021928717384E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199360659886E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169422885594E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4911410263870E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7437965862062E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754547450631E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005962772E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606340813926E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0146767494622E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2903536987305E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8562549743652E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6662669470921E+01
@@ -2486,68 +2506,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1440480618348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.5389519193385E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3433914989091E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.7766934379197E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8125590149216E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5771373909772E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8260609532365E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.5914224419346E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9719624945044E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5977530453139E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.4285700442680E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.5655576591506E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3641287258070E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.7961747226356E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8306155893304E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5732530507357E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8655926959051E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.6361441770498E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9734108582736E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.6073371772804E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.4346992717026E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0892901270117E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2322392802152E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807135569E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604186087813E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649853576E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163586594108E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0503044248888E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2081278264924E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1075556450475E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2671366043701E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807135630E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604186020231E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649839003E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163586344066E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0507707683574E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2075055330181E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.39759924927766E-02  2.01930904825837E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.32014742921132E-01
+ cg2d: Sum(rhs),rhsMax =   2.36375476596636E-02  2.04822172243693E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.14677497395544E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.58521672385087E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.46447899162277E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8766307347237E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5429796423387E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911410E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5646041049067E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2723046423358E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.8817756647726E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7516912706741E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8598751045100E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.6934219516807E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8596665674487E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4156380758950E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.3746428784328E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6781609532747E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.6679489189220E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0896788141996E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0311055332455E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7152068885952E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.2561188739872E-11
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2667861834644E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0626019789193E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9706188006461E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028523435558E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200186253277E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4166508433798E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3867234888461E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433471292910E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753896021032E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007473181E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9602895770436E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0100018054631E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8777975775856E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5432238150061E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911403E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5658255355912E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2913269741464E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.9050240821152E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8305572726688E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8611285794193E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.7115415734053E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9282734997072E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4412151188211E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4030270589650E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6782235904036E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.6679514018878E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.1279085363692E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0481371190015E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7265712867491E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.0655719037675E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2763313114233E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0876227389108E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9707175597629E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028192113379E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200186036514E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169388770782E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4183337567373E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7436632479703E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753429994380E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007475513E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605774871015E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0118413697100E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3008355712891E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8515833485921E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6650157515098E+01
@@ -2573,68 +2593,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8129818781863E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6222938138638E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.5705626759539E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.2657838292442E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8213427600838E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8113834923805E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.7062033171121E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9623234841724E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3837054743557E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8703321124828E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8310403129941E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6336192939406E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.6052316591348E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.2575315570183E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8268573511337E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8609281103712E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.7622519790854E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9640631345864E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.4013478953991E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8797305805115E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.3362440139835E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.3274663538121E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807069682E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604218355944E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661337472E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163668735828E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0818321635243E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0207007922397E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2039177169536E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2285733120516E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807069385E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604218272499E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661319056E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163666305984E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0854759375217E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0228297549658E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.24731638324971E-02  1.80008613261865E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.45991003986194E-01
+ cg2d: Sum(rhs),rhsMax =   3.19253387837991E-02  1.83097483453495E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.26115996708907E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   9.79500758238396E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.61790666523831E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0322888547748E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4933148746564E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609397E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4660503096510E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1811801941737E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0873295321938E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.5211989798539E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8115640639145E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.9492057488732E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5441106669745E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3780746870206E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0638264999546E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.5696040635912E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531382386139E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0001953506500E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2223149991387E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8154063334264E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6327060397244E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4425433336523E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2156986767515E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9702754301253E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035192610541E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200939135040E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165995634356E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3078277930084E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433557089934E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9752497723803E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008669517E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9602181216460E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0077504678916E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0324494695148E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4936645375733E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609398E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4674921472835E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2025090841702E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0905621736217E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.1129114795118E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8118372371677E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.9750899897844E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.6103149899784E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.4152548753138E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0626286821971E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.8756490759922E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531021445634E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0043702033452E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2434239832782E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8374626452105E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6468815460120E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4534837388408E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2433662253162E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9703921752775E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9034895357452E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200938776482E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169407352750E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3436424633386E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7437078383823E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751939694213E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008673623E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605675424207E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0098653460363E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3113174438477E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8469117228190E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6637645559275E+01
@@ -2660,68 +2680,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9965230081132E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.2661153146501E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7708339313014E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4451756093314E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9676665912646E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0668442721539E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.5586600763376E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.5517208429635E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8232149956272E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3148762425676E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.3878706558569E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.2578615500354E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7767671000876E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4862584634488E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9963564850570E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0645171043579E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.6308481296447E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.6333871606481E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8252322398953E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.3428468022032E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.4042149563262E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1072519953079E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.0975474710438E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807029370E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604258285896E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668353707E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163653866742E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0974547715485E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1887783569026E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1197993562371E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.1012221377744E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807028997E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604258193298E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668329957E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163650224591E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0946749277173E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1891815411545E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.35517550753397E-02  1.57543364885390E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.55403301336019E-01
+ cg2d: Sum(rhs),rhsMax =   4.27065817461170E-02  1.60661185248258E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.36174558208514E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   9.75868995006715E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.63795532728593E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0917845119341E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4562388543415E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545961E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3582120686418E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0853780497341E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2742174785767E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9053560823525E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.6028531419524E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2616984171993E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0248450892780E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0476432835184E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1288828659619E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9243540430830E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0332767076131E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0555909997916E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3457395799974E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8990202451859E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8183609593035E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5235244148221E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2221378572609E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699949761774E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042457536336E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201626507336E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165515574418E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2297678415694E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7432974286627E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751194441609E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009435849E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601746136468E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0060127980704E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0919912970085E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4566490977245E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545966E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3598334344746E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1086410903730E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2784112262049E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.0025292200396E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.6006768221756E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2850819675800E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1144309506199E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0957497952758E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1340642051417E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9240676211630E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0341594333130E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0628200193222E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3717409599198E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9232509014696E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8235214263355E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5374976324220E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2546072562475E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701289071333E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9043078564365E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201625887070E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169429389181E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2695001839694E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7436888033282E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750544512943E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009441156E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605768017097E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0084141219138E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164062E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8422400970459E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6625133603452E+01
@@ -2747,68 +2767,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9227604812524E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9684041930018E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9763233007328E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8331052900753E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0586724081140E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1932383575192E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0452549528689E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.1023311277946E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6738496353302E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.2883523099455E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   7.8988960342702E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9970994079050E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9838811636437E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9102796657307E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.1138714440517E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2033048685588E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.1347790984516E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.2036105018281E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6760733438446E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3283684434953E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.9246619811438E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0215495476827E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.4638979294162E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807037561E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604299350296E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669417794E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163608746225E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7605489775262E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9843234228884E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0314577670180E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.4414584997349E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807037086E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604299344363E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669388286E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163606122832E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7579631892295E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9810300937057E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.80565565447977E-02  1.35885021128348E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.77059921565014E-01
+ cg2d: Sum(rhs),rhsMax =   5.68035912187068E-02  1.38882353095458E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.55551901906148E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.31143673468040E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.17206777111523E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0696389413342E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4250003337957E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721103E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2783539194405E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9919445956779E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4424962478010E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1563112500262E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4570732402987E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5880936974407E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.4104687424088E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4484126810460E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1678246436671E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9441242276415E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0727435716817E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0860904365595E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3935760444528E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9235235864486E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1562692250682E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5205589881691E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1081207281432E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697556873107E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050355926985E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202270793713E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4165070798884E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1573434437644E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7432118086740E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750122052199E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009863289E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601471367702E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0049484326799E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0698881275461E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4256004230624E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721101E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2801319046977E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0165717637167E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4476605055902E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1809762001809E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4162990328284E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.6045761033905E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5163751106815E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5073330618725E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1742356529818E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9439814944159E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0743268991235E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0941908543665E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4230465194419E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9282085885903E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1732692398410E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5357209508242E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1422241068323E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699059922938E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9052684513020E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202269780947E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169464846448E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2001849957637E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7436457076132E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749380778547E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009870112E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605994943595E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0074700064905E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3322811889648E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8375684712728E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6612621647628E+01
@@ -2834,68 +2854,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0596105705693E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1232918666922E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2060121428374E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.5684064304752E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2688959860902E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2907302481127E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3801486788347E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5651575260764E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1211853198763E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   9.3469210630878E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.1148198161772E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1330367275524E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2861916472806E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7085152612073E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2813515489864E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3935706984555E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4964943287993E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5675597365172E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.1264869994580E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   9.3765528308148E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3391079511633E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7832431286262E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807082224E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336695383E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665622298E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163561336646E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2797442144711E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4933622525854E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3655340872789E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.7699647423267E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807081758E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336757836E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665590663E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163558699692E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2765007650101E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4892213138392E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.62383743773920E-02  1.17114620781291E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.84765613765487E-01
+ cg2d: Sum(rhs),rhsMax =   7.44606920469408E-02  1.19910627456465E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.63695102931408E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.50859462312395E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.35886315559167E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8854257556393E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3964404488771E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8882453060821E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3974832106352E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134807E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2446130453753E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9092919086457E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5868226074399E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4052707831574E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.4969513197222E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0878556092207E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7362960912140E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5953642889253E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1856430954683E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1260220072253E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0857889409479E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0885454657307E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3545543659662E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9708566397556E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1326119155874E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4474856500272E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9018620201283E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695585563507E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9132355269702E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202890358025E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164681188826E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0917276086988E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7431143002485E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749442744153E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010094946E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601303009336E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0039950069044E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2464932920513E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9348778802850E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5929158984262E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4203259460712E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5026020653757E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0889924373414E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.8398813246706E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6640436331645E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1950051414461E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1257800168224E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0884578473785E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0976414677336E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3870306681949E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9759753131057E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1339567283412E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4627632179762E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9347053361934E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697244229024E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9134806315828E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202888962280E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169527716289E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1374762102829E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435922390202E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748610422466E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010103789E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606292793431E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0066987433836E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3427630615234E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8328968454997E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6600109691805E+01
@@ -2921,68 +2941,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.5696244402707E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1965400930724E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4259510374108E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9826168330028E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3035143802039E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.2588619359864E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.3441891565531E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5197251865899E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.3006362308662E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0674674206112E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7097592404347E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2085977271024E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.5180580102994E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.0681374304137E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3217033340471E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3740296182766E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4744834959621E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5222493494952E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.3072406078877E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0711975802286E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7098226348240E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.1347689031220E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807149695E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367360970E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658603570E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163527785477E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3456920630926E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5991497208974E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7173465150976E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.1345418474685E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807149206E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367477968E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658565640E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163526291112E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3416135538007E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5928933649420E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   9.04844671184000E-02  1.10296562862768E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.85033306637990E-01
+ cg2d: Sum(rhs),rhsMax =   8.81727137592683E-02  1.13188369622790E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.64190393516074E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.71434903854611E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.57869323459449E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8001942960472E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3720030608775E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787089E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2602190562436E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8411634091154E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7028921716190E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5782853235867E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1269829507820E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2092050802129E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0292595044714E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.7635129721526E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1795668451818E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7013576728470E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0765090778227E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0685938097793E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2474512591898E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9622128569589E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4953168280030E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3241089984674E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6412908861112E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694172359614E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9134999683955E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203497131851E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4164353918851E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0346596618404E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7430083734621E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749208736739E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010263524E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9601188466241E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0034567067232E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8031936148742E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3730376320144E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787083E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2621190942498E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8673921310992E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7098543242898E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5914683846032E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1337975926248E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2099980137782E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.1537575005792E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8760905477631E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1904825923563E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7010590612980E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0802864818132E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0832445919536E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2814021180197E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9675732453851E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4952934212153E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3402069350255E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6752786983317E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695978474112E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9137195573120E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203495174393E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169626478263E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0826161595515E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435310590324E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748285631237E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010274321E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606610367291E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0062289394427E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3532449340820E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8282252197266E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6587597735982E+01
@@ -3008,25 +3028,25 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.9840964719963E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2300451571834E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.3974830822712E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.9654229934512E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2917092004106E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.0111694679662E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.0640457845129E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5407043635095E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.4608149803360E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1853294553277E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0696329458291E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2476525729429E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.5006327676367E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.0403091478082E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3129167464953E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.1342256186246E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.2032674671987E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5432626890828E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.4686611414821E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1898604121231E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2441590782420E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.3848072432050E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209145E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389536174E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649773334E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163505237410E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1325577127935E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7730807667534E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2847439529282E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   5.4657527121821E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807208904E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389706260E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649735110E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163504623863E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1285441952209E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7673468452168E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -3055,159 +3075,159 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.863589286804199
-(PID.TID 0000.0001)         System time:  0.27817099029198289
-(PID.TID 0000.0001)     Wall clock time:   16.149056911468506
+(PID.TID 0000.0001)           User time:   16.435054422821850
+(PID.TID 0000.0001)         System time:  0.28051999281160533
+(PID.TID 0000.0001)     Wall clock time:   16.725636959075928
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.13060399889945984
-(PID.TID 0000.0001)         System time:   4.9622998572885990E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18166899681091309
+(PID.TID 0000.0001)           User time:  0.17052999697625637
+(PID.TID 0000.0001)         System time:   7.9357999376952648E-002
+(PID.TID 0000.0001)     Wall clock time:  0.25843501091003418
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.732969656586647
-(PID.TID 0000.0001)         System time:  0.22851799055933952
-(PID.TID 0000.0001)     Wall clock time:   15.967355012893677
+(PID.TID 0000.0001)           User time:   16.264468699693680
+(PID.TID 0000.0001)         System time:  0.20113798975944519
+(PID.TID 0000.0001)     Wall clock time:   16.467136859893799
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.73705402016639709
-(PID.TID 0000.0001)         System time:   7.2541005909442902E-002
-(PID.TID 0000.0001)     Wall clock time:  0.81026315689086914
+(PID.TID 0000.0001)           User time:  0.78636597096920013
+(PID.TID 0000.0001)         System time:   6.4582005143165588E-002
+(PID.TID 0000.0001)     Wall clock time:  0.85104417800903320
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.995883524417877
-(PID.TID 0000.0001)         System time:  0.15597300231456757
-(PID.TID 0000.0001)     Wall clock time:   15.157057046890259
+(PID.TID 0000.0001)           User time:   15.478080093860626
+(PID.TID 0000.0001)         System time:  0.13655199110507965
+(PID.TID 0000.0001)     Wall clock time:   15.616068124771118
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.995788395404816
-(PID.TID 0000.0001)         System time:  0.15597200393676758
-(PID.TID 0000.0001)     Wall clock time:   15.156961441040039
+(PID.TID 0000.0001)           User time:   15.478000640869141
+(PID.TID 0000.0001)         System time:  0.13655099272727966
+(PID.TID 0000.0001)     Wall clock time:   15.615987539291382
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   14.995633304119110
-(PID.TID 0000.0001)         System time:  0.15597100555896759
-(PID.TID 0000.0001)     Wall clock time:   15.156803131103516
+(PID.TID 0000.0001)           User time:   15.477854430675507
+(PID.TID 0000.0001)         System time:  0.13654999434947968
+(PID.TID 0000.0001)     Wall clock time:   15.615839242935181
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32676905393600464
-(PID.TID 0000.0001)         System time:   1.3992190361022949E-005
-(PID.TID 0000.0001)     Wall clock time:  0.32682681083679199
+(PID.TID 0000.0001)           User time:  0.31277477741241455
+(PID.TID 0000.0001)         System time:   6.9990754127502441E-005
+(PID.TID 0000.0001)     Wall clock time:  0.31289553642272949
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.29777890443801880
-(PID.TID 0000.0001)         System time:   2.9951333999633789E-006
-(PID.TID 0000.0001)     Wall clock time:  0.29783368110656738
+(PID.TID 0000.0001)           User time:  0.28230375051498413
+(PID.TID 0000.0001)         System time:   1.7401576042175293E-004
+(PID.TID 0000.0001)     Wall clock time:  0.28251647949218750
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.8170893192291260E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8172264099121094E-002
+(PID.TID 0000.0001)           User time:   1.7694711685180664E-002
+(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
+(PID.TID 0000.0001)     Wall clock time:   1.7698526382446289E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7986893653869629E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8008708953857422E-002
+(PID.TID 0000.0001)           User time:   1.7499208450317383E-002
+(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
+(PID.TID 0000.0001)     Wall clock time:   1.7509937286376953E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6903572082519531E-005
+(PID.TID 0000.0001)           User time:   8.0704689025878906E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.3446502685546875E-005
+(PID.TID 0000.0001)     Wall clock time:   8.0108642578125000E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8164287209510803
-(PID.TID 0000.0001)         System time:   3.5972997546195984E-002
-(PID.TID 0000.0001)     Wall clock time:   4.8544754981994629
+(PID.TID 0000.0001)           User time:   4.8851264715194702
+(PID.TID 0000.0001)         System time:   6.0229018330574036E-002
+(PID.TID 0000.0001)     Wall clock time:   4.9459810256958008
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
-(PID.TID 0000.0001)   Seconds in section "GMREDI_K3D      [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.2949277162551880
-(PID.TID 0000.0001)         System time:   3.5783991217613220E-002
-(PID.TID 0000.0001)     Wall clock time:   3.3321151733398438
+(PID.TID 0000.0001)   Seconds in section "GMREDI_CALC_BATES_K [GMREDI_CALC_TENSOR]":
+(PID.TID 0000.0001)           User time:   3.2552852630615234
+(PID.TID 0000.0001)         System time:   5.1818996667861938E-002
+(PID.TID 0000.0001)     Wall clock time:   3.3077001571655273
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5113046169281006
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.5128266811370850
+(PID.TID 0000.0001)           User time:   2.8601326942443848
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   2.8606145381927490
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.0143959522247314
-(PID.TID 0000.0001)         System time:   3.0100345611572266E-006
-(PID.TID 0000.0001)     Wall clock time:   4.0156540870666504
+(PID.TID 0000.0001)           User time:   4.1093819141387939
+(PID.TID 0000.0001)         System time:   8.0019235610961914E-006
+(PID.TID 0000.0001)     Wall clock time:   4.1096191406250000
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0795078277587891E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.0812482833862305E-002
+(PID.TID 0000.0001)           User time:   5.0323963165283203E-002
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   5.0334930419921875E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5320127010345459
-(PID.TID 0000.0001)         System time:   8.0019235610961914E-006
-(PID.TID 0000.0001)     Wall clock time:   1.5320441722869873
+(PID.TID 0000.0001)           User time:   1.5172023773193359
+(PID.TID 0000.0001)         System time:   2.1010637283325195E-005
+(PID.TID 0000.0001)     Wall clock time:   1.5172586441040039
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.2309951782226562E-002
-(PID.TID 0000.0001)         System time:   9.9986791610717773E-006
-(PID.TID 0000.0001)     Wall clock time:   9.2325925827026367E-002
+(PID.TID 0000.0001)           User time:   9.8677635192871094E-002
+(PID.TID 0000.0001)         System time:   5.8993697166442871E-005
+(PID.TID 0000.0001)     Wall clock time:   9.8749160766601562E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13371205329895020
-(PID.TID 0000.0001)         System time:   1.0997056961059570E-005
-(PID.TID 0000.0001)     Wall clock time:  0.13374805450439453
+(PID.TID 0000.0001)           User time:  0.13827443122863770
+(PID.TID 0000.0001)         System time:   4.9918889999389648E-006
+(PID.TID 0000.0001)     Wall clock time:  0.13830232620239258
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3499717712402344E-002
+(PID.TID 0000.0001)           User time:   3.6375999450683594E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.3517599105834961E-002
+(PID.TID 0000.0001)     Wall clock time:   3.6392688751220703E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.7499618530273438E-005
+(PID.TID 0000.0001)           User time:   8.0585479736328125E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.7976455688476562E-005
+(PID.TID 0000.0001)     Wall clock time:   8.1062316894531250E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.35375142097473145
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:  0.35378384590148926
+(PID.TID 0000.0001)           User time:  0.36056566238403320
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:  0.36061048507690430
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.65095376968383789
+(PID.TID 0000.0001)           User time:  0.61893606185913086
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.65101933479309082
+(PID.TID 0000.0001)     Wall clock time:  0.61897635459899902
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5558433532714844E-002
-(PID.TID 0000.0001)         System time:   5.9961006045341492E-002
-(PID.TID 0000.0001)     Wall clock time:  0.12568664550781250
+(PID.TID 0000.0001)           User time:   8.6414813995361328E-002
+(PID.TID 0000.0001)         System time:   2.7963995933532715E-002
+(PID.TID 0000.0001)     Wall clock time:  0.11447405815124512
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.5203161239624023E-002
-(PID.TID 0000.0001)         System time:   5.9973001480102539E-002
-(PID.TID 0000.0001)     Wall clock time:  0.15536785125732422
+(PID.TID 0000.0001)           User time:  0.10068392753601074
+(PID.TID 0000.0001)         System time:   4.7992005944252014E-002
+(PID.TID 0000.0001)     Wall clock time:  0.14872312545776367
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -3610,9 +3630,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          17434
+(PID.TID 0000.0001) //            No. barriers =          17446
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          17434
+(PID.TID 0000.0001) //     Total barrier spins =          17446
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,8 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #769: after fixing bug in GM_ExtraDiag setting, update ref. output 
+    of the 2 exp. that use Bates-K3d (previous wrong results as ExtraDiag=F).
   - post PR #768: change #include "ctrl_dummy.h" to "CTRL_DUMMY.h" in 1 file.
   - post PR #767: change #include "ctrl.h" to "CTRL.h" in 1 customized src file.
 


### PR DESCRIPTION
After fixing bug in `GM_ExtraDiag` setting (see https://github.com/MITgcm/MITgcm/pull/769), 
update reference output of the 2 experiments that use Bates-K3d 
(previous results were wrong with `GM_ExtraDiag`=F).