### PR TITLE
Remove CPP option EXACT_CONSERV

### DIFF
--- a/atm_gray_ll/code/CPP_OPTIONS.h
+++ b/atm_gray_ll/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/atm_strato/code/CPP_OPTIONS.h
+++ b/atm_strato/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/cpl_aqua_cs24/code_atm/CPP_OPTIONS.h
+++ b/cpl_aqua_cs24/code_atm/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/cpl_aqua_cs24/code_ocn/CPP_OPTIONS.h
+++ b/cpl_aqua_cs24/code_ocn/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/cpl_gray+ocn/code_atm/CPP_OPTIONS.h
+++ b/cpl_gray+ocn/code_atm/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/cpl_gray+ocn/code_ocn/CPP_OPTIONS.h
+++ b/cpl_gray+ocn/code_ocn/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/cpl_gray+swamp+ocn/code_atm/CPP_OPTIONS.h
+++ b/cpl_gray+swamp+ocn/code_atm/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/cpl_gray+swamp+ocn/code_ocn/CPP_OPTIONS.h
+++ b/cpl_gray+swamp+ocn/code_ocn/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/global_oce_cs32/code/CPP_OPTIONS.h
+++ b/global_oce_cs32/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/global_oce_llc90/code/CPP_OPTIONS.h
+++ b/global_oce_llc90/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/global_ocean.gm_k3d/code/CPP_OPTIONS.h
+++ b/global_ocean.gm_k3d/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/global_ocean.gm_res/code/CPP_OPTIONS.h
+++ b/global_ocean.gm_res/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/offline_cheapaml/code/CPP_OPTIONS.h
+++ b/offline_cheapaml/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #undef NONLIN_FRSURF

--- a/shelfice_remeshing/code/CPP_OPTIONS.h
+++ b/shelfice_remeshing/code/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/shelfice_remeshing/code_vrm/CPP_OPTIONS.h
+++ b/shelfice_remeshing/code_vrm/CPP_OPTIONS.h
@@ -104,10 +104,6 @@ C o Include/exclude Quasi-Hydrostatic Stagger Time-step AdamsBashforth code
 
 C-- Model formulation options:
 
-C o Allow/exclude "Exact Convervation" of fluid in Free-Surface formulation
-C   that ensures that d/dt(eta) is exactly equal to - Div.Transport
-#define EXACT_CONSERV
-
 C o Allow the use of Non-Linear Free-Surface formulation
 C   this implies that grid-cell thickness (hFactors) varies with time
 #define NONLIN_FRSURF

--- a/update_history
+++ b/update_history
@@ -1,6 +1,8 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - remove CPP option EXACT_CONSERV from all */code*/CPP_OPTIONS.h
+
 checkpoint69g (2025/09/12) synchronised with main MITgcm code.
   - remove unsupported old setups (global1x1_tot, global2x2_tot, lab_sea,
     natl_box_adjoint);


### PR DESCRIPTION
This PR remove the setting (`#define EXACT_CONSERV`) from all test experiment `code*/CPP_OPTIONS.h`, as done in main MITgcm repos. https://github.com/MITgcm/MITgcm/pull/930 for all verification experiments (see issue https://github.com/MITgcm/MITgcm/issues/924 ).
Note: should not be merged before PR 930.