### PR TITLE
Updates following addition of seaice metric-terms (MITgcm pr976).

### DIFF
--- a/global_oce_cs32/code/CTRL_OPTIONS.h
+++ b/global_oce_cs32/code/CTRL_OPTIONS.h
@@ -67,20 +67,27 @@ C       >>> Generic Control.
 C       >>> Open boundaries
 #ifdef ALLOW_OBCS
 C    Control of Open-Boundaries is meaningless without compiling pkg/obcs
-C    Note: Make sure that corresponding OBCS N/S/W/E Option is defined
+C    Note: Make sure that corresponding OBCS N/S/E/W Option is defined
 # define ALLOW_OBCSN_CONTROL
 # define ALLOW_OBCSS_CONTROL
-# define ALLOW_OBCSW_CONTROL
 # define ALLOW_OBCSE_CONTROL
-# undef ALLOW_OBCS_CONTROL_MODES
+# define ALLOW_OBCSW_CONTROL
 #endif /* ALLOW_OBCS */
 
 C  o Set ALLOW_OBCS_CONTROL (Do not edit/modify):
 #if (defined (ALLOW_OBCSN_CONTROL) || \
      defined (ALLOW_OBCSS_CONTROL) || \
-     defined (ALLOW_OBCSW_CONTROL) || \
-     defined (ALLOW_OBCSE_CONTROL))
+     defined (ALLOW_OBCSE_CONTROL) || \
+     defined (ALLOW_OBCSW_CONTROL))
 # define ALLOW_OBCS_CONTROL
+#endif
+
+#ifdef ALLOW_OBCS_CONTROL
+C     Untested code:
+# undef ALLOW_OBCS_CONTROL_MODES
+C     Enable code for 2D (horizontal,vertical) weights for obcs;
+C     this code is incomplete (fields are defined but not used anywhere)
+# undef ALLOW_OBCS_WEIGHTS2D
 #endif
 
 C  o Impose bounds on controls

--- a/global_oce_cs32/code/EXF_OPTIONS.h
+++ b/global_oce_cs32/code/EXF_OPTIONS.h
@@ -1,3 +1,8 @@
+#ifndef EXF_OPTIONS_H
+#define EXF_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
 CBOP
 C !ROUTINE: EXF_OPTIONS.h
 C !INTERFACE:
@@ -10,11 +15,6 @@ C | Control which optional features to compile in this package code.
 C *==================================================================*
 CEOP
 
-#ifndef EXF_OPTIONS_H
-#define EXF_OPTIONS_H
-#include "PACKAGES_CONFIG.h"
-#include "CPP_OPTIONS.h"
-
 #ifdef ALLOW_EXF
 #ifdef ECCO_CPPOPTIONS_H
 
@@ -26,6 +26,7 @@ C   are specific to this package are assumed to be set in ECCO_CPPOPTIONS.h
 
 C-- Package-specific Options & Macros go here
 
+C   --------------------
 C   pkg/exf CPP options:
 C   (see also table below on how to combine options)
 
@@ -90,16 +91,19 @@ C       If defined, atmospheric pressure can be read-in from files.
 C   WARNING: this flag is set (define/undef) in CPP_OPTIONS.h
 C            and cannot be changed here (in EXF_OPTIONS.h)
 C
+C   >>> EXF_ALLOW_TIDES <<<
+C       If defined, 2-D tidal geopotential can be read-in from files
+C
 C   >>> EXF_SEAICE_FRACTION <<<
 C       If defined, seaice fraction can be read-in from files (areaMaskFile)
 C
 C   >>> ALLOW_CLIMSST_RELAXATION <<<
-C       Allow the relaxation to a monthly climatology of sea surface
-C       temperature, e.g. the Reynolds climatology.
+C       Allow the relaxation of surface level temperature to SST (climatology),
+C       e.g. the Reynolds climatology.
 C
 C   >>> ALLOW_CLIMSSS_RELAXATION <<<
-C       Allow the relaxation to a monthly climatology of sea surface
-C       salinity, e.g. the Levitus climatology.
+C       Allow the relaxation of surface level salinity to SSS (climatology),
+C       e.g. the Levitus climatology.
 C
 C   >>> USE_EXF_INTERPOLATION <<<
 C       Allows to provide input field on arbitrary Lat-Lon input grid
@@ -168,14 +172,17 @@ C-  Bulk formulae related flags.
 #ifdef ALLOW_ATM_TEMP
 C Note: To use ALLOW_BULKFORMULAE or EXF_READ_EVAP, needs #define ALLOW_ATM_TEMP
 # define ALLOW_BULKFORMULAE
+C use Large and Yeager (2004) modification to Large and Pond bulk formulae
 # define ALLOW_BULK_LARGEYEAGER04
+C use drag formulation of Large and Yeager (2009), Climate Dyn., 33, pp 341-364
+# undef  ALLOW_DRAG_LARGEYEAGER09
 # undef  EXF_READ_EVAP
 # ifndef ALLOW_BULKFORMULAE
 C  Note: To use ALLOW_READ_TURBFLUXES, ALLOW_ATM_TEMP needs to
 C        be defined but ALLOW_BULKFORMULAE needs to be undef
 #  define ALLOW_READ_TURBFLUXES
 # endif
-#endif
+#endif /* ALLOW_ATM_TEMP */
 
 C-  Other forcing fields
 #define ALLOW_RUNOFF
@@ -191,7 +198,6 @@ C       and ATMOSPHERIC_LOADING need to be defined
 C-  Zenith Angle/Albedo related flags.
 #ifdef ALLOW_DOWNWARD_RADIATION
 # define ALLOW_ZENITHANGLE
-# undef ALLOW_ZENITHANGLE_BOUNDSWDOWN
 #endif
 
 C-  Use ocean_emissivity*lwdown in lwFlux. This flag should be defined
@@ -200,9 +206,12 @@ C   unless to reproduce old results (obtained with inconsistent old code)
 # define EXF_LWDOWN_WITH_EMISSIVITY
 #endif
 
-C-  Relaxation to monthly climatologies.
+C-  Surface level relaxation to prescribed fields (e.g., climatologies)
 #define ALLOW_CLIMSST_RELAXATION
 #define ALLOW_CLIMSSS_RELAXATION
+
+C-  Allows to read-in (2-d) tidal geopotential forcing
+#undef EXF_ALLOW_TIDES
 
 C-  Allows to read-in seaice fraction from files (areaMaskFile)
 #undef EXF_SEAICE_FRACTION
@@ -218,9 +227,13 @@ C   (no pole symmetry, single vector-comp interp, reset to 0 zonal-comp @ N.pole
 #undef EXF_USE_OLD_INTERP_POLE
 
 #define EXF_INTERP_USE_DYNALLOC
-#if ( defined (EXF_INTERP_USE_DYNALLOC) && defined (USING_THREADS) )
+#if ( defined USE_EXF_INTERPOLATION && defined EXF_INTERP_USE_DYNALLOC && defined USING_THREADS )
 # define EXF_IREAD_USE_GLOBAL_POINTER
 #endif
+
+C-  Not recommended (not tested nor maintained) and un-documented Options:
+#undef ALLOW_BULK_OFFLINE
+#undef ALLOW_CLIMSTRESS_RELAXATION
 
 #endif /* ndef ECCO_CPPOPTIONS_H */
 #endif /* ALLOW_EXF */

--- a/global_oce_cs32/code/GMREDI_OPTIONS.h
+++ b/global_oce_cs32/code/GMREDI_OPTIONS.h
@@ -1,10 +1,19 @@
-C CPP options file for GM/Redi package
-C Use this file for selecting options within the GM/Redi package
-
 #ifndef GMREDI_OPTIONS_H
 #define GMREDI_OPTIONS_H
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
+
+CBOP
+C !ROUTINE: GMREDI_OPTIONS.h
+C !INTERFACE:
+C #include "GMREDI_OPTIONS.h"
+
+C !DESCRIPTION:
+C *==================================================================*
+C | CPP options file for GM/Redi package:
+C | Control which optional features to compile in this package code.
+C *==================================================================*
+CEOP
 
 #ifdef ALLOW_GMREDI
 C     Package-specific Options & Macros go here
@@ -25,9 +34,9 @@ C Note: need these to be defined for use as control (pkg/ctrl) parameters
 
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
-C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi
-C (which depends on tapering scheme)
-#undef OLD_VISBECK_CALC
+
+C This allows to use the GEOMETRIC formulation to compute K_GM
+#undef GM_GEOM_VARIABLE_K
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
@@ -52,9 +61,9 @@ C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 C Allow QG Leith variable viscosity to be added to GMRedi coefficient
 #undef ALLOW_GM_LEITH_QG
 
+C Related to Adjoint-code:
+#undef GM_AUTODIFF_EXCESSIVE_STORE
+#undef GMREDI_MASK_SLOPES
+
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */
-
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***

--- a/global_oce_cs32/code/SEAICE_OPTIONS.h
+++ b/global_oce_cs32/code/SEAICE_OPTIONS.h
@@ -85,7 +85,7 @@ C     the thermodynamics component of the code. Note that, if needed,
 C     sea-ice dynamics can be turned off at runtime (SEAICEuseDYNAMICS=F).
 
 C--   Historically, the seaice model was discretized on a B-Grid. This
-C     discretization should still work but it is not longer actively
+C     discretization should still work but it is no longer actively
 C     tested and supported. Define this flag to compile it. It cannot be
 C     defined together with SEAICE_CGRID
 #undef SEAICE_BGRID_DYNAMICS
@@ -99,6 +99,14 @@ C--   Options for the C-grid version only:
 
 C     enable advection of sea ice momentum
 # undef SEAICE_ALLOW_MOM_ADVECTION
+
+C     Use parameterisation of grounding ice for a better representation
+C     of fastice in shallow seas
+# undef SEAICE_ALLOW_BOTTOMDRAG
+
+C     Use parameterisation of explicit lateral drag for a better
+C     representation of fastice along coast lines and islands
+# undef SEAICE_ALLOW_SIDEDRAG
 
 C     enable JFNK code by defining the following flag
 # undef SEAICE_ALLOW_JFNK
@@ -179,9 +187,10 @@ C     This flag is also required for an actual adjoint of seaice_lsr;
 C     increases memory requirements a lot.
 # undef SEAICE_LSR_ADJOINT_ITER
 
-C     Use parameterisation of grounding ice for a better representation
-C     of fastice in shallow seas
-# undef SEAICE_ALLOW_BOTTOMDRAG
+C     Allow using the flexible LSR solver, where the number of non-linear
+C     iteration depends on the residual. Good for when a non-linear
+C     convergence criterion must be satified
+# undef SEAICE_ALLOW_LSR_FLEX
 
 #endif /* SEAICE_CGRID */
 

--- a/global_oce_cs32/input/data.seaice
+++ b/global_oce_cs32/input/data.seaice
@@ -1,6 +1,6 @@
 # SEAICE parameters
  &SEAICE_PARM01
-#here I take the fields from pickup.seaice.previous.data that 
+#here I take the fields from pickup.seaice.previous.data that
 #came out of experiment 2 ("relax") part 4 to initialize part 5
       AreaFile='siAREA.ini',
       HeffFile='siHEFF.ini',
@@ -24,7 +24,7 @@
       SEAICE_strength = 2.25e4,
       SEAICE_multDim=1,
       SEAICErestoreUnderIce=.TRUE.,
-      SEAICE_area_max=0.97,      
+      SEAICE_area_max=0.97,
       SEAICE_salt0=4.,
       LSR_ERROR          = 2.e-4,
       SEAICEuseDYNAMICS  = .TRUE.,
@@ -46,11 +46,10 @@
       SEAICEheatConsFix  = .TRUE.,
       SEAICE_tempFrz0    = -1.96,
       SEAICE_dTempFrz_dS = 0.,
-      SEAICEuseMetricTerms = .TRUE.,
       SEAICE_no_slip     = .TRUE.,
       SEAICE_clipVelocities = .TRUE.,
  &
-#
+
  &SEAICE_PARM02
  &
 

--- a/global_oce_cs32/input_ad/data.seaice
+++ b/global_oce_cs32/input_ad/data.seaice
@@ -1,13 +1,13 @@
 # SEAICE parameters
  &SEAICE_PARM01
-#here I take the fields from pickup.seaice.previous.data that 
+#here I take the fields from pickup.seaice.previous.data that
 #came out of experiment 2 ("relax") part 4 to initialize part 5
       AreaFile='siAREA.ini',
       HeffFile='siHEFF.ini',
       HsnowFile='siHSNOW.ini',
       uIceFile='siUICE.ini',
       vIceFile='siVICE.ini',
-#the following is needed to recover old default values 
+#the following is needed to recover old default values
 #since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
       SEAICE_drag=0.002,
       SEAICE_waterDrag=0.005344995140913508357982664,
@@ -24,7 +24,7 @@
       SEAICE_strength = 2.25e4,
       SEAICE_multDim=1,
       SEAICErestoreUnderIce=.TRUE.,
-      SEAICE_area_max=0.97,      
+      SEAICE_area_max=0.97,
       SEAICE_salt0=4.,
       LSR_ERROR          = 2.e-4,
       SEAICEuseDYNAMICS  = .TRUE.,
@@ -46,11 +46,10 @@
       SEAICEheatConsFix  = .TRUE.,
       SEAICE_tempFrz0    = -1.96,
       SEAICE_dTempFrz_dS = 0.,
-      SEAICEuseMetricTerms = .TRUE.,
       SEAICE_no_slip     = .TRUE.,
       SEAICE_clipVelocities = .TRUE.,
  &
-#
+
  &SEAICE_PARM02
  &
 

--- a/global_oce_cs32/results/output.txt
+++ b/global_oce_cs32/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:33:31 EDT 2023
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:43:56 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -192,7 +192,7 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=300,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-12,
+(PID.TID 0000.0001) > cg2dTargetResWunit=6.65E-11,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -600,7 +600,6 @@
 (PID.TID 0000.0001) ># | Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) ># =====================================================================
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) ># GGL90taveFreq = 345600000.,
 (PID.TID 0000.0001) ># GGL90dumpFreq = 86400.,
 (PID.TID 0000.0001) ># GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) ># GGL90diffTKEh=3.e3,
@@ -620,9 +619,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) GGL90dumpFreq =   /* GGL90 state write out interval ( s ). */
 (PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
@@ -664,6 +660,9 @@
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) adMxlMaxFlag =   /* Flag for limiting mixing-length method in AD-mode */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
@@ -777,11 +776,10 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEuseMetricTerms = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -868,6 +866,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: opening data.ecco
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ecco
 (PID.TID 0000.0001) // =======================================================
@@ -1152,7 +1163,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1671,47 +1686,6 @@
 (PID.TID 0000.0001) // External forcing (EXF) configuration  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) etaday defined by gencost   1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 1) = etastep
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_eta_step.bin
-(PID.TID 0000.0001)   starts and ends at :
-(PID.TID 0000.0001)   19480101  120000  2   7
-(PID.TID 0000.0001)   19480101  200000  2   7
-(PID.TID 0000.0001)   number of records =     9
-(PID.TID 0000.0001)  model file = m_etastep
-(PID.TID 0000.0001)  error file = some_eta_sigma.bin
-(PID.TID 0000.0001)  preprocess = clim
-(PID.TID 0000.0001)  posprocess = smooth
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 2) = sststep
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_sst_step.bin
-(PID.TID 0000.0001)   starts and ends at :
-(PID.TID 0000.0001)   19480101  120000  2   7
-(PID.TID 0000.0001)   19480101  200000  2   7
-(PID.TID 0000.0001)   number of records =     9
-(PID.TID 0000.0001)  model file = m_sststep
-(PID.TID 0000.0001)  error file = some_sst_sigma.bin
-(PID.TID 0000.0001)  posprocess = smooth
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // insitu profiles model sampling >>> START <<<
@@ -1731,6 +1705,14 @@
 (PID.TID 0000.0001)   # of profiles within tile and time period  =      237
 (PID.TID 0000.0001)   variable #  1 is            prof_T and theta
 (PID.TID 0000.0001)   variable #  2 is            prof_S and salt
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  1  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  1  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  1  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  1  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) profiles file #  1 is some_TS_atlas.sortedInTime
 (PID.TID 0000.0001)   current tile is bi,bj                      =   2,   1
@@ -1740,6 +1722,14 @@
 (PID.TID 0000.0001)   # of profiles within tile and time period  =      152
 (PID.TID 0000.0001)   variable #  1 is            prof_T and theta
 (PID.TID 0000.0001)   variable #  2 is            prof_S and salt
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  2  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  2  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  2  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  2  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) profiles file #  1 is some_TS_atlas.sortedInTime
 (PID.TID 0000.0001)   current tile is bi,bj                      =   3,   1
@@ -1749,6 +1739,14 @@
 (PID.TID 0000.0001)   # of profiles within tile and time period  =      205
 (PID.TID 0000.0001)   variable #  1 is            prof_T and theta
 (PID.TID 0000.0001)   variable #  2 is            prof_S and salt
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  3  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  3  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  3  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
+(PID.TID 0000.0001) NF_MESSAGE: PROFILES_INIT_FIXED: NF_INQ_VARID prof_names = empty  3  1 NetCDF: Variable not found
+(PID.TID 0000.0001) S/R PROFILES_INIT_FIXED: no empty, setting corresponding vec_quantities = F
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // insitu profiles model sampling >>> END <<<
@@ -1795,6 +1793,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseLSRflex  = /* with residual norm criterion */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
 (PID.TID 0000.0001)                   F
@@ -1877,8 +1878,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -1949,25 +1950,28 @@
 (PID.TID 0000.0001) SEAICEadvSnow = /* advect snow layer together with ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEmultiDimAdvection = /* multidimadvec */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEadvScheme   = /* advection scheme for ice */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchArea   = /* advection scheme for area */
+(PID.TID 0000.0001) SEAICEadvSchArea  = /* advection scheme for area */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchHeff   = /* advection scheme for thickness */
+(PID.TID 0000.0001) SEAICEadvSchHeff  = /* advection scheme for thickness */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchSnow   = /* advection scheme for snow */
+(PID.TID 0000.0001) SEAICEadvSchSnow  = /* advection scheme for snow */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhArea   = /* diffusivity (m^2/s) for area */
+(PID.TID 0000.0001) SEAICEdiffKhArea  = /* diffusivity (m^2/s) for area */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhHeff   = /* diffusivity (m^2/s) for heff */
+(PID.TID 0000.0001) SEAICEdiffKhHeff  = /* diffusivity (m^2/s) for heff */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhSnow   = /* diffusivity (m^2/s) for snow */
+(PID.TID 0000.0001) SEAICEdiffKhSnow  = /* diffusivity (m^2/s) for snow */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) DIFF1             = /* parameter used in advect.F [m/s] */
@@ -2058,6 +2062,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
@@ -2162,16 +2169,10 @@
 (PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
@@ -2200,469 +2201,81 @@
 (PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   3 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =        78927
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          237
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          228
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          233
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =        10699
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         21398
-(PID.TID 0000.0001) ctrl-wet 8: atmos        21398
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    10           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    11           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    12           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    13           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    14           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    15           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   50      557358
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5        4420        4232        4206           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6        4313        4125        4106           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7        4297        4110        4095           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8        4285        4097        4081           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9        4276        4090        4073           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10        4258        4074        4058           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11        4248        4065        4049           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12        4235        4051        4035           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13        4224        4039        4026           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14        4205        4026        4008           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15        4194        4015        3996           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   16        4185        4005        3987           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   17        4172        3993        3972           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   18        4151        3972        3951           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   19        4134        3954        3931           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   20        4122        3942        3921           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   21        4109        3929        3906           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   22        4096        3916        3891           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   23        4081        3899        3878           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   24        4046        3863        3845           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   25        4028        3847        3829           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   26        4013        3831        3812           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   27        4002        3819        3801           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   28        3981        3798        3782           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   29        3971        3786        3768           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   30        3944        3756        3737           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   31        3932        3746        3725           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   32        3910        3723        3700           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   33        3897        3709        3684           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   34        3879        3689        3665           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   35        3840        3652        3627           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   36        3818        3628        3607           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   37        3799        3605        3585           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   38        3748        3547        3515           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   39        3712        3509        3474           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   40        3675        3469        3431           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   41        3582        3369        3334           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   42        3512        3293        3254           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   43        3302        3039        3018           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   44        3092        2794        2784           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   45        2721        2419        2394           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   46        2237        1936        1924           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   47        1745        1471        1443           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   48        1133         922         899           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   49         483         345         328           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   50          99          61          53           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5        4420        4232        4206
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6        4313        4125        4106
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7        4297        4110        4095
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8        4285        4097        4081
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9        4276        4090        4073
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10        4258        4074        4058
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11        4248        4065        4049
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12        4235        4051        4035
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13        4224        4039        4026
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14        4205        4026        4008
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15        4194        4015        3996
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   16        4185        4005        3987
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   17        4172        3993        3972
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   18        4151        3972        3951
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   19        4134        3954        3931
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   20        4122        3942        3921
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   21        4109        3929        3906
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   22        4096        3916        3891
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   23        4081        3899        3878
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   24        4046        3863        3845
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   25        4028        3847        3829
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   26        4013        3831        3812
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   27        4002        3819        3801
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   28        3981        3798        3782
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   29        3971        3786        3768
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   30        3944        3756        3737
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   31        3932        3746        3725
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   32        3910        3723        3700
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   33        3897        3709        3684
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   34        3879        3689        3665
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   35        3840        3652        3627
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   36        3818        3628        3607
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   37        3799        3605        3585
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   38        3748        3547        3515
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   39        3712        3509        3474
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   40        3675        3469        3431
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   41        3582        3369        3334
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   42        3512        3293        3254
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   43        3302        3039        3018
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   44        3092        2794        2784
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   45        2721        2419        2394
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   46        2237        1936        1924
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   47        1745        1471        1443
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   48        1133         922         899
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   49         483         345         328
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   50          99          61          53
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:          557358
@@ -2673,32 +2286,37 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Total number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------------
-(PID.TID 0000.0001)  snx*sny*nr =    12800
+(PID.TID 0000.0001)  sNx*sNy*Nr =    12800
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 010699 010456 010085
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 006514 006422 005882
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 009096 008680 008935
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001   10699   10456   10085
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001    6514    6422    5882
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001    9096    8680    8935
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2706,74 +2324,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   367
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   283 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   285 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    85 sIceLoad
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    78 MXLDEPTH
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   367 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   312 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceQnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceFWflx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   332 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   340 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   341 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   342 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   343 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    48 WVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   265 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   266 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   136 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   137 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   133 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   143 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   144 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   140 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
-(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
-(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
-(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
-(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
-(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
-(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
-(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
-(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
-(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
-(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
-(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
-(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
-(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
-(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
-(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
-(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
+(PID.TID 0000.0001)   set mate pointer for diag #   332  ADVxHEFF , Parms: UU      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVyHEFF , Parms: VV      M1 , mate:   332
+(PID.TID 0000.0001)   set mate pointer for diag #   334  DFxEHEFF , Parms: UU      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFyEHEFF , Parms: VV      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   340  ADVxSNOW , Parms: UU      M1 , mate:   341
+(PID.TID 0000.0001)   set mate pointer for diag #   341  ADVySNOW , Parms: VV      M1 , mate:   340
+(PID.TID 0000.0001)   set mate pointer for diag #   342  DFxESNOW , Parms: UU      M1 , mate:   343
+(PID.TID 0000.0001)   set mate pointer for diag #   343  DFyESNOW , Parms: VV      M1 , mate:   342
+(PID.TID 0000.0001)   set mate pointer for diag #   297  SIuice   , Parms: UU      M1 , mate:   298
+(PID.TID 0000.0001)   set mate pointer for diag #   298  SIvice   , Parms: VV      M1 , mate:   297
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   265  GM_PsiX  , Parms: UU      LR , mate:   266
+(PID.TID 0000.0001)   set mate pointer for diag #   266  GM_PsiY  , Parms: VV      LR , mate:   265
+(PID.TID 0000.0001)   set mate pointer for diag #   136  DFxE_TH  , Parms: UU      MR , mate:   137
+(PID.TID 0000.0001)   set mate pointer for diag #   137  DFyE_TH  , Parms: VV      MR , mate:   136
+(PID.TID 0000.0001)   set mate pointer for diag #   133  ADVx_TH  , Parms: UU      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   134  ADVy_TH  , Parms: VV      MR , mate:   133
+(PID.TID 0000.0001)   set mate pointer for diag #   143  DFxE_SLT , Parms: UU      MR , mate:   144
+(PID.TID 0000.0001)   set mate pointer for diag #   144  DFyE_SLT , Parms: VV      MR , mate:   143
+(PID.TID 0000.0001)   set mate pointer for diag #   140  ADVx_SLT , Parms: UU      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   141  ADVy_SLT , Parms: VV      MR , mate:   140
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2788,12 +2406,12 @@
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
 (PID.TID 0000.0001)  Levels:      21.  22.  23.  24.  25.  26.  27.  28.  29.  30.  31.  32.  33.  34.  35.  36.  37.  38.  39.  40.
 (PID.TID 0000.0001)  Levels:      41.  42.  43.  44.  45.  46.  47.  48.  49.  50.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     825 levels (numDiags =    3000 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use       0 levels (diagSt_size=    2500 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found  19 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4574827780704E-04
@@ -2809,7 +2427,7 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   1.1514045869113E-04
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.0375849106513E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  1.6658494934563737E-04
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 1.683834825981835E-05 (Area=3.6388673751E+14)
+(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 1.684263349322450E-05 (Area=5.4733735933E+12)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -3160,7 +2778,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -3240,17 +2858,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -3258,6 +2866,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       1
@@ -3276,6 +2894,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -3330,6 +2949,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3420,7 +3042,7 @@
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-12
+(PID.TID 0000.0001)                 6.650000000000000E-11
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -3432,7 +3054,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -4639,6 +4261,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.638867375081599E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 8.204975138237117E+10
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 4.420000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 1.857860000000000E+05
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -4666,11 +4297,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+02
@@ -4726,6 +4360,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4733,7 +4370,48 @@
 (PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
-(PID.TID 0000.0001) etaday defined by gencost   1
+(PID.TID 0000.0001) ECCO_CHECK:  --> Starts to check ECCO set-up
+(PID.TID 0000.0001) etagcm defined by gencost =  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 1) = etastep
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_eta_step.bin
+(PID.TID 0000.0001)   starts and ends at :
+(PID.TID 0000.0001)   19480101  120000  2   7
+(PID.TID 0000.0001)   19480101  200000  2   7
+(PID.TID 0000.0001)   number of records =     9
+(PID.TID 0000.0001)  model file = m_etastep
+(PID.TID 0000.0001)  error file = some_eta_sigma.bin
+(PID.TID 0000.0001)  preprocess = clim
+(PID.TID 0000.0001)  posprocess = smooth
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 2) = sststep
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_sst_step.bin
+(PID.TID 0000.0001)   starts and ends at :
+(PID.TID 0000.0001)   19480101  120000  2   7
+(PID.TID 0000.0001)   19480101  200000  2   7
+(PID.TID 0000.0001)   number of records =     9
+(PID.TID 0000.0001)  model file = m_sststep
+(PID.TID 0000.0001)  error file = some_sst_sigma.bin
+(PID.TID 0000.0001)  posprocess = smooth
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) ECCO_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -5158,7 +4836,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   1.52685375416199E+00  4.17012873403983E+00
+ cg2d: Sum(rhs),rhsMax =   1.53780743470756E+00  4.17012873403983E+00
 (PID.TID 0000.0001)      cg2d_init_res =   1.25400901104588E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
 (PID.TID 0000.0001)      cg2d_last_res =   1.34462746836541E-05
@@ -5169,7 +4847,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7198958148745E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4942266735452E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2877968073376E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2877968073377E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8095163779032E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2532755888599E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2883237969741E-01
@@ -5239,8 +4917,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5194081600179E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746089187E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941921508E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0819364568103E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0057951208047E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0819364568102E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0057951207980E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5365,8 +5043,8 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.27562176959984E+00  4.04176142668240E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.99965395716136E+00
+ cg2d: Sum(rhs),rhsMax =   2.29726808616952E+00  4.04176142668240E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.99965395716137E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
 (PID.TID 0000.0001)      cg2d_last_res =   1.36249989550521E-05
 (PID.TID 0000.0001) // =======================================================
@@ -5447,7 +5125,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385742338320E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229760090533E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1667189197556E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1949448073594E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1949448073601E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5572,8 +5250,8 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.02084135214375E+00  3.85943572236572E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.85364692571300E+00
+ cg2d: Sum(rhs),rhsMax =   3.05425779352041E+00  3.85943572236571E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.85364692571299E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
 (PID.TID 0000.0001)      cg2d_last_res =   1.20046364383687E-05
 (PID.TID 0000.0001) // =======================================================
@@ -5654,7 +5332,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737849075E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623696127E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7362235527993E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0933593027827E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0933593027802E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5779,10 +5457,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.74471613139090E+00  3.61217726753160E+00
+ cg2d: Sum(rhs),rhsMax =   3.79205605273486E+00  3.61217726753160E+00
 (PID.TID 0000.0001)      cg2d_init_res =   5.57930382167635E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.42219155120608E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.42219155120610E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5790,7 +5468,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1404016647630E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0741590726092E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1073283312607E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1073283312613E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.5178792679493E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1507794768372E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2868838254637E-01
@@ -5805,7 +5483,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6774436857260E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9979697065429E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0982429405399E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.1874190720086E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.1874190720087E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.3150704094188E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6000666245471E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153625517001E+01
@@ -5817,7 +5495,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7955690137084E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722425129955E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8377146041077E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2541867143791E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2541867143792E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.5192196398706E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0470511721041E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5782874237971E+01
@@ -5860,8 +5538,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192845752149E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734926271E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229530526531E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1072181554295E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.9851622506218E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1072181554297E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.9851622508142E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5986,10 +5664,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.45564259744722E+00  3.33482048706553E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96839324707069E+00
+ cg2d: Sum(rhs),rhsMax =   4.51388023593563E+00  3.33482048706551E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96839324707076E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.34356910327846E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.34356910327841E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5997,9 +5675,9 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390913767014E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266642171440E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6505717773675E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6505717773671E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7120981713726E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1446751212565E-03
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1446751212566E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7250482909508E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7645074455239E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3506722402532E-03
@@ -6012,7 +5690,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8143049637635E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5245371770836E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.4966678399809E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3594420526951E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3594420526953E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8838556287460E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9215122660405E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152883307839E+01
@@ -6067,8 +5745,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771603816E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734543749E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484402108E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4609499696439E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2467121221304E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4609499696438E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2467121219896E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6081,10 +5759,10 @@
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8903652861827E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8856185441551E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2808998488468E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2808998488469E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4646692511830E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4646692511829E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8657270702442E-01
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   2.3476660124600E-03
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.2343536618429E-01
@@ -6127,7 +5805,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9182914494362E+00
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.7457695395741E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342840136601E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4037188934142E-09
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4037188934143E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4422435758543E-08
 (PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8568336763528E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.0472183881203E+01
@@ -6158,10 +5836,10 @@
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3817508881300E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1151716150208E+01
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7443198409197E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7577814582197E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7577814582196E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431695554325E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.0916345812712E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7177657060958E-08
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7177657060957E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7085440485613E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5822245611208E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   5.0408473972077E-10
@@ -6193,10 +5871,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.15648389869520E+00  3.10565393023254E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.59442350333145E+00
+ cg2d: Sum(rhs),rhsMax =   5.22378551439951E+00  3.10565393023255E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.59442350333151E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.24155965095467E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.24155965095491E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6236,7 +5914,7 @@
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8488656388529E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6678133577939E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3313529647758E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2702238262293E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2702238262292E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0868927255252E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595543006364E+02
@@ -6246,7 +5924,7 @@
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2472629445288E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.3382671522620E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4704740677235E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.2691495578114E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.2691495578115E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   9.5279112837015E-01
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -6.8176610094127E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -7.8019484216668E-03
@@ -6275,7 +5953,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385736586875E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229489807718E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.6257538645406E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.1830839046716E-08
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.1830839044983E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6286,7 +5964,7 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.9539654133701E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.9539654133702E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9203130151586E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   2.3396440142773E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
@@ -6304,7 +5982,7 @@
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.2626412468061E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9431121170489E-03
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   6.2547439716130E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7693352123003E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7693352123004E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.6035993617453E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.1995485944651E-06
@@ -6329,7 +6007,7 @@
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   1.9058444760857E-03
 (PID.TID 0000.0001) %MON exf_hflux_max                =   9.5448996490151E+02
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8005205413571E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0836859654224E+01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0836859654223E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6850973489905E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9136183197248E+00
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.6825327701776E-07
@@ -6367,10 +6045,10 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7437390194850E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7555637398794E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431385024112E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.1790880052829E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5605511829966E-08
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.1790880052827E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5605511829965E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7225368083906E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5887078830193E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5887078830194E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   5.0616985024984E-10
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.3952657573221E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   5.2770680852235E-10
@@ -6400,10 +6078,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.85005068088557E+00  2.96119649638921E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.22912098901427E+00
+ cg2d: Sum(rhs),rhsMax =   5.92587470002084E+00  2.96119649638921E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.22912098901423E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   1.67541046565554E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.67541046565464E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6414,7 +6092,7 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2669383356907E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7979374130950E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1340252834053E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3041032731176E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3041032731175E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7962180591953E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1084776836385E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2498105851853E-02
@@ -6439,9 +6117,9 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722429830554E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8373591711667E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2446338350359E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9492876201845E+02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9492876201839E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8005205413571E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6254021761750E+01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6254021761749E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3334247682812E+02
 (PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2730613402122E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
@@ -6451,11 +6129,11 @@
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.5794372463368E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3219048372661E-03
 (PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2725834611742E-04
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.2905026125904E-05
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.2905026125905E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4411660007973E-04
 (PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.1865506247634E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.0826407904782E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.0252593856887E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.0252593856888E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -8.2778201501586E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1863113757761E-01
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5808055836984E-03
@@ -6467,7 +6145,7 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4792132558596E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5471530443595E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1055333375727E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8811151026852E-03
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8811151026851E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7112174285834E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1974778395630E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.2984174394513E-01
@@ -6481,8 +6159,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193060004194E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740359616E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538945466E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8351287290418E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.5959338906509E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8351287290440E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.5959338903847E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6493,282 +6171,294 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0133998878801E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0133998878802E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9405456069014E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4063504974745E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6014828457706E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6014828457705E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9403888440048E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4458061834070E-03
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4458061834071E-03
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.6094595211572E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_mean             =   3.4321607367103E-03
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.8029545216619E-02
 (PID.TID 0000.0001) %MON seaice_area_del2             =   1.6698556097789E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3384652252725E-02
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3384652252724E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4322943817504E-03
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8701497629906E-03
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8701497629907E-03
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   6.9802249762397E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0283212822379E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8381828158227E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6018675632909E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2325513813528E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2325513813529E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT         8 ckptA
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) == cost_profiles: begin ==
-(PID.TID 0000.0001)  cost_profiles( 1, 1)=  0.13501D+04 0.18579D+06
-(PID.TID 0000.0001)  cost_profiles( 1, 2)=  0.10995D+04 0.18579D+06
-(PID.TID 0000.0001) == cost_profiles: end   ==
+(PID.TID 0000.0001) == profiles_cost: begin ==
+(PID.TID 0000.0001)  profiles_cost( 1, 1) =  0.135012753328356D+04 0.185786000000000D+06
+(PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.109945066105183D+04 0.185786000000000D+06
+(PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.135012753328356D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.109945066105183D+04 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.404002220976427D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.418277523185974D+05 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.846775526105755D+05
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.108467522039521D+05
-(PID.TID 0000.0001)  global fc =  0.846775526105755D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.35012753328356E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  1.09945066105183E+03  1  2  1.00E+00
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  4.04002220976427E+04  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.18277523185974E+04  2  1.00E+00 (sststep)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.08467522039521E+04
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   8.46775526105755E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.570025399327278
-(PID.TID 0000.0001)         System time:   1.6135089695453644
-(PID.TID 0000.0001)     Wall clock time:   19.495706796646118
+(PID.TID 0000.0001)           User time:   7.4494682215154171
+(PID.TID 0000.0001)         System time:  0.11250899732112885
+(PID.TID 0000.0001)     Wall clock time:   7.5693979263305664
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.63043401390314102
-(PID.TID 0000.0001)         System time:  0.49438602104783058
-(PID.TID 0000.0001)     Wall clock time:   1.2275180816650391
+(PID.TID 0000.0001)           User time:  0.24918000493198633
+(PID.TID 0000.0001)         System time:   3.6627998575568199E-002
+(PID.TID 0000.0001)     Wall clock time:  0.28931307792663574
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.939538836479187
-(PID.TID 0000.0001)         System time:   1.1190940141677856
-(PID.TID 0000.0001)     Wall clock time:   18.268112897872925
+(PID.TID 0000.0001)           User time:   7.2002648711204529
+(PID.TID 0000.0001)         System time:   7.5869996100664139E-002
+(PID.TID 0000.0001)     Wall clock time:   7.2800538539886475
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0135470032691956
-(PID.TID 0000.0001)         System time:  0.64651101827621460
-(PID.TID 0000.0001)     Wall clock time:   2.6918640136718750
+(PID.TID 0000.0001)           User time:  0.44619199633598328
+(PID.TID 0000.0001)         System time:   2.3724999278783798E-002
+(PID.TID 0000.0001)     Wall clock time:  0.47027611732482910
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.925962448120117
-(PID.TID 0000.0001)         System time:  0.47257089614868164
-(PID.TID 0000.0001)     Wall clock time:   15.576209068298340
+(PID.TID 0000.0001)           User time:   6.7540570497512817
+(PID.TID 0000.0001)         System time:   5.2143000066280365E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8097608089447021
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   8.6557626724243164E-002
-(PID.TID 0000.0001)         System time:   6.9149732589721680E-003
-(PID.TID 0000.0001)     Wall clock time:  0.10581326484680176
+(PID.TID 0000.0001)           User time:   4.5317530632019043E-002
+(PID.TID 0000.0001)         System time:   1.6299635171890259E-004
+(PID.TID 0000.0001)     Wall clock time:   4.5503377914428711E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   8.4171295166015625E-002
-(PID.TID 0000.0001)         System time:   7.1361064910888672E-003
-(PID.TID 0000.0001)     Wall clock time:  0.13107419013977051
+(PID.TID 0000.0001)           User time:   4.7047138214111328E-002
+(PID.TID 0000.0001)         System time:   1.2002885341644287E-005
+(PID.TID 0000.0001)     Wall clock time:   4.7071695327758789E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.359805107116699
-(PID.TID 0000.0001)         System time:  0.31129503250122070
-(PID.TID 0000.0001)     Wall clock time:   14.782106161117554
+(PID.TID 0000.0001)           User time:   6.5361770987510681
+(PID.TID 0000.0001)         System time:   4.7924995422363281E-002
+(PID.TID 0000.0001)     Wall clock time:   6.5876019001007080
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   14.359663724899292
-(PID.TID 0000.0001)         System time:  0.31128680706024170
-(PID.TID 0000.0001)     Wall clock time:   14.781951665878296
+(PID.TID 0000.0001)           User time:   6.5361087918281555
+(PID.TID 0000.0001)         System time:   4.7923997044563293E-002
+(PID.TID 0000.0001)     Wall clock time:   6.5875301361083984
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.21557235717773438
-(PID.TID 0000.0001)         System time:   2.2053718566894531E-005
-(PID.TID 0000.0001)     Wall clock time:  0.21585679054260254
+(PID.TID 0000.0001)           User time:  0.10011142492294312
+(PID.TID 0000.0001)         System time:   8.7000429630279541E-005
+(PID.TID 0000.0001)     Wall clock time:  0.10027313232421875
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.9613704681396484E-002
-(PID.TID 0000.0001)         System time:   8.8279247283935547E-003
-(PID.TID 0000.0001)     Wall clock time:   6.8524360656738281E-002
+(PID.TID 0000.0001)           User time:   2.1853327751159668E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.2168159484863281E-002
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18710112571716309
-(PID.TID 0000.0001)         System time:   6.7831277847290039E-003
-(PID.TID 0000.0001)     Wall clock time:  0.19403362274169922
+(PID.TID 0000.0001)           User time:   5.5790424346923828E-002
+(PID.TID 0000.0001)         System time:   3.9599984884262085E-003
+(PID.TID 0000.0001)     Wall clock time:   5.9766530990600586E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.18669748306274414
-(PID.TID 0000.0001)         System time:   6.7209005355834961E-003
-(PID.TID 0000.0001)     Wall clock time:  0.19358801841735840
+(PID.TID 0000.0001)           User time:   5.5453181266784668E-002
+(PID.TID 0000.0001)         System time:   3.9590001106262207E-003
+(PID.TID 0000.0001)     Wall clock time:   5.9429407119750977E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.7393989562988281E-005
-(PID.TID 0000.0001)         System time:   3.2901763916015625E-005
-(PID.TID 0000.0001)     Wall clock time:   1.3303756713867188E-004
+(PID.TID 0000.0001)           User time:   4.1902065277099609E-005
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   4.3153762817382812E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.2139787673950195E-002
-(PID.TID 0000.0001)         System time:   1.3411045074462891E-003
-(PID.TID 0000.0001)     Wall clock time:   2.3489236831665039E-002
+(PID.TID 0000.0001)           User time:   1.1033117771148682E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.1037111282348633E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.4082612991333008E-003
-(PID.TID 0000.0001)         System time:   3.7586688995361328E-004
-(PID.TID 0000.0001)     Wall clock time:   7.7917575836181641E-003
+(PID.TID 0000.0001)           User time:   3.1634569168090820E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.1640529632568359E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7878596782684326
-(PID.TID 0000.0001)         System time:   2.5455117225646973E-002
-(PID.TID 0000.0001)     Wall clock time:   2.8245861530303955
+(PID.TID 0000.0001)           User time:   1.1160311102867126
+(PID.TID 0000.0001)         System time:   7.8229978680610657E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1248950958251953
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  0.45202660560607910
-(PID.TID 0000.0001)         System time:   4.4448375701904297E-003
-(PID.TID 0000.0001)     Wall clock time:  0.45948123931884766
+(PID.TID 0000.0001)           User time:  0.11883211135864258
+(PID.TID 0000.0001)         System time:   1.9997358322143555E-005
+(PID.TID 0000.0001)     Wall clock time:  0.11886310577392578
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:  0.28657865524291992
-(PID.TID 0000.0001)         System time:   3.4878253936767578E-003
-(PID.TID 0000.0001)     Wall clock time:  0.29294681549072266
+(PID.TID 0000.0001)           User time:   8.7288141250610352E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.7298870086669922E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  0.58916532993316650
-(PID.TID 0000.0001)         System time:   1.2796998023986816E-002
-(PID.TID 0000.0001)     Wall clock time:  0.60203099250793457
+(PID.TID 0000.0001)           User time:  0.27754569053649902
+(PID.TID 0000.0001)         System time:   3.9639994502067566E-003
+(PID.TID 0000.0001)     Wall clock time:  0.28174519538879395
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6633291244506836
-(PID.TID 0000.0001)         System time:   9.7110271453857422E-003
-(PID.TID 0000.0001)     Wall clock time:   2.7570247650146484
+(PID.TID 0000.0001)           User time:   1.4705587029457092
+(PID.TID 0000.0001)         System time:   1.2002885341644287E-005
+(PID.TID 0000.0001)     Wall clock time:   1.4709758758544922
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30183410644531250
-(PID.TID 0000.0001)         System time:   6.2000751495361328E-004
-(PID.TID 0000.0001)     Wall clock time:  0.30269312858581543
+(PID.TID 0000.0001)           User time:   3.2974362373352051E-002
+(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
+(PID.TID 0000.0001)     Wall clock time:   3.2985210418701172E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16972041130065918
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.17400908470153809
+(PID.TID 0000.0001)           User time:   6.9574117660522461E-002
+(PID.TID 0000.0001)         System time:   7.5995922088623047E-005
+(PID.TID 0000.0001)     Wall clock time:   6.9654226303100586E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.6720724105834961E-002
+(PID.TID 0000.0001)           User time:   3.1373143196105957E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.6951990127563477E-002
+(PID.TID 0000.0001)     Wall clock time:   3.1384468078613281E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15086340904235840
-(PID.TID 0000.0001)         System time:   3.9690732955932617E-003
-(PID.TID 0000.0001)     Wall clock time:  0.15486836433410645
+(PID.TID 0000.0001)           User time:   4.5214772224426270E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.5218467712402344E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0886430740356445E-002
+(PID.TID 0000.0001)           User time:   4.4467449188232422E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.0897397994995117E-002
+(PID.TID 0000.0001)     Wall clock time:   4.4479370117187500E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.16826820373535156
-(PID.TID 0000.0001)         System time:   1.5094876289367676E-002
-(PID.TID 0000.0001)     Wall clock time:  0.18354487419128418
+(PID.TID 0000.0001)           User time:   6.0601830482482910E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.0624599456787109E-002
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6263103485107422
-(PID.TID 0000.0001)         System time:   1.1201977729797363E-002
-(PID.TID 0000.0001)     Wall clock time:   3.6451230049133301
+(PID.TID 0000.0001)           User time:   1.6995612382888794
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.7003536224365234
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.8439712524414062E-005
-(PID.TID 0000.0001)         System time:   3.0994415283203125E-006
-(PID.TID 0000.0001)     Wall clock time:   9.0122222900390625E-005
+(PID.TID 0000.0001)           User time:   3.7550926208496094E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.1007995605468750E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.68308138847351074
-(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
-(PID.TID 0000.0001)     Wall clock time:  0.68428158760070801
+(PID.TID 0000.0001)           User time:  0.25543105602264404
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.25556397438049316
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.9141387939453125E-005
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   7.0095062255859375E-005
+(PID.TID 0000.0001)           User time:   3.7431716918945312E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6954879760742188E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.93296074867248535
-(PID.TID 0000.0001)         System time:  0.15568602085113525
-(PID.TID 0000.0001)     Wall clock time:   1.0893309116363525
+(PID.TID 0000.0001)           User time:  0.29331147670745850
+(PID.TID 0000.0001)         System time:   1.1946998536586761E-002
+(PID.TID 0000.0001)     Wall clock time:  0.30538487434387207
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.18527793884277344
-(PID.TID 0000.0001)         System time:   7.2070002555847168E-002
-(PID.TID 0000.0001)     Wall clock time:  0.25739121437072754
+(PID.TID 0000.0001)           User time:   8.1879138946533203E-002
+(PID.TID 0000.0001)         System time:   2.3970998823642731E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10612320899963379
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1495590209960938E-002
-(PID.TID 0000.0001)         System time:   3.9520263671875000E-003
-(PID.TID 0000.0001)     Wall clock time:   1.5450954437255859E-002
+(PID.TID 0000.0001)           User time:   5.5088996887207031E-003
+(PID.TID 0000.0001)         System time:   2.5004148483276367E-005
+(PID.TID 0000.0001)     Wall clock time:   5.5339336395263672E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.3405761718750000E-004
-(PID.TID 0000.0001)         System time:   4.8995018005371094E-005
-(PID.TID 0000.0001)     Wall clock time:   5.8484077453613281E-004
+(PID.TID 0000.0001)           User time:   1.0776519775390625E-004
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
+(PID.TID 0000.0001)     Wall clock time:   1.1086463928222656E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.27046585083007812
-(PID.TID 0000.0001)         System time:  0.11914789676666260
-(PID.TID 0000.0001)     Wall clock time:  0.40362691879272461
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   9.4486236572265625E-002
+(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
+(PID.TID 0000.0001)     Wall clock time:   9.4528913497924805E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.18062973022460938
-(PID.TID 0000.0001)         System time:   8.7460994720458984E-002
-(PID.TID 0000.0001)     Wall clock time:  0.28121805191040039
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   6.4402103424072266E-002
+(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
+(PID.TID 0000.0001)     Wall clock time:   6.4448118209838867E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   8.9786529541015625E-002
-(PID.TID 0000.0001)         System time:   3.1682968139648438E-002
-(PID.TID 0000.0001)     Wall clock time:  0.12236404418945312
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   3.0063152313232422E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.0062913894653320E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.6365051269531250E-003
-(PID.TID 0000.0001)         System time:   1.6295909881591797E-004
-(PID.TID 0000.0001)     Wall clock time:   1.8019676208496094E-003
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   8.9693069458007812E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.9812278747558594E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6808,9 +6498,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          18588
+(PID.TID 0000.0001) //            No. barriers =          18586
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          18588
+(PID.TID 0000.0001) //     Total barrier spins =          18586
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_cs32/results/output_adm.sens.txt
+++ b/global_oce_cs32/results/output_adm.sens.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69j
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Dec 25 16:22:59 EST 2025
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 10:54:07 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -783,11 +783,10 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEuseMetricTerms = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -1711,8 +1710,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -1895,6 +1894,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
@@ -2195,6 +2197,9 @@
 (PID.TID 0000.0001)       ncvarindex =     5
 (PID.TID 0000.0001)       weight     = wt_ones.bin
 (PID.TID 0000.0001)       period     =  00000000 020000
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -4434,7 +4439,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7220921237260E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4941547703982E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874425E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874426E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8092937315121E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2533470859263E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2884747902342E-01
@@ -4480,7 +4485,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746079982E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854223E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823556648655E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328655665451E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328655665452E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4491,7 +4496,7 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0677224251052E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0677224251053E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.0561021612741E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3843152618827E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
@@ -4605,11 +4610,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.87992650799733E-01  7.97821468767044E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300438E-01  7.74858747615991E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.84404459441547E-01
+ cg2d: Sum(rhs),rhsMax =   2.87992650799731E-01  7.97821468767044E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300431E-01  7.74858747615990E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.84404459441544E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      47
-(PID.TID 0000.0001)      cg2d_last_res =   9.19496287074656E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19496287074642E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4617,7 +4622,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890399859476E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303095657177E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5316966869627E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5316966869630E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1483051158071E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1622406823897E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6559728187354E-01
@@ -4647,7 +4652,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3772566990058E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.1338171517743E-03
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5802354497477E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240911757E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240911756E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4564500167921E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8555597219715E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2173753949865E-01
@@ -4663,7 +4668,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737833612E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623570993E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959017430E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276265061556E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276265061567E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4789,10 +4794,10 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   4.95270753311019E-01  7.65934820675236E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207482506E-01  7.61970515877181E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.51870870684699E-01
+ cg2d: Sum(rhs),rhsMax =   5.92660207482520E-01  7.61970515877186E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.51870870684693E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      46
-(PID.TID 0000.0001)      cg2d_last_res =   9.43883227761028E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.43883227760983E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4803,7 +4808,7 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206935E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527919085E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463461580090E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901465213E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901465211E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680926573E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510302348038E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436491859088E-02
@@ -4815,7 +4820,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188719804444E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487115575E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840646586E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673510500975E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673510500982E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943369582164E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264808108150E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706944E+01
@@ -4827,11 +4832,11 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981819416167E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726333694657E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067567206882E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088836774E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576152252E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088836775E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576152248E-03
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681575436E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550012920689E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686365119E-03
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686365117E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534733322E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209520170E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925323475E-01
@@ -4845,8 +4850,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771506334E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734511739E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484263698E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614782964016E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210451893675E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614782964014E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210451893047E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4903,7 +4908,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891369987E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909459000E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387149987E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539017089E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539017090E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342284317846E-07
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796477E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781655E-08
@@ -4938,7 +4943,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046679E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104752E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172419E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594357E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594356E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197745550E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371846E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764647E-08
@@ -4971,11 +4976,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   6.88070042799517E-01  7.59584828994187E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243680696E-01  7.57582533116074E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.57970833906411E-01
+ cg2d: Sum(rhs),rhsMax =   6.88070042799573E-01  7.59584828994177E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243680671E-01  7.57582533116067E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.57970833906427E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      46
-(PID.TID 0000.0001)      cg2d_last_res =   8.72165674874134E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.72165674873427E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4986,7 +4991,7 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993124E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977403021025E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361004056978E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754371174E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754371170E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152033571924E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089658606654E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499029751211E-02
@@ -5000,7 +5005,7 @@
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786384335E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072405465265E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644189430346E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246311413E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246311412E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185599E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458180603E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892053E+00
@@ -5010,17 +5015,17 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439292116E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726336750298E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222985484E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976413609E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976413610E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502778593E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601919657E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633162380E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753295838550E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633162381E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753295838545E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356029118E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446514695E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745471558E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.8987366598998E-04
 (PID.TID 0000.0001) %MON ke_max                       =   5.3813407931395E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2893724685645E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2893724685644E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542976161516E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -4.4706133438089E-06
 (PID.TID 0000.0001) %MON vort_r_max                   =   4.7511635093729E-06
@@ -5028,8 +5033,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943442E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316408E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538645657E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826895112E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326267299603E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826895125E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326267299667E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5040,12 +5045,12 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015706083E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015706084E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425196443E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935392124E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032167482683E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032167482682E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9397438201898E-01
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4451765116121E-03
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.6121956409117E-01
@@ -5053,15 +5058,15 @@
 (PID.TID 0000.0001) %MON seaice_area_mean             =   3.4332297665618E-03
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.8035737713302E-02
 (PID.TID 0000.0001) %MON seaice_area_del2             =   1.6753780942344E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283725507E-02
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283725506E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4331232104455E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8738037375310E-03
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   7.0030891670950E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657520899E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587134E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146826E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587133E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146827E-06
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095039265E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
@@ -5112,39 +5117,50 @@
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428492916643E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899009538D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866498861491D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428492916643D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889306469D+09
-(PID.TID 0000.0001) Writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157301216935D+08
-(PID.TID 0000.0001)  global fc =  0.139129889306469D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736899009538E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866498861491E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428492916643E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157301216935E+07
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   1.39129889306469E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689202E-01  6.80494402321960E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537588E-01  8.23075697484955E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799742E-01  7.97821468767062E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300474E-01  7.74858747615994E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799723E-01  7.97821468767062E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300477E-01  7.74858747615995E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   4.95270753311090E-01  7.65934820675229E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207482545E-01  7.61970515877196E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042799509E-01  7.59584828994228E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243680685E-01  7.57582533116121E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753311083E-01  7.65934820675233E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207482574E-01  7.61970515877206E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042799527E-01  7.59584828994222E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243680710E-01  7.57582533116127E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   4.95270620995271E-01  7.65935025998748E+00
- cg2d: Sum(rhs),rhsMax =   5.92660475395590E-01  7.61970724306709E+00
- cg2d: Sum(rhs),rhsMax =   6.88070473820577E-01  7.59585024200483E+00
- cg2d: Sum(rhs),rhsMax =   7.82661729692801E-01  7.57582726826315E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270620995285E-01  7.65935025998748E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660475395579E-01  7.61970724306709E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070473820574E-01  7.59585024200483E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661729692791E-01  7.57582726826315E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  Calling cg2d from S/R CG2D_MAD
@@ -5256,16 +5272,16 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.61100038759332E-14  2.58803940002607E+01
+ cg2d: Sum(rhs),rhsMax =  -3.39173134022985E-14  2.58803940002607E+01
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   2.10942374678780E-15  2.01187058421159E+01
+ cg2d: Sum(rhs),rhsMax =  -2.37587727269783E-14  2.01187058421160E+01
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689202E-01  6.80494402321960E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537588E-01  8.23075697484955E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799742E-01  7.97821468767062E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300474E-01  7.74858747615994E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799723E-01  7.97821468767062E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300477E-01  7.74858747615995E+00
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   6.43929354282591E-14  1.40292498062924E+01
+ cg2d: Sum(rhs),rhsMax =   5.68434188608080E-14  1.40292498062924E+01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5321,7 +5337,7 @@
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.2190590376602E+03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   6.3099596008467E+06
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5522772835806E+06
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.5577693656680E+01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.5577693656679E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   3.4023230915602E+04
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   2.8397720115681E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   9.7023943080810E+05
@@ -5371,11 +5387,11 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   4.35207425653061E-14  1.46870523376667E+01
+ cg2d: Sum(rhs),rhsMax =  -1.77635683940025E-15  1.46870523376666E+01
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.01980662698043E-14  1.70587737165359E+01
+ cg2d: Sum(rhs),rhsMax =  -2.84217094304040E-14  1.70587737165361E+01
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -4.44089209850063E-14  1.86295980616999E+01
+ cg2d: Sum(rhs),rhsMax =   3.55271367880050E-14  1.86295980616999E+01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5391,17 +5407,17 @@
 (PID.TID 0000.0001) %MON ad_exf_adfv_mean             =   1.9874027169815E+03
 (PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.3363770018557E+04
 (PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388689192404E+02
-(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.0328576541207E-01
+(PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   8.0328576541208E-01
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -9.9174900079740E-01
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =   4.1794201235044E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   2.5583928537474E-01
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   3.0807315570061E-03
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.3410719000779E+07
-(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.1075826254872E+06
+(PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.1075826254873E+06
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =  -1.2043463259703E+05
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   3.4619884700524E+06
 (PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   3.7776401919322E+04
-(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.2716620858802E-02
+(PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   9.2716620858801E-02
 (PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -1.1383140472928E-01
 (PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =  -6.6219295097990E-04
 (PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   7.2732234548553E-03
@@ -5507,12 +5523,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689274E-01  6.80494402321544E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537750E-01  8.23075697484161E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800128E-01  7.97821468765922E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301181E-01  7.74858747614565E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312099E-01  7.65934820673534E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207483988E-01  7.61970515875245E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042801296E-01  7.59584828992048E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243682657E-01  7.57582533113800E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800145E-01  7.97821468765922E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301184E-01  7.74858747614568E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312116E-01  7.65934820673533E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207483927E-01  7.61970515875250E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042801311E-01  7.59584828992035E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243682654E-01  7.57582533113793E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5559,22 +5575,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428491688845E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899242369D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866495196126D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428491688845D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889573509D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157303450325D+08
-(PID.TID 0000.0001)  global fc =  0.139129889573509D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736899242369E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866495196126E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428491688845E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157303450325E+07
+(PID.TID 0000.0001)  global fc =   1.39129889573509E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889573509E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5586,12 +5607,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689136E-01  6.80494402322376E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537402E-01  8.23075697485752E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799293E-01  7.97821468768214E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299688E-01  7.74858747617459E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309988E-01  7.65934820676950E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207481092E-01  7.61970515879129E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042797769E-01  7.59584828996342E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243678739E-01  7.57582533118378E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799286E-01  7.97821468768214E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299696E-01  7.74858747617459E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309963E-01  7.65934820676950E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207481075E-01  7.61970515879129E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042797786E-01  7.59584828996338E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243678646E-01  7.57582533118370E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5638,22 +5659,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428494036026E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898753425D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866502092828D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428494036026D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889069662D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157299824070D+08
-(PID.TID 0000.0001)  global fc =  0.139129889069662D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736898753425E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866502092828E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428494036026E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157299824070E+07
+(PID.TID 0000.0001)  global fc =   1.39129889069662E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889069662E+08
 grad-res -------------------------------
  grad-res     0    1    1    1    1    1    1    1   1.39129889306E+08  1.39129889574E+08  1.39129889070E+08
@@ -5677,12 +5703,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689302E-01  6.80494402321359E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537837E-01  8.23075697483809E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800351E-01  7.97821468765414E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301557E-01  7.74858747613875E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312621E-01  7.65934820672700E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207484663E-01  7.61970515874314E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042802163E-01  7.59584828991020E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243683631E-01  7.57582533112685E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800344E-01  7.97821468765414E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301554E-01  7.74858747613875E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312631E-01  7.65934820672701E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207484599E-01  7.61970515874313E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042802202E-01  7.59584828991022E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243683648E-01  7.57582533112692E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5723,29 +5749,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707096734484E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748515096249E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748515096232E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664496527778E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428491595690E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899242369D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866494180501D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428491595690D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889665756D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157304280472D+08
-(PID.TID 0000.0001)  global fc =  0.139129889665756D+09
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889665756E+08
+(PID.TID 0000.0001) moc fc:  8.47428491595673E+07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736899242369E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866494180501E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428491595673E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157304280455E+07
+(PID.TID 0000.0001)  global fc =   1.39129889665754E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889665754E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -5756,12 +5787,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689107E-01  6.80494402322561E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537318E-01  8.23075697486113E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799099E-01  7.97821468768740E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299305E-01  7.74858747618163E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309459E-01  7.65934820677783E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207480353E-01  7.61970515880055E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042796905E-01  7.59584828997387E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243677666E-01  7.57582533119499E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799124E-01  7.97821468768741E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299312E-01  7.74858747618166E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309448E-01  7.65934820677782E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207480392E-01  7.61970515880061E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042796863E-01  7.59584828997374E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243677715E-01  7.57582533119476E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5808,29 +5839,34 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428494153652E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898753425D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866502344564D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428494153652D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889056251D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157299759404D+08
-(PID.TID 0000.0001)  global fc =  0.139129889056251D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736898753425E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866502344564E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428494153652E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157299759404E+07
+(PID.TID 0000.0001)  global fc =   1.39129889056251E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889056251E+08
 grad-res -------------------------------
  grad-res     0    2    2    1    1    1    1    1   1.39129889306E+08  1.39129889666E+08  1.39129889056E+08
- grad-res     0    2    2    2    0    1    1    1   3.87030715942E+01  3.04752230644E+01  2.12589032108E-01
+ grad-res     0    2    2    2    0    1    1    1   3.87030715942E+01  3.04751381278E+01  2.12591226678E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129889306469E+08
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  3.87030715942383E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.04752230644226E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.04751381278038E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3         594           3
@@ -5848,11 +5884,11 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =   1.13674863689321E-01  6.80494402321269E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537874E-01  8.23075697483626E+00
  cg2d: Sum(rhs),rhsMax =   2.87992650800442E-01  7.97821468765121E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301735E-01  7.74858747613507E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312870E-01  7.65934820672279E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207485068E-01  7.61970515873797E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042802590E-01  7.59584828990426E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243684217E-01  7.57582533112054E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301777E-01  7.74858747613505E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312873E-01  7.65934820672280E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207485036E-01  7.61970515873796E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042802654E-01  7.59584828990425E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243684203E-01  7.57582533112046E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5899,22 +5935,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428491709411E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899428633D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866495968696D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428491709411D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889516935D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157302931152D+08
-(PID.TID 0000.0001)  global fc =  0.139129889516935D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736899428633E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866495968696E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428491709411E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157302931152E+07
+(PID.TID 0000.0001)  global fc =   1.39129889516935E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889516935E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5926,12 +5967,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689084E-01  6.80494402322651E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537270E-01  8.23075697486299E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650798966E-01  7.97821468769039E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299138E-01  7.74858747618519E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309200E-01  7.65934820678222E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207480062E-01  7.61970515880569E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042796419E-01  7.59584828997955E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243677154E-01  7.57582533120111E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650798975E-01  7.97821468769039E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299116E-01  7.74858747618519E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309185E-01  7.65934820678221E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207480051E-01  7.61970515880569E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042796429E-01  7.59584828997952E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243677140E-01  7.57582533120106E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5978,22 +6019,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428494027685E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898706858D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866501910536D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428494027685D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889082401D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157299974332D+08
-(PID.TID 0000.0001)  global fc =  0.139129889082401D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736898706858E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866501910536E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428494027685E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157299974332E+07
+(PID.TID 0000.0001)  global fc =   1.39129889082401E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889082401E+08
 grad-res -------------------------------
  grad-res     0    3    3    1    1    1    1    1   1.39129889306E+08  1.39129889517E+08  1.39129889082E+08
@@ -6017,12 +6063,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689329E-01  6.80494402321186E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537919E-01  8.23075697483461E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800545E-01  7.97821468764866E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301920E-01  7.74858747613166E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800554E-01  7.97821468764866E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301902E-01  7.74858747613166E+00
  cg2d: Sum(rhs),rhsMax =   4.95270753313171E-01  7.65934820671813E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207485469E-01  7.61970515873197E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042803190E-01  7.59584828989767E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243684874E-01  7.57582533111279E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207485430E-01  7.61970515873198E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042803190E-01  7.59584828989755E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243684906E-01  7.57582533111277E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -6069,22 +6115,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
 (PID.TID 0000.0001) moc fc:  8.47428492171184E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736899428633D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866497792697D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428492171184D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889380712D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157301615765D+08
-(PID.TID 0000.0001)  global fc =  0.139129889380712D+09
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736899428633E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866497792697E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428492171184E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157301615765E+07
+(PID.TID 0000.0001)  global fc =   1.39129889380712E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  1.39129889380712E+08
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -6096,12 +6147,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689076E-01  6.80494402322734E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537231E-01  8.23075697486459E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650798902E-01  7.97821468769250E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103298978E-01  7.74858747618816E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753308915E-01  7.65934820678655E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207479621E-01  7.61970515881125E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042795850E-01  7.59584828998597E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243676444E-01  7.57582533120898E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650798884E-01  7.97821468769249E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103298974E-01  7.74858747618816E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753308908E-01  7.65934820678656E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207479643E-01  7.61970515881127E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042795839E-01  7.59584828998612E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243676444E-01  7.57582533120883E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -6140,37 +6191,42 @@ grad-res -------------------------------
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  5  2.66222877977837E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
-(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707097397139E+07kmax:  1
+(PID.TID 0000.0001) moc cost m_trVol_step  6  2.57707097397207E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  7  1.27748515971525E+07kmax:  1
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  8  2.77664496527778E+04kmax: 50
 (PID.TID 0000.0001) **Warning: temporal msk file: north10_maskT not found, using 1/nrecloc
 (PID.TID 0000.0001) moc cost m_trVol_step  9  2.83678263888889E+04kmax: 50
-(PID.TID 0000.0001) moc fc:  8.47428493519050E+07
-(PID.TID 0000.0001)  --> f_gencost = 0.891736898706858D+01 1
-(PID.TID 0000.0001)  --> f_gencost =-0.347866501025119D+08 2
-(PID.TID 0000.0001)  --> f_gencost = 0.847428493519050D+08 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 4
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 5
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.139129889120079D+09
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.792157300281669D+08
-(PID.TID 0000.0001)  global fc =  0.139129889120079D+09
-(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889120079E+08
+(PID.TID 0000.0001) moc fc:  8.47428493519118E+07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_gencost  =  8.91736898706858E+00  1  1.00E+07 (south30_mean_theta)
+(PID.TID 0000.0001)  --> f_gencost  = -3.47866501025119E+07  2  1.00E+00 (north10_flux_vol)
+(PID.TID 0000.0001)  --> f_gencost  =  8.47428493519118E+07  3  1.00E+00 (moc_north10)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 4  0.00E+00 (xx_hflux)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 5  0.00E+00 (xx_sflux)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   7.92157300281737E+07
+(PID.TID 0000.0001)  global fc =   1.39129889120086E+08
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  1.39129889120086E+08
 grad-res -------------------------------
  grad-res     0    4    4    1    1    1    1    1   1.39129889306E+08  1.39129889381E+08  1.39129889120E+08
- grad-res     0    4    4    4    0    1    1    1   2.02525138855E+01  1.30316540599E+01  3.56541408461E-01
+ grad-res     0    4    4    4    0    1    1    1   2.02525138855E+01  1.30313158035E+01  3.56558110405E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  1.39129889306469E+08
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.02525138854980E+01
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.30316540598869E+01
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  1.30313158035278E+01
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -6188,267 +6244,267 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk output (g):   1     2.5192321836948E+01  3.4007553100586E+01  2.5921392337650E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   2  1.3912988930647E+08  1.3912988966576E+08  1.3912988905625E+08
-(PID.TID 0000.0001) grdchk output (g):   2     3.0475223064423E+01  3.8703071594238E+01  2.1258903210774E-01
+(PID.TID 0000.0001) grdchk output (c):   2  1.3912988930647E+08  1.3912988966575E+08  1.3912988905625E+08
+(PID.TID 0000.0001) grdchk output (g):   2     3.0475138127804E+01  3.8703071594238E+01  2.1259122667823E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   3  1.3912988930647E+08  1.3912988951693E+08  1.3912988908240E+08
 (PID.TID 0000.0001) grdchk output (g):   3     2.1726705133915E+01  3.3190410614014E+01  3.4539209572956E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   4  1.3912988930647E+08  1.3912988938071E+08  1.3912988912008E+08
-(PID.TID 0000.0001) grdchk output (g):   4     1.3031654059887E+01  2.0252513885498E+01  3.5654140846098E-01
+(PID.TID 0000.0001) grdchk output (c):   4  1.3912988930647E+08  1.3912988938071E+08  1.3912988912009E+08
+(PID.TID 0000.0001) grdchk output (g):   4     1.3031315803528E+01  2.0252513885498E+01  3.5655811040530E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9950101434909E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9950637456532E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   153.32772823888808
-(PID.TID 0000.0001)         System time:  0.62169697601348162
-(PID.TID 0000.0001)     Wall clock time:   154.42149591445923
+(PID.TID 0000.0001)           User time:   98.337364981882274
+(PID.TID 0000.0001)         System time:  0.49612802453339100
+(PID.TID 0000.0001)     Wall clock time:   98.898498058319092
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.66065899003297091
-(PID.TID 0000.0001)         System time:   6.2516001053154469E-002
-(PID.TID 0000.0001)     Wall clock time:  0.77984595298767090
+(PID.TID 0000.0001)           User time:  0.55882802698761225
+(PID.TID 0000.0001)         System time:   6.8083997815847397E-002
+(PID.TID 0000.0001)     Wall clock time:  0.63069200515747070
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   70.469961702823639
-(PID.TID 0000.0001)         System time:  0.33519200235605240
-(PID.TID 0000.0001)     Wall clock time:   71.168704032897949
+(PID.TID 0000.0001)           User time:   44.755402743816376
+(PID.TID 0000.0001)         System time:  0.28405399620532990
+(PID.TID 0000.0001)     Wall clock time:   45.071977138519287
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   92.760003209114075
-(PID.TID 0000.0001)         System time:  0.11936400830745697
-(PID.TID 0000.0001)     Wall clock time:   93.012198448181152
+(PID.TID 0000.0001)           User time:   58.736835241317749
+(PID.TID 0000.0001)         System time:  0.14402706921100616
+(PID.TID 0000.0001)     Wall clock time:   58.910207033157349
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3876136541366577
-(PID.TID 0000.0001)         System time:   3.1891465187072754E-004
-(PID.TID 0000.0001)     Wall clock time:   1.3883330821990967
+(PID.TID 0000.0001)           User time:   1.0058454275131226
+(PID.TID 0000.0001)         System time:   9.1969966888427734E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0066308975219727
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6399582624435425
-(PID.TID 0000.0001)         System time:   1.9889041781425476E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6599578857421875
+(PID.TID 0000.0001)           User time:  0.44836235046386719
+(PID.TID 0000.0001)         System time:   3.1874954700469971E-002
+(PID.TID 0000.0001)     Wall clock time:  0.48049902915954590
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.5505572557449341
-(PID.TID 0000.0001)         System time:   1.9827082753181458E-002
-(PID.TID 0000.0001)     Wall clock time:   1.5705258846282959
+(PID.TID 0000.0001)           User time:  0.37239944934844971
+(PID.TID 0000.0001)         System time:   3.1750991940498352E-002
+(PID.TID 0000.0001)     Wall clock time:  0.40448832511901855
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.1535835266113281E-004
-(PID.TID 0000.0001)         System time:   2.0116567611694336E-006
-(PID.TID 0000.0001)     Wall clock time:   6.6089630126953125E-004
+(PID.TID 0000.0001)           User time:   3.9112567901611328E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8456916809082031E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15365684032440186
-(PID.TID 0000.0001)         System time:   5.7905912399291992E-005
-(PID.TID 0000.0001)     Wall clock time:  0.15373730659484863
+(PID.TID 0000.0001)           User time:  0.11096286773681641
+(PID.TID 0000.0001)         System time:   2.2499263286590576E-004
+(PID.TID 0000.0001)     Wall clock time:  0.11126303672790527
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3925762176513672E-002
-(PID.TID 0000.0001)         System time:   1.4066696166992188E-005
-(PID.TID 0000.0001)     Wall clock time:   4.3949127197265625E-002
+(PID.TID 0000.0001)           User time:   3.6606550216674805E-002
+(PID.TID 0000.0001)         System time:   4.0993094444274902E-005
+(PID.TID 0000.0001)     Wall clock time:   3.6676883697509766E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   19.133158802986145
-(PID.TID 0000.0001)         System time:   2.4017140269279480E-002
-(PID.TID 0000.0001)     Wall clock time:   19.236929178237915
+(PID.TID 0000.0001)           User time:   11.088436126708984
+(PID.TID 0000.0001)         System time:   1.9911974668502808E-002
+(PID.TID 0000.0001)     Wall clock time:   11.114445924758911
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   1.6288455724716187
-(PID.TID 0000.0001)         System time:   1.6303360462188721E-004
-(PID.TID 0000.0001)     Wall clock time:   1.6292259693145752
+(PID.TID 0000.0001)           User time:   1.1172113418579102
+(PID.TID 0000.0001)         System time:   4.3913722038269043E-005
+(PID.TID 0000.0001)     Wall clock time:   1.1179859638214111
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.1947913169860840
-(PID.TID 0000.0001)         System time:   1.3802945613861084E-004
-(PID.TID 0000.0001)     Wall clock time:   1.1951305866241455
+(PID.TID 0000.0001)           User time:  0.82783067226409912
+(PID.TID 0000.0001)         System time:   1.7911195755004883E-005
+(PID.TID 0000.0001)     Wall clock time:  0.82832813262939453
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.8754146099090576
-(PID.TID 0000.0001)         System time:   3.8480162620544434E-003
-(PID.TID 0000.0001)     Wall clock time:   3.9232757091522217
+(PID.TID 0000.0001)           User time:   2.8424186706542969
+(PID.TID 0000.0001)         System time:   4.1190236806869507E-003
+(PID.TID 0000.0001)     Wall clock time:   2.8481011390686035
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   17.887591838836670
-(PID.TID 0000.0001)         System time:   3.5270452499389648E-003
-(PID.TID 0000.0001)     Wall clock time:   17.910508394241333
+(PID.TID 0000.0001)           User time:   14.220037102699280
+(PID.TID 0000.0001)         System time:   1.1499226093292236E-004
+(PID.TID 0000.0001)     Wall clock time:   14.227292537689209
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7847299575805664
-(PID.TID 0000.0001)         System time:   4.9769878387451172E-006
-(PID.TID 0000.0001)     Wall clock time:   4.7850475311279297
+(PID.TID 0000.0001)           User time:  0.36616539955139160
+(PID.TID 0000.0001)         System time:   9.0301036834716797E-006
+(PID.TID 0000.0001)     Wall clock time:  0.36631798744201660
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4537620544433594
+(PID.TID 0000.0001)           User time:  0.96930897235870361
 (PID.TID 0000.0001)         System time:   9.8347663879394531E-007
-(PID.TID 0000.0001)     Wall clock time:   1.4538743495941162
+(PID.TID 0000.0001)     Wall clock time:  0.97004699707031250
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.44031381607055664
-(PID.TID 0000.0001)         System time:   1.0013580322265625E-005
-(PID.TID 0000.0001)     Wall clock time:  0.44041037559509277
+(PID.TID 0000.0001)           User time:  0.30410146713256836
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.30421853065490723
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.97454524040222168
-(PID.TID 0000.0001)         System time:   1.2025237083435059E-005
-(PID.TID 0000.0001)     Wall clock time:  0.97469234466552734
+(PID.TID 0000.0001)           User time:  0.47780835628509521
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.47793793678283691
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.4007282257080078E-002
-(PID.TID 0000.0001)         System time:   3.0100345611572266E-006
-(PID.TID 0000.0001)     Wall clock time:   6.4037799835205078E-002
+(PID.TID 0000.0001)           User time:   4.5428991317749023E-002
+(PID.TID 0000.0001)         System time:   5.5006146430969238E-004
+(PID.TID 0000.0001)     Wall clock time:   4.6017169952392578E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0492265224456787
-(PID.TID 0000.0001)         System time:   5.1783859729766846E-002
-(PID.TID 0000.0001)     Wall clock time:   7.1016087532043457
+(PID.TID 0000.0001)           User time:   1.4170210361480713
+(PID.TID 0000.0001)         System time:   6.2044069170951843E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4797990322113037
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   19.788265705108643
-(PID.TID 0000.0001)         System time:   3.7770271301269531E-003
-(PID.TID 0000.0001)     Wall clock time:   19.823973655700684
+(PID.TID 0000.0001)           User time:   15.064396619796753
+(PID.TID 0000.0001)         System time:   2.5694072246551514E-004
+(PID.TID 0000.0001)     Wall clock time:   15.073478937149048
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0476531982421875E-004
-(PID.TID 0000.0001)         System time:   3.0398368835449219E-006
-(PID.TID 0000.0001)     Wall clock time:   7.1263313293457031E-004
+(PID.TID 0000.0001)           User time:   4.1270256042480469E-004
+(PID.TID 0000.0001)         System time:   9.8347663879394531E-007
+(PID.TID 0000.0001)     Wall clock time:   4.2295455932617188E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.23606920242309570
-(PID.TID 0000.0001)         System time:   3.9189606904983521E-003
-(PID.TID 0000.0001)     Wall clock time:  0.24002695083618164
+(PID.TID 0000.0001)           User time:  0.13062405586242676
+(PID.TID 0000.0001)         System time:   4.5010149478912354E-003
+(PID.TID 0000.0001)     Wall clock time:  0.13550853729248047
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.8126449584960938E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.4182281494140625E-004
+(PID.TID 0000.0001)           User time:   3.5607814788818359E-004
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
+(PID.TID 0000.0001)     Wall clock time:   3.6263465881347656E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.20962476730346680
-(PID.TID 0000.0001)         System time:   9.9986791610717773E-006
-(PID.TID 0000.0001)     Wall clock time:  0.20949602127075195
+(PID.TID 0000.0001)           User time:   9.8802566528320312E-002
+(PID.TID 0000.0001)         System time:   4.0099918842315674E-003
+(PID.TID 0000.0001)     Wall clock time:  0.10260176658630371
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14933872222900391
-(PID.TID 0000.0001)         System time:   1.1914998292922974E-002
-(PID.TID 0000.0001)     Wall clock time:  0.16146206855773926
+(PID.TID 0000.0001)           User time:   8.3706259727478027E-002
+(PID.TID 0000.0001)         System time:   1.9970998167991638E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10369491577148438
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.94677829742431641
-(PID.TID 0000.0001)         System time:   3.1959995627403259E-002
-(PID.TID 0000.0001)     Wall clock time:  0.99551630020141602
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.72676372528076172
+(PID.TID 0000.0001)         System time:   3.9910078048706055E-003
+(PID.TID 0000.0001)     Wall clock time:  0.73091602325439453
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.40578174591064453
-(PID.TID 0000.0001)         System time:   8.0260485410690308E-003
-(PID.TID 0000.0001)     Wall clock time:  0.42324090003967285
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.28517961502075195
+(PID.TID 0000.0001)         System time:   1.5982016921043396E-002
+(PID.TID 0000.0001)     Wall clock time:  0.30129647254943848
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.13630676269531250
-(PID.TID 0000.0001)         System time:   8.0020129680633545E-003
-(PID.TID 0000.0001)     Wall clock time:  0.17308616638183594
+(PID.TID 0000.0001)           User time:  0.13434982299804688
+(PID.TID 0000.0001)         System time:   7.9840123653411865E-003
+(PID.TID 0000.0001)     Wall clock time:  0.14236903190612793
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.14049530029296875
-(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
-(PID.TID 0000.0001)     Wall clock time:  0.14191508293151855
+(PID.TID 0000.0001)           User time:  0.13364028930664062
+(PID.TID 0000.0001)         System time:   8.0109834671020508E-003
+(PID.TID 0000.0001)     Wall clock time:  0.14197087287902832
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   81.920249938964844
-(PID.TID 0000.0001)         System time:  0.21597698330879211
-(PID.TID 0000.0001)     Wall clock time:   82.157882928848267
+(PID.TID 0000.0001)           User time:   52.755092620849609
+(PID.TID 0000.0001)         System time:  0.12798503041267395
+(PID.TID 0000.0001)     Wall clock time:   52.911437988281250
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.2278060913085938
-(PID.TID 0000.0001)         System time:   6.4456939697265625E-002
-(PID.TID 0000.0001)     Wall clock time:   5.2929818630218506
+(PID.TID 0000.0001)           User time:   3.9397926330566406
+(PID.TID 0000.0001)         System time:   3.1959980726242065E-002
+(PID.TID 0000.0001)     Wall clock time:   3.9738984107971191
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   76.660484313964844
-(PID.TID 0000.0001)         System time:  0.14803907275199890
-(PID.TID 0000.0001)     Wall clock time:   76.816479921340942
+(PID.TID 0000.0001)           User time:   48.783340454101562
+(PID.TID 0000.0001)         System time:   9.6019029617309570E-002
+(PID.TID 0000.0001)     Wall clock time:   48.905551910400391
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   3.4363327026367188
-(PID.TID 0000.0001)         System time:   2.7976006269454956E-002
-(PID.TID 0000.0001)     Wall clock time:   3.4661464691162109
+(PID.TID 0000.0001)           User time:   1.2253303527832031
+(PID.TID 0000.0001)         System time:   8.0499649047851562E-003
+(PID.TID 0000.0001)     Wall clock time:   1.2352185249328613
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   8.1863403320312500E-003
-(PID.TID 0000.0001)         System time:   7.0631504058837891E-006
-(PID.TID 0000.0001)     Wall clock time:   8.2485675811767578E-003
+(PID.TID 0000.0001)           User time:   5.9814453125000000E-003
+(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
+(PID.TID 0000.0001)     Wall clock time:   5.9447288513183594E-003
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   71.646354675292969
-(PID.TID 0000.0001)         System time:   8.0085992813110352E-002
-(PID.TID 0000.0001)     Wall clock time:   71.732550382614136
+(PID.TID 0000.0001)           User time:   46.486518859863281
+(PID.TID 0000.0001)         System time:   6.8000048398971558E-002
+(PID.TID 0000.0001)     Wall clock time:   46.577553510665894
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.38445281982421875
-(PID.TID 0000.0001)         System time:   3.9979815483093262E-003
-(PID.TID 0000.0001)     Wall clock time:  0.38848400115966797
+(PID.TID 0000.0001)           User time:  0.15462493896484375
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.15577054023742676
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1367797851562500E-003
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:   1.1327266693115234E-003
+(PID.TID 0000.0001)           User time:   7.1716308593750000E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.2407722473144531E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.1661682128906250
-(PID.TID 0000.0001)         System time:   3.5958051681518555E-002
-(PID.TID 0000.0001)     Wall clock time:   1.2021808624267578
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:  0.89562606811523438
+(PID.TID 0000.0001)         System time:   1.9960016012191772E-002
+(PID.TID 0000.0001)     Wall clock time:  0.91576838493347168
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   5.7144165039062500E-003
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-006
-(PID.TID 0000.0001)     Wall clock time:   5.7218074798583984E-003
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   5.5427551269531250E-003
+(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
+(PID.TID 0000.0001)     Wall clock time:   5.5611133575439453E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6488,9 +6544,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         244112
+(PID.TID 0000.0001) //            No. barriers =         244092
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         244112
+(PID.TID 0000.0001) //     Total barrier spins =         244092
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_cs32/results/output_adm.txt
+++ b/global_oce_cs32/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69j
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Dec 25 16:22:59 EST 2025
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 10:54:07 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -783,11 +783,10 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEuseMetricTerms = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -1767,8 +1766,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -1951,6 +1950,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
@@ -2235,6 +2237,9 @@
 (PID.TID 0000.0001)       preprocess = rmcycle
 (PID.TID 0000.0001)         param. (int.)=      2
 (PID.TID 0000.0001)       preprocess = WC01
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -4460,7 +4465,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   7.7220921237260E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -6.4941547703982E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874425E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.2880529874426E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.8092937315121E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.2533470859263E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.2884747902342E-01
@@ -4506,7 +4511,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746079982E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854223E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823556648655E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328655665451E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328655665452E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4517,7 +4522,7 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0677224251052E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0677224251053E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.0561021612741E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3843152618827E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
@@ -4631,11 +4636,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.87992650799733E-01  7.97821468767044E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300438E-01  7.74858747615991E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.84404459441547E-01
+ cg2d: Sum(rhs),rhsMax =   2.87992650799731E-01  7.97821468767044E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300431E-01  7.74858747615990E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.84404459441544E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      47
-(PID.TID 0000.0001)      cg2d_last_res =   9.19496287074656E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19496287074642E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4643,7 +4648,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890399859476E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303095657177E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5316966869627E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5316966869630E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1483051158071E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1622406823897E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6559728187354E-01
@@ -4673,7 +4678,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3772566990058E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.1338171517743E-03
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5802354497477E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240911757E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1640240911756E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.4564500167921E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   9.8555597219715E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.2173753949865E-01
@@ -4689,7 +4694,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737833612E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623570993E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959017430E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276265061556E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276265061567E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4815,10 +4820,10 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   4.95270753311019E-01  7.65934820675236E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207482506E-01  7.61970515877181E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.51870870684699E-01
+ cg2d: Sum(rhs),rhsMax =   5.92660207482520E-01  7.61970515877186E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.51870870684693E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      46
-(PID.TID 0000.0001)      cg2d_last_res =   9.43883227761028E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.43883227760983E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4829,7 +4834,7 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206935E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527919085E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463461580090E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901465213E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901465211E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680926573E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510302348038E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436491859088E-02
@@ -4841,7 +4846,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188719804444E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487115575E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840646586E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673510500975E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673510500982E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943369582164E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264808108150E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706944E+01
@@ -4853,11 +4858,11 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8981819416167E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726333694657E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067567206882E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088836774E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576152252E-03
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088836775E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576152248E-03
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681575436E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550012920689E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686365119E-03
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686365117E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534733322E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209520170E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925323475E-01
@@ -4871,8 +4876,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771506334E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734511739E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484263698E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614782964016E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210451893675E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614782964014E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210451893047E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4929,7 +4934,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891369987E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909459000E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387149987E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539017089E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539017090E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342284317846E-07
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796477E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781655E-08
@@ -4964,7 +4969,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046679E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104752E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172419E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594357E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594356E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197745550E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371846E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764647E-08
@@ -4997,11 +5002,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   6.88070042799517E-01  7.59584828994187E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243680696E-01  7.57582533116074E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.57970833906411E-01
+ cg2d: Sum(rhs),rhsMax =   6.88070042799573E-01  7.59584828994177E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243680671E-01  7.57582533116067E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.57970833906427E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      46
-(PID.TID 0000.0001)      cg2d_last_res =   8.72165674874134E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.72165674873427E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5012,7 +5017,7 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993124E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977403021025E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361004056978E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754371174E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754371170E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152033571924E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089658606654E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499029751211E-02
@@ -5026,7 +5031,7 @@
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786384335E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072405465265E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644189430346E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246311413E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246311412E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185599E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458180603E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892053E+00
@@ -5036,17 +5041,17 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439292116E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726336750298E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222985484E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976413609E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976413610E-04
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502778593E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601919657E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633162380E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753295838550E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633162381E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753295838545E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356029118E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446514695E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745471558E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.8987366598998E-04
 (PID.TID 0000.0001) %MON ke_max                       =   5.3813407931395E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.2893724685645E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   5.2893724685644E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542976161516E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -4.4706133438089E-06
 (PID.TID 0000.0001) %MON vort_r_max                   =   4.7511635093729E-06
@@ -5054,8 +5059,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943442E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316408E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538645657E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826895112E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326267299603E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826895125E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326267299667E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5066,12 +5071,12 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015706083E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015706084E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425196443E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935392124E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032167482683E-02
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.6032167482682E-02
 (PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9397438201898E-01
 (PID.TID 0000.0001) %MON seaice_vice_del2             =   2.4451765116121E-03
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.6121956409117E-01
@@ -5079,15 +5084,15 @@
 (PID.TID 0000.0001) %MON seaice_area_mean             =   3.4332297665618E-03
 (PID.TID 0000.0001) %MON seaice_area_sd               =   1.8035737713302E-02
 (PID.TID 0000.0001) %MON seaice_area_del2             =   1.6753780942344E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283725507E-02
+(PID.TID 0000.0001) %MON seaice_heff_max              =   7.3542283725506E-02
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.4331232104455E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   7.8738037375310E-03
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   7.0030891670950E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657520899E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587134E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146826E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587133E-07
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146827E-06
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095039265E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
@@ -5099,44 +5104,55 @@
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391966868D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973460975100D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391966868D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644038515654D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722019017134D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894343817657D+05
-(PID.TID 0000.0001) Writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473214878274D+04
-(PID.TID 0000.0001)  global fc =  0.331894343817657D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973460975100E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391966868E+04  1  2  1.00E+00
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644038515654E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48722019017134E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473214878274E+03
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   3.31894343817657E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) whio : write lev 2 rec   1
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689202E-01  6.80494402321960E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537588E-01  8.23075697484955E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799742E-01  7.97821468767062E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300474E-01  7.74858747615994E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799723E-01  7.97821468767062E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300477E-01  7.74858747615995E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   4.95270753311090E-01  7.65934820675229E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207482545E-01  7.61970515877196E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042799509E-01  7.59584828994228E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243680685E-01  7.57582533116121E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753311083E-01  7.65934820675233E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207482574E-01  7.61970515877206E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042799527E-01  7.59584828994222E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243680710E-01  7.57582533116127E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
- cg2d: Sum(rhs),rhsMax =   4.95270620995271E-01  7.65935025998748E+00
- cg2d: Sum(rhs),rhsMax =   5.92660475395590E-01  7.61970724306709E+00
- cg2d: Sum(rhs),rhsMax =   6.88070473820577E-01  7.59585024200483E+00
- cg2d: Sum(rhs),rhsMax =   7.82661729692801E-01  7.57582726826315E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270620995285E-01  7.65935025998748E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660475395579E-01  7.61970724306709E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070473820574E-01  7.59585024200483E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661729692791E-01  7.57582726826315E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  Calling cg2d from S/R CG2D_MAD
  cg2d: Sum(rhs),rhsMax =   3.55271367880050E-15  2.69820681560877E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -5.21804821573824E-15  3.63339520242778E-03
+ cg2d: Sum(rhs),rhsMax =  -3.44169137633799E-15  3.63339520242778E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5144,7 +5160,7 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7045337537243E-01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2105185264483E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6367239275267E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6367239275270E-04
 (PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8157598344035E-02
 (PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3143093306287E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1218851813390E-01
@@ -5165,7 +5181,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.6946736696820E-04
 (PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.3345665282855E-04
 (PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6228171838034E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584140456E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584140455E-05
 (PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.3311872051252E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
@@ -5182,7 +5198,7 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8721406077750E-02
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1342764875801E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1395601493684E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -6.0189355824486E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -6.0189355824485E-03
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0501305394603E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0663774579512E-03
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3082629986706E+01
@@ -5199,7 +5215,7 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4401545318305E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.5695883007646E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6738905626461E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691863714651E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691863714650E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1325180910331E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.3217398715748E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.1583823271522E-02
@@ -5225,7 +5241,7 @@
 (PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0870237942785E-05
 (PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378915894083E-02
 (PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1451095551669E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.7357533449625E-06
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.7357533449603E-06
 (PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0913172371214E-03
 (PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3911927948773E-04
 (PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1559218914596E+02
@@ -5237,21 +5253,21 @@
 (PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5242189980498E+01
 (PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3474524594115E+00
 (PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015608544014E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879285584804E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879285584803E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -7.20257187225570E-15  7.18267427172082E-03
+ cg2d: Sum(rhs),rhsMax =  -7.49400541621981E-16  7.18267427172082E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -7.99360577730113E-15  3.65368418840652E-03
+ cg2d: Sum(rhs),rhsMax =   2.99760216648792E-15  3.65368418840651E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689202E-01  6.80494402321960E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537588E-01  8.23075697484955E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799742E-01  7.97821468767062E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300474E-01  7.74858747615994E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799723E-01  7.97821468767062E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300477E-01  7.74858747615995E+00
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   3.55271367880050E-15  4.17414199128834E-03
+ cg2d: Sum(rhs),rhsMax =  -1.33226762955019E-15  4.17414199128834E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5271,7 +5287,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2933733622022E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6167081762205E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459234437588E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615165665889E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615165665890E-06
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5714508527757E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5830837285141E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.8955919846182E+00
@@ -5357,11 +5373,11 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   8.04911692853238E-16  4.27053409103838E-03
+ cg2d: Sum(rhs),rhsMax =  -2.30371277609720E-15  4.27053409103837E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   3.60822483003176E-16  5.79944903126073E-03
+ cg2d: Sum(rhs),rhsMax =   1.77635683940025E-15  5.79944903126073E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   2.88657986402541E-15  4.44099757422374E-03
+ cg2d: Sum(rhs),rhsMax =   2.27595720048157E-15  4.44099757422374E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5429,7 +5445,7 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   6.4368698051295E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700858060010E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0169554383020E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4861128796401E+00
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4861128796441E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.5867422157369E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3391543630407E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6756320589923E-03
@@ -5448,7 +5464,7 @@
 (PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1069734675302E-04
 (PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890407620056E-01
 (PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5618406633246E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9591900913329E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9591900913330E-05
 (PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1006181750318E-02
 (PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9937130331444E-04
 (PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1713742643341E-01
@@ -5493,12 +5509,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689274E-01  6.80494402321544E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537750E-01  8.23075697484161E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800128E-01  7.97821468765922E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301181E-01  7.74858747614565E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312099E-01  7.65934820673534E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207483988E-01  7.61970515875245E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042801296E-01  7.59584828992048E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243682657E-01  7.57582533113800E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800145E-01  7.97821468765922E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301184E-01  7.74858747614568E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312116E-01  7.65934820673533E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207483927E-01  7.61970515875250E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042801311E-01  7.59584828992035E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243682654E-01  7.57582533113793E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5506,21 +5522,26 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391963641D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973461356606D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391963641D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644037167145D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722092536889D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894351069705D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473274856484D+04
-(PID.TID 0000.0001)  global fc =  0.331894351069705D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973461356606E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391963641E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644037167145E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48722092536889E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473274856484E+03
+(PID.TID 0000.0001)  global fc =   3.31894351069705E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894351069705E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5532,12 +5553,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689136E-01  6.80494402322376E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537402E-01  8.23075697485752E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799293E-01  7.97821468768214E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299688E-01  7.74858747617459E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309988E-01  7.65934820676950E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207481092E-01  7.61970515879129E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042797769E-01  7.59584828996342E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243678739E-01  7.57582533118378E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799286E-01  7.97821468768214E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299696E-01  7.74858747617459E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309963E-01  7.65934820676950E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207481075E-01  7.61970515879129E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042797786E-01  7.59584828996338E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243678646E-01  7.57582533118370E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5545,28 +5566,33 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391970101D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973460593566D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391970101D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644039576992D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448721952150827D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894337202240D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473158672573D+04
-(PID.TID 0000.0001)  global fc =  0.331894337202240D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973460593566E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391970101E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644039576992E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48721952150827E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473158672573E+03
+(PID.TID 0000.0001)  global fc =   3.31894337202240E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894337202240E+04
 grad-res -------------------------------
  grad-res     0    1    1    1    1    1    1    1   3.31894343818E+04  3.31894351070E+04  3.31894337202E+04
- grad-res     0    1    1    1    0    1    1    1   5.09827286005E-02  6.93373236572E-02 -3.60015941880E-01
+ grad-res     0    1    1    1    0    1    1    1   5.09827286005E-02  6.93373240210E-02 -3.60015949016E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09827286005020E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.93373236572370E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.93373240210349E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2         594           2
@@ -5583,12 +5609,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689302E-01  6.80494402321359E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537837E-01  8.23075697483809E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800351E-01  7.97821468765414E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301557E-01  7.74858747613875E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312621E-01  7.65934820672700E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207484663E-01  7.61970515874314E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042802163E-01  7.59584828991020E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243683631E-01  7.57582533112685E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800344E-01  7.97821468765414E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301554E-01  7.74858747613875E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312631E-01  7.65934820672701E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207484599E-01  7.61970515874313E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042802202E-01  7.59584828991022E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243683648E-01  7.57582533112692E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5596,21 +5622,26 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391966838D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973461477186D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391966838D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644036735596D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722083271941D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894350115311D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473285494048D+04
-(PID.TID 0000.0001)  global fc =  0.331894350115311D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973461477186E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391966838E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644036735596E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48722083271941E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473285494048E+03
+(PID.TID 0000.0001)  global fc =   3.31894350115311E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894350115311E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5622,12 +5653,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689107E-01  6.80494402322561E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537318E-01  8.23075697486113E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799099E-01  7.97821468768740E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299305E-01  7.74858747618163E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309459E-01  7.65934820677783E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207480353E-01  7.61970515880055E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042796905E-01  7.59584828997387E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243677666E-01  7.57582533119499E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799124E-01  7.97821468768741E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299312E-01  7.74858747618166E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309448E-01  7.65934820677782E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207480392E-01  7.61970515880061E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042796863E-01  7.59584828997374E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243677715E-01  7.57582533119476E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5635,28 +5666,33 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391966904D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973460473044D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391966904D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644040423286D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448721949865185D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894337043056D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473143170988D+04
-(PID.TID 0000.0001)  global fc =  0.331894337043056D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973460473044E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391966904E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644040423286E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48721949865185E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473143170988E+03
+(PID.TID 0000.0001)  global fc =   3.31894337043056E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894337043056E+04
 grad-res -------------------------------
  grad-res     0    2    2    1    1    1    1    1   3.31894343818E+04  3.31894350115E+04  3.31894337043E+04
- grad-res     0    2    2    2    0    1    1    1   4.96749877930E-02  6.53612747556E-02 -3.15778375789E-01
+ grad-res     0    2    2    2    0    1    1    1   4.96749877930E-02  6.53612754832E-02 -3.15778390436E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.96749877929688E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.53612747555599E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.53612754831556E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   2 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   3 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            3         594           3
@@ -5674,11 +5710,11 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =   1.13674863689321E-01  6.80494402321269E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537874E-01  8.23075697483626E+00
  cg2d: Sum(rhs),rhsMax =   2.87992650800442E-01  7.97821468765121E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301735E-01  7.74858747613507E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312870E-01  7.65934820672279E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207485068E-01  7.61970515873797E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042802590E-01  7.59584828990426E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243684217E-01  7.57582533112054E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301777E-01  7.74858747613505E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312873E-01  7.65934820672280E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207485036E-01  7.61970515873796E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042802654E-01  7.59584828990425E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243684203E-01  7.57582533112046E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5686,22 +5722,27 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391968475D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973461501911D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391968475D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644035348534D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722054827089D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894347136228D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473274404412D+04
-(PID.TID 0000.0001)  global fc =  0.331894347136228D+05
-(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894347136228E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973461501911E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391968475E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644035347867E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48722054827089E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473274403745E+03
+(PID.TID 0000.0001)  global fc =   3.31894347136162E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894347136162E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
 (PID.TID 0000.0001) 
@@ -5712,12 +5753,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689084E-01  6.80494402322651E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537270E-01  8.23075697486299E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650798966E-01  7.97821468769039E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299138E-01  7.74858747618519E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309200E-01  7.65934820678222E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207480062E-01  7.61970515880569E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042796419E-01  7.59584828997955E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243677154E-01  7.57582533120111E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650798975E-01  7.97821468769039E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299116E-01  7.74858747618519E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309185E-01  7.65934820678221E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207480051E-01  7.61970515880569E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042796429E-01  7.59584828997952E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243677140E-01  7.57582533120106E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5725,28 +5766,33 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391965265D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973460448319D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391965265D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644041440551D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448721984345466D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894340588699D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473158078685D+04
-(PID.TID 0000.0001)  global fc =  0.331894340588699D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973460448319E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391965265E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644041440551E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48721984345466E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473158078685E+03
+(PID.TID 0000.0001)  global fc =   3.31894340588699E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894340588699E+04
 grad-res -------------------------------
  grad-res     0    3    3    1    1    1    1    1   3.31894343818E+04  3.31894347136E+04  3.31894340589E+04
- grad-res     0    3    3    3    0    1    1    1   2.86160372198E-02  3.27376474161E-02 -1.44031480133E-01
+ grad-res     0    3    3    3    0    1    1    1   2.86160372198E-02  3.27373145410E-02 -1.44019847668E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.86160372197628E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27376474160701E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27373145410093E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4         594           4
@@ -5763,12 +5809,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689329E-01  6.80494402321186E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537919E-01  8.23075697483461E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800545E-01  7.97821468764866E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301920E-01  7.74858747613166E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800554E-01  7.97821468764866E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301902E-01  7.74858747613166E+00
  cg2d: Sum(rhs),rhsMax =   4.95270753313171E-01  7.65934820671813E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207485469E-01  7.61970515873197E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042803190E-01  7.59584828989767E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243684874E-01  7.57582533111279E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207485430E-01  7.61970515873198E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042803190E-01  7.59584828989755E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243684906E-01  7.57582533111277E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5776,21 +5822,26 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391968861D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973461444339D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391968861D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644034039826D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722023437674D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894343861045D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473249727557D+04
-(PID.TID 0000.0001)  global fc =  0.331894343861045D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973461444339E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391968861E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644034039826E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48722023437674E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473249727557E+03
+(PID.TID 0000.0001)  global fc =   3.31894343861045E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(+)fc: fcpertplus  =  3.31894343861045E+04
 (PID.TID 0000.0001) Start initial hydrostatic pressure computation
 (PID.TID 0000.0001) Pressure is predetermined for buoyancyRelation OCEANIC
@@ -5802,12 +5853,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689076E-01  6.80494402322734E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537231E-01  8.23075697486459E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650798902E-01  7.97821468769250E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103298978E-01  7.74858747618816E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753308915E-01  7.65934820678655E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207479621E-01  7.61970515881125E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042795850E-01  7.59584828998597E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243676444E-01  7.57582533120898E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650798884E-01  7.97821468769249E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103298974E-01  7.74858747618816E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753308908E-01  7.65934820678656E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207479643E-01  7.61970515881127E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042795839E-01  7.59584828998612E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243676444E-01  7.57582533120883E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5815,28 +5866,33 @@ grad-res -------------------------------
 (PID.TID 0000.0001)  profiles_cost( 1, 2) =  0.229260391964885D+05 0.185786000000000D+06
 (PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_profiles = 0.134973460505734D+04 1 1
-(PID.TID 0000.0001)  --> f_profiles = 0.229260391964885D+05 1 2
-(PID.TID 0000.0001)  --> f_gencost = 0.442644042803301D+04 1
-(PID.TID 0000.0001)  --> f_gencost = 0.448722009096924D+04 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.999999955296517D-04 1
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_gentim2d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.331894343205481D+05
-(PID.TID 0000.0001) Not writing cost function info to costfunction0000
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.142473175104049D+04
-(PID.TID 0000.0001)  global fc =  0.331894343205481D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001)  --> f_profiles =  1.34973460505734E+03  1  1  1.00E+00
+(PID.TID 0000.0001)  --> f_profiles =  2.29260391964885E+04  1  2  1.00E+00
+(PID.TID 0000.0001)  --> f_gencost  =  4.42644042803301E+03  1  1.00E+00 (etastep)
+(PID.TID 0000.0001)  --> f_gencost  =  4.48722009096924E+03  2  1.00E+00 (sststep)
+(PID.TID 0000.0001)  skip writing to costfunction_ecco.XXXX
+(PID.TID 0000.0001)  --> f_gentim2d =  9.99999955296517E-05 1  0.00E+00 (xx_atempA)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 2  0.00E+00 (xx_atempB)
+(PID.TID 0000.0001)  --> f_gentim2d =  0.00000000000000E+00 3  0.00E+00 (xx_atempC)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_theta)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_salt)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.42473175104049E+03
+(PID.TID 0000.0001)  global fc =   3.31894343205481E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894343205481E+04
 grad-res -------------------------------
  grad-res     0    4    4    1    1    1    1    1   3.31894343818E+04  3.31894343861E+04  3.31894343205E+04
- grad-res     0    4    4    4    0    1    1    1   4.69273794442E-03  3.27782072418E-03  3.01512088892E-01
+ grad-res     0    4    4    4    0    1    1    1   4.69273794442E-03  3.27781999658E-03  3.01512243939E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.69273794442415E-03
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27782072417904E-03
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27781999658328E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -5851,270 +5907,270 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   1  3.3189434381766E+04  3.3189435106970E+04  3.3189433720224E+04
-(PID.TID 0000.0001) grdchk output (g):   1     6.9337323657237E-02  5.0982728600502E-02 -3.6001594188025E-01
+(PID.TID 0000.0001) grdchk output (g):   1     6.9337324021035E-02  5.0982728600502E-02 -3.6001594901596E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   2  3.3189434381766E+04  3.3189435011531E+04  3.3189433704306E+04
-(PID.TID 0000.0001) grdchk output (g):   2     6.5361274755560E-02  4.9674987792969E-02 -3.1577837578878E-01
+(PID.TID 0000.0001) grdchk output (g):   2     6.5361275483156E-02  4.9674987792969E-02 -3.1577839043590E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
-(PID.TID 0000.0001) grdchk output (c):   3  3.3189434381766E+04  3.3189434713623E+04  3.3189434058870E+04
-(PID.TID 0000.0001) grdchk output (g):   3     3.2737647416070E-02  2.8616037219763E-02 -1.4403148013313E-01
+(PID.TID 0000.0001) grdchk output (c):   3  3.3189434381766E+04  3.3189434713616E+04  3.3189434058870E+04
+(PID.TID 0000.0001) grdchk output (g):   3     3.2737314541009E-02  2.8616037219763E-02 -1.4401984766780E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   4  3.3189434381766E+04  3.3189434386105E+04  3.3189434320548E+04
-(PID.TID 0000.0001) grdchk output (g):   4     3.2778207241790E-03  4.6927379444242E-03  3.0151208889180E-01
+(PID.TID 0000.0001) grdchk output (g):   4     3.2778199965833E-03  4.6927379444242E-03  3.0151224393897E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9196834932958E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9196696096456E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   146.91302276588976
-(PID.TID 0000.0001)         System time:  0.70996398199349642
-(PID.TID 0000.0001)     Wall clock time:   150.36704301834106
+(PID.TID 0000.0001)           User time:   97.206560136750340
+(PID.TID 0000.0001)         System time:  0.44249100424349308
+(PID.TID 0000.0001)     Wall clock time:   98.141612052917480
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.57799199223518372
-(PID.TID 0000.0001)         System time:   7.0148997008800507E-002
-(PID.TID 0000.0001)     Wall clock time:  0.83146595954895020
+(PID.TID 0000.0001)           User time:  0.46267701406031847
+(PID.TID 0000.0001)         System time:   3.4939999692142010E-002
+(PID.TID 0000.0001)     Wall clock time:  0.50069880485534668
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   72.732129037380219
-(PID.TID 0000.0001)         System time:  0.41175201535224915
-(PID.TID 0000.0001)     Wall clock time:   75.559532880783081
+(PID.TID 0000.0001)           User time:   43.733761817216873
+(PID.TID 0000.0001)         System time:  0.25557598844170570
+(PID.TID 0000.0001)     Wall clock time:   44.013284921646118
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   82.868281006813049
-(PID.TID 0000.0001)         System time:  0.10422703623771667
-(PID.TID 0000.0001)     Wall clock time:   83.162929296493530
+(PID.TID 0000.0001)           User time:   58.588659644126892
+(PID.TID 0000.0001)         System time:   7.5638011097908020E-002
+(PID.TID 0000.0001)     Wall clock time:   58.693045377731323
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0408577919006348
-(PID.TID 0000.0001)         System time:   5.9713423252105713E-004
-(PID.TID 0000.0001)     Wall clock time:   1.0480573177337646
+(PID.TID 0000.0001)           User time:  0.99812769889831543
+(PID.TID 0000.0001)         System time:   9.3996524810791016E-005
+(PID.TID 0000.0001)     Wall clock time:  0.99895668029785156
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9163385629653931
-(PID.TID 0000.0001)         System time:   1.6146048903465271E-002
-(PID.TID 0000.0001)     Wall clock time:   1.9636480808258057
+(PID.TID 0000.0001)           User time:  0.48167109489440918
+(PID.TID 0000.0001)         System time:   4.0410012006759644E-003
+(PID.TID 0000.0001)     Wall clock time:  0.48574304580688477
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.8686292171478271
-(PID.TID 0000.0001)         System time:   1.4647081494331360E-002
-(PID.TID 0000.0001)     Wall clock time:   1.9055383205413818
+(PID.TID 0000.0001)           User time:  0.43381047248840332
+(PID.TID 0000.0001)         System time:   3.9920210838317871E-003
+(PID.TID 0000.0001)     Wall clock time:  0.43789386749267578
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.1641464233398438E-004
-(PID.TID 0000.0001)         System time:   9.8347663879394531E-007
-(PID.TID 0000.0001)     Wall clock time:   5.5694580078125000E-004
+(PID.TID 0000.0001)           User time:   4.0316581726074219E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8599967956542969E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.14732515811920166
-(PID.TID 0000.0001)         System time:   2.7954578399658203E-005
-(PID.TID 0000.0001)     Wall clock time:  0.14733266830444336
+(PID.TID 0000.0001)           User time:  0.10829925537109375
+(PID.TID 0000.0001)         System time:   2.4981796741485596E-005
+(PID.TID 0000.0001)     Wall clock time:  0.10835862159729004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4093737602233887E-002
-(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
-(PID.TID 0000.0001)     Wall clock time:   3.4077644348144531E-002
+(PID.TID 0000.0001)           User time:   3.6279916763305664E-002
+(PID.TID 0000.0001)         System time:   1.1987984180450439E-005
+(PID.TID 0000.0001)     Wall clock time:   3.6309480667114258E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   17.618304610252380
-(PID.TID 0000.0001)         System time:   4.6895787119865417E-002
-(PID.TID 0000.0001)     Wall clock time:   17.732823371887207
+(PID.TID 0000.0001)           User time:   11.228682875633240
+(PID.TID 0000.0001)         System time:   1.5842020511627197E-002
+(PID.TID 0000.0001)     Wall clock time:   11.250275850296021
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   1.5991832017898560
-(PID.TID 0000.0001)         System time:   7.2130113840103149E-003
-(PID.TID 0000.0001)     Wall clock time:   1.6490674018859863
+(PID.TID 0000.0001)           User time:   1.1132563352584839
+(PID.TID 0000.0001)         System time:   4.1998922824859619E-005
+(PID.TID 0000.0001)     Wall clock time:   1.1142530441284180
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   1.1804434061050415
-(PID.TID 0000.0001)         System time:   7.1799904108047485E-003
-(PID.TID 0000.0001)     Wall clock time:   1.2250840663909912
+(PID.TID 0000.0001)           User time:  0.82263386249542236
+(PID.TID 0000.0001)         System time:   1.9006431102752686E-005
+(PID.TID 0000.0001)     Wall clock time:  0.82344079017639160
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.9795036315917969
-(PID.TID 0000.0001)         System time:   2.8073787689208984E-005
-(PID.TID 0000.0001)     Wall clock time:   2.9814248085021973
+(PID.TID 0000.0001)           User time:   2.8561478853225708
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8568546772003174
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.832730293273926
-(PID.TID 0000.0001)         System time:   1.2794137001037598E-004
-(PID.TID 0000.0001)     Wall clock time:   14.838910818099976
+(PID.TID 0000.0001)           User time:   14.229704618453979
+(PID.TID 0000.0001)         System time:   6.8977475166320801E-005
+(PID.TID 0000.0001)     Wall clock time:   14.237637519836426
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.4095056056976318
-(PID.TID 0000.0001)         System time:   3.9971172809600830E-003
-(PID.TID 0000.0001)     Wall clock time:   6.4270963668823242
+(PID.TID 0000.0001)           User time:  0.52908098697662354
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-006
+(PID.TID 0000.0001)     Wall clock time:  0.52938342094421387
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3342306613922119
-(PID.TID 0000.0001)         System time:   3.1024217605590820E-005
-(PID.TID 0000.0001)     Wall clock time:   1.3346674442291260
+(PID.TID 0000.0001)           User time:  0.97060990333557129
+(PID.TID 0000.0001)         System time:   3.7929788231849670E-003
+(PID.TID 0000.0001)     Wall clock time:  0.97464275360107422
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32743978500366211
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.32762050628662109
+(PID.TID 0000.0001)           User time:  0.30726265907287598
+(PID.TID 0000.0001)         System time:   9.9003314971923828E-005
+(PID.TID 0000.0001)     Wall clock time:  0.30750966072082520
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.94293808937072754
-(PID.TID 0000.0001)         System time:   1.9013881683349609E-005
-(PID.TID 0000.0001)     Wall clock time:  0.94319725036621094
+(PID.TID 0000.0001)           User time:  0.49397659301757812
+(PID.TID 0000.0001)         System time:   1.6018748283386230E-005
+(PID.TID 0000.0001)     Wall clock time:  0.49442434310913086
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.8700323104858398E-002
-(PID.TID 0000.0001)         System time:   3.2037496566772461E-005
-(PID.TID 0000.0001)     Wall clock time:   5.8762788772583008E-002
+(PID.TID 0000.0001)           User time:   4.6119451522827148E-002
+(PID.TID 0000.0001)         System time:   1.3992190361022949E-005
+(PID.TID 0000.0001)     Wall clock time:   4.6136140823364258E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.9853599071502686
-(PID.TID 0000.0001)         System time:   2.0003050565719604E-002
-(PID.TID 0000.0001)     Wall clock time:   8.0289719104766846
+(PID.TID 0000.0001)           User time:   1.5162745714187622
+(PID.TID 0000.0001)         System time:   3.5533025860786438E-002
+(PID.TID 0000.0001)     Wall clock time:   1.5525424480438232
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.292306423187256
-(PID.TID 0000.0001)         System time:   3.4998357295989990E-004
-(PID.TID 0000.0001)     Wall clock time:   16.317201614379883
+(PID.TID 0000.0001)           User time:   15.059634089469910
+(PID.TID 0000.0001)         System time:   5.1021575927734375E-005
+(PID.TID 0000.0001)     Wall clock time:   15.067534685134888
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3845176696777344E-004
-(PID.TID 0000.0001)         System time:   2.9653310775756836E-006
-(PID.TID 0000.0001)     Wall clock time:   4.5824050903320312E-004
+(PID.TID 0000.0001)           User time:   4.2104721069335938E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.2915344238281250E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.22292017936706543
-(PID.TID 0000.0001)         System time:   9.8347663879394531E-007
-(PID.TID 0000.0001)     Wall clock time:  0.22292065620422363
+(PID.TID 0000.0001)           User time:  0.12185132503509521
+(PID.TID 0000.0001)         System time:   5.9999525547027588E-005
+(PID.TID 0000.0001)     Wall clock time:  0.12188982963562012
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8552284240722656E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.7193298339843750E-004
+(PID.TID 0000.0001)           User time:   3.1971931457519531E-004
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   3.3497810363769531E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.43979573249816895
-(PID.TID 0000.0001)         System time:   7.9420208930969238E-003
-(PID.TID 0000.0001)     Wall clock time:  0.44761872291564941
+(PID.TID 0000.0001)           User time:   7.5953722000122070E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.5787544250488281E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13502812385559082
-(PID.TID 0000.0001)         System time:   7.9710185527801514E-003
-(PID.TID 0000.0001)     Wall clock time:  0.14299988746643066
+(PID.TID 0000.0001)           User time:   8.6259007453918457E-002
+(PID.TID 0000.0001)         System time:   1.5935003757476807E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10217952728271484
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.5942792892456055
-(PID.TID 0000.0001)         System time:   1.5989944338798523E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6505737304687500
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   1.2610411643981934
+(PID.TID 0000.0001)         System time:   1.9964009523391724E-002
+(PID.TID 0000.0001)     Wall clock time:   1.2816660404205322
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.29499435424804688
-(PID.TID 0000.0001)         System time:   1.5964046120643616E-002
-(PID.TID 0000.0001)     Wall clock time:  0.31329202651977539
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.27277183532714844
+(PID.TID 0000.0001)         System time:   1.2014001607894897E-002
+(PID.TID 0000.0001)     Wall clock time:  0.28482270240783691
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.11183929443359375
-(PID.TID 0000.0001)         System time:   1.1983990669250488E-002
-(PID.TID 0000.0001)     Wall clock time:  0.14787817001342773
+(PID.TID 0000.0001)           User time:  0.11747741699218750
+(PID.TID 0000.0001)         System time:   4.0100216865539551E-003
+(PID.TID 0000.0001)     Wall clock time:  0.12177419662475586
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.10754394531250000
-(PID.TID 0000.0001)         System time:   1.1954009532928467E-002
-(PID.TID 0000.0001)     Wall clock time:  0.12194204330444336
+(PID.TID 0000.0001)           User time:  0.11560821533203125
+(PID.TID 0000.0001)         System time:   3.9969980716705322E-003
+(PID.TID 0000.0001)     Wall clock time:  0.11961889266967773
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   73.383468627929688
-(PID.TID 0000.0001)         System time:  0.20411896705627441
-(PID.TID 0000.0001)     Wall clock time:   73.706166028976440
+(PID.TID 0000.0001)           User time:   52.776988983154297
+(PID.TID 0000.0001)         System time:  0.14396199584007263
+(PID.TID 0000.0001)     Wall clock time:   53.386186122894287
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   4.5513534545898438
-(PID.TID 0000.0001)         System time:   7.0191979408264160E-002
-(PID.TID 0000.0001)     Wall clock time:   4.6566677093505859
+(PID.TID 0000.0001)           User time:   3.7369956970214844
+(PID.TID 0000.0001)         System time:   3.5967051982879639E-002
+(PID.TID 0000.0001)     Wall clock time:   3.7759630680084229
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   68.789390563964844
-(PID.TID 0000.0001)         System time:  0.13295000791549683
-(PID.TID 0000.0001)     Wall clock time:   69.003185987472534
+(PID.TID 0000.0001)           User time:   49.009090423583984
+(PID.TID 0000.0001)         System time:  0.10796099901199341
+(PID.TID 0000.0001)     Wall clock time:   49.579324245452881
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   3.6797256469726562
-(PID.TID 0000.0001)         System time:   4.0360093116760254E-003
-(PID.TID 0000.0001)     Wall clock time:   3.6847956180572510
+(PID.TID 0000.0001)           User time:  0.51087570190429688
+(PID.TID 0000.0001)         System time:   7.9859793186187744E-003
+(PID.TID 0000.0001)     Wall clock time:  0.94960927963256836
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.36520385742187500
-(PID.TID 0000.0001)         System time:   3.0934810638427734E-005
-(PID.TID 0000.0001)     Wall clock time:  0.36541843414306641
+(PID.TID 0000.0001)           User time:  0.35552978515625000
+(PID.TID 0000.0001)         System time:   7.9909861087799072E-003
+(PID.TID 0000.0001)     Wall clock time:  0.36373734474182129
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   62.284362792968750
-(PID.TID 0000.0001)         System time:   6.8212032318115234E-002
-(PID.TID 0000.0001)     Wall clock time:   62.423041343688965
+(PID.TID 0000.0001)           User time:   46.501670837402344
+(PID.TID 0000.0001)         System time:   4.4033020734786987E-002
+(PID.TID 0000.0001)     Wall clock time:   46.568268299102783
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.47878265380859375
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.48765206336975098
+(PID.TID 0000.0001)           User time:   6.7314147949218750E-002
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   7.5578212738037109E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   8.7738037109375000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.8977813720703125E-004
+(PID.TID 0000.0001)           User time:   8.3541870117187500E-004
+(PID.TID 0000.0001)         System time:   9.8347663879394531E-007
+(PID.TID 0000.0001)     Wall clock time:   8.3422660827636719E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.6763839721679688
-(PID.TID 0000.0001)         System time:   1.6038000583648682E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6927316188812256
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   1.3586158752441406
+(PID.TID 0000.0001)         System time:   2.7990013360977173E-002
+(PID.TID 0000.0001)     Wall clock time:   1.3871238231658936
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   4.9972534179687500E-003
-(PID.TID 0000.0001)         System time:   7.2896480560302734E-004
-(PID.TID 0000.0001)     Wall clock time:   5.7179927825927734E-003
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   5.6228637695312500E-003
+(PID.TID 0000.0001)         System time:   1.4036893844604492E-005
+(PID.TID 0000.0001)     Wall clock time:   5.6321620941162109E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================
@@ -6154,9 +6210,9 @@ grad-res -------------------------------
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =         250562
+(PID.TID 0000.0001) //            No. barriers =         250542
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =         250562
+(PID.TID 0000.0001) //     Total barrier spins =         250542
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/code/CTRL_OPTIONS.h
+++ b/global_oce_llc90/code/CTRL_OPTIONS.h
@@ -67,20 +67,27 @@ C       >>> Generic Control.
 C       >>> Open boundaries
 #ifdef ALLOW_OBCS
 C    Control of Open-Boundaries is meaningless without compiling pkg/obcs
-C    Note: Make sure that corresponding OBCS N/S/W/E Option is defined
+C    Note: Make sure that corresponding OBCS N/S/E/W Option is defined
 # define ALLOW_OBCSN_CONTROL
 # define ALLOW_OBCSS_CONTROL
-# define ALLOW_OBCSW_CONTROL
 # define ALLOW_OBCSE_CONTROL
-# undef ALLOW_OBCS_CONTROL_MODES
+# define ALLOW_OBCSW_CONTROL
 #endif /* ALLOW_OBCS */
 
 C  o Set ALLOW_OBCS_CONTROL (Do not edit/modify):
 #if (defined (ALLOW_OBCSN_CONTROL) || \
      defined (ALLOW_OBCSS_CONTROL) || \
-     defined (ALLOW_OBCSW_CONTROL) || \
-     defined (ALLOW_OBCSE_CONTROL))
+     defined (ALLOW_OBCSE_CONTROL) || \
+     defined (ALLOW_OBCSW_CONTROL))
 # define ALLOW_OBCS_CONTROL
+#endif
+
+#ifdef ALLOW_OBCS_CONTROL
+C     Untested code:
+# undef ALLOW_OBCS_CONTROL_MODES
+C     Enable code for 2D (horizontal,vertical) weights for obcs;
+C     this code is incomplete (fields are defined but not used anywhere)
+# undef ALLOW_OBCS_WEIGHTS2D
 #endif
 
 C  o Impose bounds on controls

--- a/global_oce_llc90/code/EXF_OPTIONS.h
+++ b/global_oce_llc90/code/EXF_OPTIONS.h
@@ -1,3 +1,8 @@
+#ifndef EXF_OPTIONS_H
+#define EXF_OPTIONS_H
+#include "PACKAGES_CONFIG.h"
+#include "CPP_OPTIONS.h"
+
 CBOP
 C !ROUTINE: EXF_OPTIONS.h
 C !INTERFACE:
@@ -10,11 +15,6 @@ C | Control which optional features to compile in this package code.
 C *==================================================================*
 CEOP
 
-#ifndef EXF_OPTIONS_H
-#define EXF_OPTIONS_H
-#include "PACKAGES_CONFIG.h"
-#include "CPP_OPTIONS.h"
-
 #ifdef ALLOW_EXF
 #ifdef ECCO_CPPOPTIONS_H
 
@@ -26,6 +26,7 @@ C   are specific to this package are assumed to be set in ECCO_CPPOPTIONS.h
 
 C-- Package-specific Options & Macros go here
 
+C   --------------------
 C   pkg/exf CPP options:
 C   (see also table below on how to combine options)
 
@@ -90,16 +91,19 @@ C       If defined, atmospheric pressure can be read-in from files.
 C   WARNING: this flag is set (define/undef) in CPP_OPTIONS.h
 C            and cannot be changed here (in EXF_OPTIONS.h)
 C
+C   >>> EXF_ALLOW_TIDES <<<
+C       If defined, 2-D tidal geopotential can be read-in from files
+C
 C   >>> EXF_SEAICE_FRACTION <<<
 C       If defined, seaice fraction can be read-in from files (areaMaskFile)
 C
 C   >>> ALLOW_CLIMSST_RELAXATION <<<
-C       Allow the relaxation to a monthly climatology of sea surface
-C       temperature, e.g. the Reynolds climatology.
+C       Allow the relaxation of surface level temperature to SST (climatology),
+C       e.g. the Reynolds climatology.
 C
 C   >>> ALLOW_CLIMSSS_RELAXATION <<<
-C       Allow the relaxation to a monthly climatology of sea surface
-C       salinity, e.g. the Levitus climatology.
+C       Allow the relaxation of surface level salinity to SSS (climatology),
+C       e.g. the Levitus climatology.
 C
 C   >>> USE_EXF_INTERPOLATION <<<
 C       Allows to provide input field on arbitrary Lat-Lon input grid
@@ -168,14 +172,17 @@ C-  Bulk formulae related flags.
 #ifdef ALLOW_ATM_TEMP
 C Note: To use ALLOW_BULKFORMULAE or EXF_READ_EVAP, needs #define ALLOW_ATM_TEMP
 # define ALLOW_BULKFORMULAE
+C use Large and Yeager (2004) modification to Large and Pond bulk formulae
 # define ALLOW_BULK_LARGEYEAGER04
+C use drag formulation of Large and Yeager (2009), Climate Dyn., 33, pp 341-364
+# undef  ALLOW_DRAG_LARGEYEAGER09
 # undef  EXF_READ_EVAP
 # ifndef ALLOW_BULKFORMULAE
 C  Note: To use ALLOW_READ_TURBFLUXES, ALLOW_ATM_TEMP needs to
 C        be defined but ALLOW_BULKFORMULAE needs to be undef
 #  define ALLOW_READ_TURBFLUXES
 # endif
-#endif
+#endif /* ALLOW_ATM_TEMP */
 
 C-  Other forcing fields
 #define ALLOW_RUNOFF
@@ -191,7 +198,6 @@ C       and ATMOSPHERIC_LOADING need to be defined
 C-  Zenith Angle/Albedo related flags.
 #ifdef ALLOW_DOWNWARD_RADIATION
 # define ALLOW_ZENITHANGLE
-# undef ALLOW_ZENITHANGLE_BOUNDSWDOWN
 #endif
 
 C-  Use ocean_emissivity*lwdown in lwFlux. This flag should be defined
@@ -200,9 +206,12 @@ C   unless to reproduce old results (obtained with inconsistent old code)
 # define EXF_LWDOWN_WITH_EMISSIVITY
 #endif
 
-C-  Relaxation to monthly climatologies.
+C-  Surface level relaxation to prescribed fields (e.g., climatologies)
 #define ALLOW_CLIMSST_RELAXATION
 #define ALLOW_CLIMSSS_RELAXATION
+
+C-  Allows to read-in (2-d) tidal geopotential forcing
+#undef EXF_ALLOW_TIDES
 
 C-  Allows to read-in seaice fraction from files (areaMaskFile)
 #undef EXF_SEAICE_FRACTION
@@ -218,9 +227,13 @@ C   (no pole symmetry, single vector-comp interp, reset to 0 zonal-comp @ N.pole
 #undef EXF_USE_OLD_INTERP_POLE
 
 #define EXF_INTERP_USE_DYNALLOC
-#if ( defined (EXF_INTERP_USE_DYNALLOC) && defined (USING_THREADS) )
+#if ( defined USE_EXF_INTERPOLATION && defined EXF_INTERP_USE_DYNALLOC && defined USING_THREADS )
 # define EXF_IREAD_USE_GLOBAL_POINTER
 #endif
+
+C-  Not recommended (not tested nor maintained) and un-documented Options:
+#undef ALLOW_BULK_OFFLINE
+#undef ALLOW_CLIMSTRESS_RELAXATION
 
 #endif /* ndef ECCO_CPPOPTIONS_H */
 #endif /* ALLOW_EXF */

--- a/global_oce_llc90/code/GMREDI_OPTIONS.h
+++ b/global_oce_llc90/code/GMREDI_OPTIONS.h
@@ -1,10 +1,19 @@
-C CPP options file for GM/Redi package
-C Use this file for selecting options within the GM/Redi package
-
 #ifndef GMREDI_OPTIONS_H
 #define GMREDI_OPTIONS_H
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
+
+CBOP
+C !ROUTINE: GMREDI_OPTIONS.h
+C !INTERFACE:
+C #include "GMREDI_OPTIONS.h"
+
+C !DESCRIPTION:
+C *==================================================================*
+C | CPP options file for GM/Redi package:
+C | Control which optional features to compile in this package code.
+C *==================================================================*
+CEOP
 
 #ifdef ALLOW_GMREDI
 C     Package-specific Options & Macros go here
@@ -25,9 +34,9 @@ C Note: need these to be defined for use as control (pkg/ctrl) parameters
 
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
-C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi
-C (which depends on tapering scheme)
-#undef OLD_VISBECK_CALC
+
+C This allows to use the GEOMETRIC formulation to compute K_GM
+#undef GM_GEOM_VARIABLE_K
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
@@ -52,9 +61,9 @@ C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 C Allow QG Leith variable viscosity to be added to GMRedi coefficient
 #undef ALLOW_GM_LEITH_QG
 
+C Related to Adjoint-code:
+#undef GM_AUTODIFF_EXCESSIVE_STORE
+#undef GMREDI_MASK_SLOPES
+
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */
-
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***

--- a/global_oce_llc90/code/SEAICE_OPTIONS.h
+++ b/global_oce_llc90/code/SEAICE_OPTIONS.h
@@ -85,7 +85,7 @@ C     the thermodynamics component of the code. Note that, if needed,
 C     sea-ice dynamics can be turned off at runtime (SEAICEuseDYNAMICS=F).
 
 C--   Historically, the seaice model was discretized on a B-Grid. This
-C     discretization should still work but it is not longer actively
+C     discretization should still work but it is no longer actively
 C     tested and supported. Define this flag to compile it. It cannot be
 C     defined together with SEAICE_CGRID
 #undef SEAICE_BGRID_DYNAMICS
@@ -99,6 +99,14 @@ C--   Options for the C-grid version only:
 
 C     enable advection of sea ice momentum
 # undef SEAICE_ALLOW_MOM_ADVECTION
+
+C     Use parameterisation of grounding ice for a better representation
+C     of fastice in shallow seas
+# undef SEAICE_ALLOW_BOTTOMDRAG
+
+C     Use parameterisation of explicit lateral drag for a better
+C     representation of fastice along coast lines and islands
+# undef SEAICE_ALLOW_SIDEDRAG
 
 C     enable JFNK code by defining the following flag
 # undef SEAICE_ALLOW_JFNK
@@ -179,9 +187,10 @@ C     This flag is also required for an actual adjoint of seaice_lsr;
 C     increases memory requirements a lot.
 # undef SEAICE_LSR_ADJOINT_ITER
 
-C     Use parameterisation of grounding ice for a better representation
-C     of fastice in shallow seas
-# undef SEAICE_ALLOW_BOTTOMDRAG
+C     Allow using the flexible LSR solver, where the number of non-linear
+C     iteration depends on the residual. Good for when a non-linear
+C     convergence criterion must be satified
+# undef SEAICE_ALLOW_LSR_FLEX
 
 #endif /* SEAICE_CGRID */
 

--- a/global_oce_llc90/input.ecco_v4/data.seaice
+++ b/global_oce_llc90/input.ecco_v4/data.seaice
@@ -1,13 +1,15 @@
 # SEAICE parameters
  &SEAICE_PARM01
-#the following is needed to recover old default values
-#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+#- the following is needed to recover old default values
+#  since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
       SEAICE_waterDrag=0.005344995140913508357982664,
       SEAICEetaZmethod=0,
       SEAICEscaleSurfStress=.FALSE.,
       SEAICEaddSnowMass=.FALSE.,
       SEAICE_OLx=0,
       SEAICE_OLy=0,
+#- to reproduce old results/defaults after PR-976
+      SEAICEselectMetricTerms= 1,
 #
       SEAICEuseTILT=.FALSE.,
       SEAICEpresH0=2.,
@@ -41,15 +43,14 @@
       SEAICEheatConsFix  = .TRUE.,
       SEAICE_tempFrz0    = -1.96,
       SEAICE_dTempFrz_dS = 0.,
-      SEAICEselectMetricTerms= 1,
       SEAICE_no_slip     = .TRUE.,
       SEAICE_clipVelocities = .TRUE.,
-#take 33% out of (1-albedo)
+#- take 33% out of (1-albedo)
       SEAICE_dryIceAlb   = 0.84,
       SEAICE_wetIceAlb   = 0.78,
       SEAICE_drySnowAlb  = 0.90,
       SEAICE_wetSnowAlb  = 0.8 ,
-#default albedos
+#- default albedos
       SEAICE_dryIceAlb_south   = 0.75,
       SEAICE_wetIceAlb_south   = 0.66,
       SEAICE_drySnowAlb_south  = 0.84,
@@ -58,4 +59,3 @@
 
  &SEAICE_PARM02
  &
-

--- a/global_oce_llc90/input.ecco_v4/data.seaice
+++ b/global_oce_llc90/input.ecco_v4/data.seaice
@@ -19,7 +19,7 @@
 #
       SEAICE_multDim=1,
       SEAICErestoreUnderIce=.TRUE.,
-      SEAICE_area_max=0.97,      
+      SEAICE_area_max=0.97,
       SEAICE_salt0=4.,
       LSR_ERROR          = 2.e-4,
       SEAICEuseDYNAMICS  = .TRUE.,
@@ -41,7 +41,7 @@
       SEAICEheatConsFix  = .TRUE.,
       SEAICE_tempFrz0    = -1.96,
       SEAICE_dTempFrz_dS = 0.,
-      SEAICEuseMetricTerms = .TRUE.,
+      SEAICEselectMetricTerms= 1,
       SEAICE_no_slip     = .TRUE.,
       SEAICE_clipVelocities = .TRUE.,
 #take 33% out of (1-albedo)
@@ -50,12 +50,12 @@
       SEAICE_drySnowAlb  = 0.90,
       SEAICE_wetSnowAlb  = 0.8 ,
 #default albedos
-      SEAICE_dryIceAlb_south   = 0.75
-      SEAICE_wetIceAlb_south   = 0.66
-      SEAICE_drySnowAlb_south  = 0.84
-      SEAICE_wetSnowAlb_south  = 0.7 
+      SEAICE_dryIceAlb_south   = 0.75,
+      SEAICE_wetIceAlb_south   = 0.66,
+      SEAICE_drySnowAlb_south  = 0.84,
+      SEAICE_wetSnowAlb_south  = 0.7,
  &
-#
+
  &SEAICE_PARM02
  &
 

--- a/global_oce_llc90/input/data.seaice
+++ b/global_oce_llc90/input/data.seaice
@@ -1,6 +1,6 @@
 # SEAICE parameters
  &SEAICE_PARM01
-#here I take the fields from pickup.seaice.previous.data that 
+#here I take the fields from pickup.seaice.previous.data that
 #came out of experiment 2 ("relax") part 4 to initialize part 5
       AreaFile='siAREA.ini',
       HeffFile='siHEFF.ini',
@@ -24,7 +24,7 @@
       SEAICE_strength = 2.25e4,
       SEAICE_multDim=1,
       SEAICErestoreUnderIce=.TRUE.,
-      SEAICE_area_max=0.97,      
+      SEAICE_area_max=0.97,
       SEAICE_salt0=4.,
       LSR_ERROR          = 2.e-4,
       SEAICEuseDYNAMICS  = .TRUE.,
@@ -46,11 +46,10 @@
       SEAICEheatConsFix  = .TRUE.,
       SEAICE_tempFrz0    = -1.96,
       SEAICE_dTempFrz_dS = 0.,
-      SEAICEuseMetricTerms = .TRUE.,
       SEAICE_no_slip     = .TRUE.,
       SEAICE_clipVelocities = .TRUE.,
  &
-#
+
  &SEAICE_PARM02
  &
 

--- a/global_oce_llc90/results/output.core2.txt
+++ b/global_oce_llc90/results/output.core2.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -227,7 +227,7 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=300,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-12,
+(PID.TID 0000.0001) > cg2dTargetResWunit=2.46E-10,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -635,7 +635,6 @@
 (PID.TID 0000.0001) ># | Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) ># =====================================================================
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) ># GGL90taveFreq = 345600000.,
 (PID.TID 0000.0001) ># GGL90dumpFreq = 86400.,
 (PID.TID 0000.0001) ># GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) ># GGL90diffTKEh=3.e3,
@@ -655,9 +654,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) GGL90dumpFreq =   /* GGL90 state write out interval ( s ). */
 (PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
@@ -699,6 +695,9 @@
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) adMxlMaxFlag =   /* Flag for limiting mixing-length method in AD-mode */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
@@ -812,11 +811,10 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEuseMetricTerms = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -903,6 +901,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: opening data.ecco
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ecco
 (PID.TID 0000.0001) // =======================================================
@@ -1174,7 +1185,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1717,38 +1732,6 @@
 (PID.TID 0000.0001) // External forcing (EXF) configuration  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) etaday defined by gencost   0
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 1) = thetaatlas
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_T_atlas.bin
-(PID.TID 0000.0001)  model file = m_theta_mon
-(PID.TID 0000.0001)  error file = some_T_sigma.bin
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 2) = saltatlas
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_S_atlas.bin
-(PID.TID 0000.0001)  model file = m_salt_mon
-(PID.TID 0000.0001)  error file = some_S_sigma.bin
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  2
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // insitu profiles model sampling >>> START <<<
@@ -1805,6 +1788,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseLSRflex  = /* with residual norm criterion */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
 (PID.TID 0000.0001)                   F
@@ -1887,8 +1873,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -1959,25 +1945,28 @@
 (PID.TID 0000.0001) SEAICEadvSnow = /* advect snow layer together with ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEmultiDimAdvection = /* multidimadvec */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEadvScheme   = /* advection scheme for ice */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchArea   = /* advection scheme for area */
+(PID.TID 0000.0001) SEAICEadvSchArea  = /* advection scheme for area */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchHeff   = /* advection scheme for thickness */
+(PID.TID 0000.0001) SEAICEadvSchHeff  = /* advection scheme for thickness */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchSnow   = /* advection scheme for snow */
+(PID.TID 0000.0001) SEAICEadvSchSnow  = /* advection scheme for snow */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhArea   = /* diffusivity (m^2/s) for area */
+(PID.TID 0000.0001) SEAICEdiffKhArea  = /* diffusivity (m^2/s) for area */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhHeff   = /* diffusivity (m^2/s) for heff */
+(PID.TID 0000.0001) SEAICEdiffKhHeff  = /* diffusivity (m^2/s) for heff */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhSnow   = /* diffusivity (m^2/s) for snow */
+(PID.TID 0000.0001) SEAICEdiffKhSnow  = /* diffusivity (m^2/s) for snow */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) DIFF1             = /* parameter used in advect.F [m/s] */
@@ -2068,6 +2057,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
@@ -2172,16 +2164,10 @@
 (PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
@@ -2210,469 +2196,81 @@
 (PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   3 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =      1203786
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          312
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          312
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          283
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =        11544
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         23088
-(PID.TID 0000.0001) ctrl-wet 8: atmos        23088
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    10           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    11           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    12           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    13           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    14           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    15           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   50     7220976
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3       59874       58517       58725           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4       59387       58040       58258           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5       58882       57536       57754           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6       58399       57057       57276           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7       58052       56735       56936           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8       57781       56461       56669           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9       57530       56212       56416           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10       57283       55964       56154           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11       57022       55702       55883           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12       56818       55497       55681           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13       56634       55322       55509           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14       56430       55125       55312           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15       56238       54935       55117           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   16       55975       54689       54858           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   17       55703       54421       54600           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   18       55358       54075       54251           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   19       54964       53666       53853           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   20       54471       53205       53372           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   21       53952       52716       52877           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   22       53489       52249       52409           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   23       52892       51633       51797           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   24       52223       50961       51129           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   25       51696       50480       50635           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   26       51259       50075       50241           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   27       50929       49774       49935           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   28       50664       49532       49678           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   29       50438       49306       49450           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   30       50187       49035       49179           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   31       49964       48805       48937           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   32       49700       48530       48662           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   33       49431       48260       48383           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   34       49176       47993       48108           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   35       48854       47652       47764           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   36       48501       47264       47375           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   37       48098       46846       46951           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   38       47523       46253       46362           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   39       46849       45558       45657           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   40       45984       44670       44751           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   41       44793       43419       43459           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   42       42984       41497       41533           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   43       40302       38691       38718           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   44       36689       35007       35032           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   45       31681       30069       29999           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   46       25595       24028       24031           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   47       18224       16890       16872           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   48       11407       10397       10351           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   49        4597        3913        3912           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   50         818         624         622           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3       59874       58517       58725
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4       59387       58040       58258
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5       58882       57536       57754
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6       58399       57057       57276
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7       58052       56735       56936
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8       57781       56461       56669
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9       57530       56212       56416
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10       57283       55964       56154
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11       57022       55702       55883
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12       56818       55497       55681
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13       56634       55322       55509
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14       56430       55125       55312
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15       56238       54935       55117
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   16       55975       54689       54858
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   17       55703       54421       54600
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   18       55358       54075       54251
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   19       54964       53666       53853
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   20       54471       53205       53372
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   21       53952       52716       52877
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   22       53489       52249       52409
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   23       52892       51633       51797
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   24       52223       50961       51129
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   25       51696       50480       50635
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   26       51259       50075       50241
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   27       50929       49774       49935
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   28       50664       49532       49678
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   29       50438       49306       49450
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   30       50187       49035       49179
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   31       49964       48805       48937
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   32       49700       48530       48662
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   33       49431       48260       48383
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   34       49176       47993       48108
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   35       48854       47652       47764
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   36       48501       47264       47375
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   37       48098       46846       46951
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   38       47523       46253       46362
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   39       46849       45558       45657
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   40       45984       44670       44751
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   41       44793       43419       43459
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   42       42984       41497       41533
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   43       40302       38691       38718
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   44       36689       35007       35032
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   45       31681       30069       29999
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   46       25595       24028       24031
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   47       18224       16890       16872
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   48       11407       10397       10351
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   49        4597        3913        3912
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   50         818         624         622
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
@@ -2683,41 +2281,46 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Total number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------------
-(PID.TID 0000.0001)  snx*sny*nr =    45000
+(PID.TID 0000.0001)  sNx*sNy*Nr =    45000
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 011544 010207 011460
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 041559 041310 041343
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 039915 038420 039722
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0004 0001 035457 033982 035227
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0005 0001 040378 040035 040082
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0006 0001 040418 040096 040138
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0007 0001 040462 040067 040100
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0008 0001 040877 040589 040319
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0009 0001 031231 030937 030957
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0010 0001 020622 020046 018422
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0011 0001 039018 038680 038425
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0012 0001 019781 019699 019576
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001   11544   10207   11460
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001   41559   41310   41343
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001   39915   38420   39722
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 004 001   35457   33982   35227
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 005 001   40378   40035   40082
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 006 001   40418   40096   40138
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 007 001   40462   40067   40100
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 008 001   40877   40589   40319
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 009 001   31231   30937   30957
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 010 001   20622   20046   18422
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 011 001   39018   38680   38425
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 012 001   19781   19699   19576
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2725,74 +2328,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   367
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   283 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   285 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    85 sIceLoad
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    78 MXLDEPTH
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   367 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   312 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceQnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceFWflx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   332 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   340 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   341 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   342 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   343 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    48 WVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   265 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   266 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   136 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   137 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   133 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   143 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   144 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   140 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
-(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
-(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
-(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
-(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
-(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
-(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
-(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
-(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
-(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
-(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
-(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
-(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
-(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
-(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
-(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
-(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
+(PID.TID 0000.0001)   set mate pointer for diag #   332  ADVxHEFF , Parms: UU      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVyHEFF , Parms: VV      M1 , mate:   332
+(PID.TID 0000.0001)   set mate pointer for diag #   334  DFxEHEFF , Parms: UU      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFyEHEFF , Parms: VV      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   340  ADVxSNOW , Parms: UU      M1 , mate:   341
+(PID.TID 0000.0001)   set mate pointer for diag #   341  ADVySNOW , Parms: VV      M1 , mate:   340
+(PID.TID 0000.0001)   set mate pointer for diag #   342  DFxESNOW , Parms: UU      M1 , mate:   343
+(PID.TID 0000.0001)   set mate pointer for diag #   343  DFyESNOW , Parms: VV      M1 , mate:   342
+(PID.TID 0000.0001)   set mate pointer for diag #   297  SIuice   , Parms: UU      M1 , mate:   298
+(PID.TID 0000.0001)   set mate pointer for diag #   298  SIvice   , Parms: VV      M1 , mate:   297
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   265  GM_PsiX  , Parms: UU      LR , mate:   266
+(PID.TID 0000.0001)   set mate pointer for diag #   266  GM_PsiY  , Parms: VV      LR , mate:   265
+(PID.TID 0000.0001)   set mate pointer for diag #   136  DFxE_TH  , Parms: UU      MR , mate:   137
+(PID.TID 0000.0001)   set mate pointer for diag #   137  DFyE_TH  , Parms: VV      MR , mate:   136
+(PID.TID 0000.0001)   set mate pointer for diag #   133  ADVx_TH  , Parms: UU      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   134  ADVy_TH  , Parms: VV      MR , mate:   133
+(PID.TID 0000.0001)   set mate pointer for diag #   143  DFxE_SLT , Parms: UU      MR , mate:   144
+(PID.TID 0000.0001)   set mate pointer for diag #   144  DFyE_SLT , Parms: VV      MR , mate:   143
+(PID.TID 0000.0001)   set mate pointer for diag #   140  ADVx_SLT , Parms: UU      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   141  ADVy_SLT , Parms: VV      MR , mate:   140
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2807,12 +2410,12 @@
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
 (PID.TID 0000.0001)  Levels:      21.  22.  23.  24.  25.  26.  27.  28.  29.  30.  31.  32.  33.  34.  35.  36.  37.  38.  39.  40.
 (PID.TID 0000.0001)  Levels:      41.  42.  43.  44.  45.  46.  47.  48.  49.  50.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     825 levels (numDiags =    3000 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use       0 levels (diagSt_size=    2500 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found   0 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4584096177006E-04
@@ -2828,7 +2431,7 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   9.3876998486639E-05
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.9559575367967E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  7.1522409280111305E-05
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.112781640300954E-06 (Area=3.5801386115E+14)
+(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.105154116076021E-06 (Area=1.4537802370E+12)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -3179,7 +2782,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -3259,17 +2862,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -3277,6 +2870,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       1
@@ -3295,6 +2898,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -3349,6 +2953,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3439,7 +3046,7 @@
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-12
+(PID.TID 0000.0001)                 2.460000000000000E-10
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -3451,7 +3058,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -4591,6 +4198,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.580138611494435E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 6.226703613420189E+09
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 6.064600000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 2.406992000000000E+06
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -4618,11 +4234,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+02
@@ -4678,6 +4297,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4685,7 +4307,39 @@
 (PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
-(PID.TID 0000.0001) etaday defined by gencost   0
+(PID.TID 0000.0001) ECCO_CHECK:  --> Starts to check ECCO set-up
+(PID.TID 0000.0001) etagcm defined by gencost =  0
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 1) = thetaatlas
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_T_atlas.bin
+(PID.TID 0000.0001)  model file = m_theta_mon
+(PID.TID 0000.0001)  error file = some_T_sigma.bin
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 2) = saltatlas
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_S_atlas.bin
+(PID.TID 0000.0001)  model file = m_salt_mon
+(PID.TID 0000.0001)  error file = some_S_sigma.bin
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  2
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) ECCO_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -4908,89 +4562,89 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -1.46974556251414E-01  1.33762140836063E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.47822788885375E+01
+ cg2d: Sum(rhs),rhsMax =  -1.46974705685466E-01  1.33762099639416E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.47823081867847E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     141
-(PID.TID 0000.0001)      cg2d_last_res =   6.64324167529871E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.64325002939744E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2829372703665E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5433292678774E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.4388393917127E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0510375715059E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6548967052402E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.8939058276657E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.7434080363195E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9586197773256E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.4841840031702E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.7974143751810E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.6461235799442E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9442147679285E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2234203840855E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.4134142075025E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7421707053741E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5209980752150E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9063740931300E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6543358899612E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915977063703E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2630275811541E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2829369845406E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5433303076922E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.4388469550313E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0510379110931E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6549227387739E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.8939135842725E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.7434093528128E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9586101363393E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.4841894649410E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.7974057457539E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.6455503193963E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9442124592385E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2234194688368E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.4134132112185E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7421771757568E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5209980752152E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9063716716029E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6543703159251E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915975192357E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2630244740207E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1236607045720E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006897524940E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920460854196E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366238156159E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3103845549347E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006897523980E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920460854146E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366238156168E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3103846211154E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701817293653E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0261095994559E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611345631E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183956969534E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451185877405E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3313330664857E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5452465871677E+03
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8076268830244E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3605376819188E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8058670292529E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0261095249882E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611345588E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183957018339E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451188012279E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3313336200503E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5452465823252E+03
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8076264403968E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3605379405461E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8058634625034E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1870783737789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402300808847E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1471386423784E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2450883134896E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.9756623915573E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2343273510193E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1262682594644E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8740941992249E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5321186221407E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   7.7487730023156E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.4638773816961E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0896109910114E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.2707411707449E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1151926575027E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   5.2340168966572E-01
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402300808046E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1471386232969E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2451057950583E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.9756615718267E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2343720744564E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1262704213132E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8740933790859E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5320849767613E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   7.7487727598731E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.4631979500249E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0910323735632E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.2708450104366E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1159601814038E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   5.2340487564790E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5853743342117E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -8.4376673345424E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.2200869615651E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5389893932617E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6773160238546E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9591770662818E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6987562011557E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4800959956625E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9118682617553E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5979484389632E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6796866353966E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8331876022676E-07
-(PID.TID 0000.0001) %MON ke_max                       =   4.5256849637077E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   4.1133647715545E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -8.4384426777975E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.2201019766437E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5393624947922E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6773136256344E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9591764259509E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6987531897463E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4800971857989E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9118886439716E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5979454588278E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6796836239872E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8331156960749E-07
+(PID.TID 0000.0001) %MON ke_max                       =   4.5258411259819E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   4.1133673880811E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1264351054633E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.4214021006935E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1185617196228E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.4213491899388E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542346159734E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542346159832E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760527755546E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246696836759E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9306371519881E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.7145995451258E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246696830552E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9306375579137E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.7150404472011E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5001,29 +4655,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0570110298808E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.8165983174224E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.8613511173209E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0572959353059E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.8167078746235E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.8612697803213E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.0817428885536E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.1386659357742E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.7452267429965E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.0816250248410E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.1386694940874E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.7452583855470E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5024523006893E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9274805379614E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4404140883233E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8292510716785E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5024526865021E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9274806825501E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4404304858243E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8292510728642E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4822397791584E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2589009742813E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7424485925219E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8159637892077E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4822397734755E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2589005912154E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7424777464961E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8159630745076E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5188403182895E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5280276537787E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.0002954544468E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5188402391600E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5280275161133E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.0003455462850E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5032,26 +4686,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     1
 (PID.TID 0000.0001) %MON exf_time_sec                 =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON exf_ustress_max              =   8.2706254083762E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.1622581722300E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4769662955845E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.3794523026032E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.3301653641519E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   5.1065588605240E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9421075569157E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9254068932876E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.4037150316359E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.4802894143487E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0746167724330E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5777890722939E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.3631123958081E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5334026135173E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   2.9730447943576E-01
+(PID.TID 0000.0001) %MON exf_ustress_max              =   8.2706254077132E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.1622581599242E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4769663016750E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.3794523006453E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.3301653482966E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   5.1065588453960E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9421075569251E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9254068881121E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.4037150302010E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.4802893903159E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0746167681734E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5777890722903E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.3631123983538E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5334026129468E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   2.9730448113096E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9596994233695E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935342722974E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.3355796074980E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4862331976434E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834256598405E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.3355796164772E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4862331970551E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834256583713E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.7909514465496E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.5472462207317E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   4.0259440308204E-01
@@ -5077,16 +4731,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0863231607036E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3142124339145E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4449102036184E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226299699938E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0761648575119E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8871619657227E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7654519126914E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4333371059563E-02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226299430886E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0761648575035E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8871619669432E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7654519209058E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4333371402295E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.3963031225247E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.6689805202220E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6046448222292E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.4772429668789E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.4722338464021E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6046448213313E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.4772429637331E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.4722338566920E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8691348354493E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0209653692469E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689458656738E-08
@@ -5120,89 +4774,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.89667992072702E-01  1.31165947868857E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.78965985889577E+00
+ cg2d: Sum(rhs),rhsMax =  -2.98346437575719E-01  1.31165860336181E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.78966340287414E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.32917826052206E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.32917362123142E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5901944630486E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234117039476E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100217402231E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379286666464E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433022553217E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5739352778241E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4879234606579E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728482806794E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359397602868E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383865005086E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5873393006783E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5773119177539E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5461075869997E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838093146008E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931300081183E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8989891142390E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251161206207E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434115624202E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213740883918E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987533186399E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5902151157993E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234141596814E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100241081308E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379284858949E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433531912840E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5744483066822E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4878994071172E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728461940518E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359417518262E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383718136773E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5864656337756E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5772926731760E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5460951622654E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838094422226E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931435366632E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8989891142392E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251161206281E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434126540594E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213746516264E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987530192831E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1222710237771E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002308883004E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920380579600E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366232204328E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3007629995277E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002308879297E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920380579552E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366232204334E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3007629843347E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699562851827E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0288920744280E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610141679E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184137902046E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2201159730884E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3210309404514E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8258516668232E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7380840216567E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3468130040938E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400097256257E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0288918844698E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610141667E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184137900619E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2201121442685E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3210319497847E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8258508812940E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7380830296743E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3468135696151E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400280377636E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1849455478432E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8405072600423E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1429927206917E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2368174899780E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.7434643757336E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1967878758819E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1898772146726E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6699772055108E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6780106717714E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   8.1726352282884E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.8469188936009E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.4613886702438E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4235683688242E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8505584103464E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   5.7330184281764E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.8736297951126E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.6839437785180E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.4242282413640E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5672440492997E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.9749621297928E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1245862046152E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7527346883418E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9961080813059E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2265580949272E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6602409153502E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7474740302065E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691393705763E-05
-(PID.TID 0000.0001) %MON ke_max                       =   9.9277088111487E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3333733925461E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8405072599645E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1429926688056E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2368558159546E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.7434619962840E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1968835489810E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1898818210941E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6699776127285E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6780013517565E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   8.1726355276371E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.8468589124393E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.4633749907108E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4238387091792E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8513239429262E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   5.7330360373610E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.8736297951233E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.6837435134663E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.4243215045596E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5676477242133E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.9749831227015E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1245903057909E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7527316886657E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9960752233858E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2265403250378E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6602383920052E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7474710096473E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691379969079E-05
+(PID.TID 0000.0001) %MON ke_max                       =   9.9293436527262E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3333756575919E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979035714E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0937711709687E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.3293128553806E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0938784277352E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.3293075971785E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292367E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525964211E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410400831E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729597539734E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636121022092E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292617E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525964223E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410425692E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729598913382E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636222296724E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5213,29 +4867,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0081950256000E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.0495522151297E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.1638703086948E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0086850799613E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.0495722758574E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.1636398787268E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5497208149087E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.2020282523433E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.1590442704241E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5495160274221E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.2020422086414E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.1595846770606E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4920743884332E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9245970137978E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4385895877052E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8287443114189E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4920745060339E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9245969272118E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4386198004152E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8287443139695E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4739078608348E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2565692050917E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7252438415773E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8126052609271E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4739078409116E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2565681648271E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7252987455664E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8126036291323E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5097035819739E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5249153867990E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9841255787289E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5097033930164E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5249147710877E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9842298234266E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5244,26 +4898,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     2
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON exf_ustress_max              =   8.7395092657237E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.8535530089935E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.5409209925231E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.6115582142987E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.5228782843261E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   5.6070078317531E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.4232352997070E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.0729257342907E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.7095342930904E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.7171874388408E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1058761351411E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5770376042287E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.2506779430269E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5569779768415E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0097863376290E-01
+(PID.TID 0000.0001) %MON exf_ustress_max              =   8.7395092646221E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.8535529900266E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.5409209925933E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.6115582061138E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.5228782849043E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   5.6070078284158E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.4232352997439E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.0729257328602E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.7095342896634E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.7171873888685E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1058757018562E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5770376042171E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.2506779108212E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5569779887577E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0097862315472E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.1263204911274E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947255065370E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.0852240449786E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4932097476532E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834179823525E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.0852240176253E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4932097459238E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834179459853E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8143659315325E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6386292701266E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.9995680111159E-01
@@ -5289,16 +4943,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0859175242602E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3091213923571E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4450134252705E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157563660880E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0706584532814E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8870052460710E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7619904334611E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4299743497818E-02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157563255516E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0706584532386E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8870052568600E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7619904853711E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4299739974138E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.5629559171084E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9581136089418E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6296948165765E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5123038472181E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5321681145823E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9581136089416E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6296948193119E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5123038383471E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5321680772104E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8682981508973E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0258273948293E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689307363123E-08
@@ -5332,89 +4986,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.26224449285407E-01  1.27905011464686E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.36968525444578E+00
+ cg2d: Sum(rhs),rhsMax =  -4.43229186209859E-01  1.27904872486847E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.36967565807600E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.88805560858676E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.88784009141309E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852434731235E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371596791290E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433175005801E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239327123753E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6942880112635E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0991256867566E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8578922183793E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757981460814E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478414491192E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058782978138E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992069298777E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8026345979235E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9249868870607E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391077868694E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392544590096E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051681E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093392E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7369044959523E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668608153465E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568113840582E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1210551784620E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661235355E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072924E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260846136E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511367264378E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697156897789E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0318799939218E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609342233E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184382329828E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1927616531542E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3096929610956E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3350613557702E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6826178319498E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3588565792310E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2383552697863E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852435797554E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371647067441E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433207583861E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239322362663E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6943715972380E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0998083666458E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8580665326517E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757932950788E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478448655192E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058941347460E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992064376081E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8025999262904E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9250121752582E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391087858710E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392834181959E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051642E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093199E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7368524714466E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668621164615E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568143592103E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1210551784617E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661226353E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072971E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260845968E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511365184523E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697156897790E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0318797488038E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609342287E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184382253342E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1927566930563E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3096939494550E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3350571892100E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6826174271750E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3588579553094E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2384060658262E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1828127219075E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407189623652E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1397080465376E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2220667011185E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   4.8444674164819E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1531082093213E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0960037150221E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6666033635551E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6622027319137E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   8.6356523115538E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3148155983243E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5759732717289E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.6593057914501E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8745796948952E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.1945781064940E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.2931863274540E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8243075091888E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7333547489713E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1057887027857E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995059053510E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1110973947886E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419806E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3060882997654E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327809900543E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312324E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789215059E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521114072720E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.3313107009681E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.2348086306017E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407189624568E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1397079568199E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2221256477236E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   4.8444611682995E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1532645150341E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0960062586464E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6666087727276E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6622671570899E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   8.6356523069977E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3148202708265E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5790205982737E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.6596922998005E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8748715515116E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.1945932327456E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.2931863274809E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8246903420095E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7334803532792E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1063142799300E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995153452836E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1099979666076E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419693E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3062376814339E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327805582203E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312206E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789214938E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521023576792E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.3316048840203E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.2348147068866E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979310002E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5011413893878E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2237592651162E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5013291546771E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2237599900537E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956593E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524076675E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720107348E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160975801283E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6606529620548E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956902E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524076729E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720186159E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160966251319E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6605938298897E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5425,29 +5079,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1105978604925E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337399852367E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8142368719250E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1111725158506E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337711190034E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8143935390962E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6534876363413E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853214563016E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8422173157258E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6533003575814E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853346058567E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8427090465787E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4809172584734E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9217617520535E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4358758997561E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8282464626234E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4809170738964E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9217614478689E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4359207988034E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8282464655762E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4659438874333E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2542805457974E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7093083829805E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8092501542326E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4659438629728E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2542787378088E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7093935678451E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8092477912793E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5006612311042E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5217781587022E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9702450236108E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5006608897798E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5217769066925E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9704020343916E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5456,26 +5110,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     3
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   9.2344675752536E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.6473925163909E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.6381822052088E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9198891687884E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.7897002556912E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.1973395318396E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.9669975184919E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.1709856671420E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1143958794330E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0215487212600E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1371226656589E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5759648457271E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078477102269E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342513427E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564288755256E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961404E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   9.2344675692342E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.6473925103629E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.6381821864417E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9198891571638E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.7897002456990E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.1973395471047E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.9669975185873E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.1709856742956E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1143958770599E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0215486753565E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1371212055746E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5759648456968E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078476700244E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342561061E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564287454116E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961398E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1959313010779E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967983395E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671552496E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2983094236237E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967618022E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671457475E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2983093851801E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8377804165155E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7300123195215E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.9731919914113E-01
@@ -5501,16 +5155,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0855118878168E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3049237339092E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4452384486965E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5090022723799E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0610391612379E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867058504251E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7589415393265E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4265980500492E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.7443598489472E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.3273191857038E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6633819793358E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5611002593109E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6183286037807E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5090023047454E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0610391611114E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867058653098E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7589416067668E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4265976267551E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.7443598489465E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.3273191857036E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6633819829895E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5611002428356E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6183285505398E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8674614663454E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0306894204118E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689156069507E-08
@@ -5544,89 +5198,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.59284749032712E-01  1.25698027958438E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.10916376186209E+00
+ cg2d: Sum(rhs),rhsMax =  -5.84050173838804E-01  1.25697846847363E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.10916404308707E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.57975907859729E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.57919988167320E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514672310E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125941060680E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560542601180E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068862026121E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6892154340857E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5258371800005E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2150972780396E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646948941946E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820779321470E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8424643069548E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529039E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1326532725175E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354413578503E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819336841862E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6561578076241E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366748209E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851166853E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2071680682799E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769604881537E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161276219507E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1205582170152E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920323719E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137739E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315522436E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857746187128E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694681496378E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0349724301766E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608743590E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184629437159E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1661433290067E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3067391886893E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.0717968736748E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5891712494344E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3742336389064E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2008723232545E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514900176E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125980155718E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560595729621E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068862492546E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6893312645950E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5267298155061E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2153042195729E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646873967420E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820811893995E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8425014229115E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529781E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1332511419587E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354471781587E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819364824366E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6562015889022E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366747940E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851166574E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2070884546504E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769616603508E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161278359698E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1205582170132E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920322462E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137830E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315522131E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857746592136E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694681496380E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0349721712134E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608743669E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184629312460E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1661357905619E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3067404342678E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.0717773910393E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5891695924809E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3742348715489E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2008964849562E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409268140178E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1365543464803E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2152801340304E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.8661626089838E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1243140556992E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0372392376771E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6379084601073E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5177564682895E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.1348105208740E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.9128795216288E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.6894462330343E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9711363433304E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1314957164115E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.6912046025137E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.9128743129779E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9466947733558E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1311395488824E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9557858483769E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3877147053167E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0042615142087E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316522506E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6122014313696E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5032839077019E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2601661689071E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372785971E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452282912779E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.6804274836495E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.0314803360943E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979572532E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7464979737729E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4422500773816E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409268144304E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1365542220538E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2153583051035E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.8660117549349E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1245278609030E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0372451116611E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6379113678407E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5177464380593E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.1348105059781E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.9128357838762E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.6926660323102E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9715696904424E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1320637594446E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.6912298839077E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.9128743130540E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9473002552148E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1312897661412E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9563933353690E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3880519194623E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0015560907266E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316521802E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6123787735408E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5034277647091E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2601661688341E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372785240E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452267999361E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.6808934165968E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.0314901966410E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979572533E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7467664078278E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4423531641952E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876467129E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523225355E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196393414E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026206757038E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6681477701189E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876467593E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523225477E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196519604E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026188757404E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6680610088885E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5637,29 +5291,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1036451350238E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3467928816647E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8139477681837E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1041820554956E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3468223595255E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8142549756035E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6720063491819E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956529998029E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8870249866809E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6719694501925E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956689921719E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8874597765719E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713013021417E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9191243154946E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4226116864932E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8277576041862E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713006617257E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9191237241467E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4226715649393E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8277576073071E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4582083731112E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2521074060320E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6950039478397E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8059157443754E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4917296183000E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5187760946152E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9570095063642E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4582083315534E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2521047306375E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6951252698449E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8059127359744E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4917291076465E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5187740588672E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9572257918500E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5668,26 +5322,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   9.5970547637497E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.4364361535134E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4894531034865E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8160221279484E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6664102180652E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.4453638013316E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.5031145425415E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2253457528668E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0377375911675E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.9870198916589E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1048789532727E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5711805917318E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516930026708E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794438497433E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532605930542E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877178523E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   9.5970547480660E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.4364361223001E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4894529625444E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8160220421878E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6664086155990E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.4453638277411E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.5031145427106E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2253458350575E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0377375579796E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.9870190905628E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1048775067532E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5711805916621E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516932894272E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794436549056E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532603111569E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877178490E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1953168675345E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688489731498E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941368575110E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777782093E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688493821066E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941367671794E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777138175E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8655087463369E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7050055040743E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.8836561680071E-01
@@ -5713,16 +5367,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0854532945828E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2992477109139E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4444818183202E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5023324034258E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530496702800E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423782669E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322377909E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236191605282E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865974849E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945807E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611999501E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460849298917E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5994549303747E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5023324959205E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530496700265E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423650647E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322658444E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236187017483E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865974816E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945773E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611590544E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460848194149E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5994548148012E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8666247817934E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0355514459942E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689004775892E-08
@@ -5756,89 +5410,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -6.90938016339523E-01  1.23313674960492E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.04940080733895E+00
+ cg2d: Sum(rhs),rhsMax =  -7.22692663326199E-01  1.23313465318446E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.04940178251669E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   7.05019234270238E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.05014952239370E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558351744362E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368821226311E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577657752796E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793084344680E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6741838504005E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8934450164746E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690540225E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274930534958E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837440695630E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8724608665229E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399849301E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8640451417633E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303083317698E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662401152285E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373105094632E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1886122269183E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589366813E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9968463500908E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191352785732E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854464718170E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1199063567507E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001246601E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901086E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404809968E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215814659541E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692092293852E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0380536133796E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608317438E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873339059E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416950975670E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027821997173E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0050559357388E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396670551141E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662368516261E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577753998952E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558352013185E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368942032834E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577723309168E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793095176438E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6743315392833E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8944943890812E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690525571E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274846765468E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837464662813E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8725057867256E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399847968E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8648367843179E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303177177731E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662446712564E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373634742923E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1886122267755E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589358867E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9967565854213E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191361199682E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854465296233E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1199063567496E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001248404E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901184E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404809521E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215815509575E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692092293856E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0380533054230E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608317521E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873182882E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416879925246E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027835014706E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0047157101858E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396659293911E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662378151831E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577911545708E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411340663931E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336243105060E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2089859042887E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1352437325556E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1118162547741E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057254141708E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013330260582E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699471672378E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948883251E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281781555663E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5343781147238E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8718909788553E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9514290889742E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.8999414025698E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.4686855380668E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0399621453203E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0552330020920E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8397379902916E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5093307150614E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596315435268E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472416069E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8654798554186E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1462528787395E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378188190E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502543054E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3418656395235E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0680659200977E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.7587388842522E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979827701E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9652318616986E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6835037865793E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411340673200E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336241417603E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2090852064955E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1351655989138E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1120703174771E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057289664884E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013337085849E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699749156482E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948572597E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281699171760E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5373608208363E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8723028205796E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9517976278184E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.8999768005902E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.4686855382039E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0409380333935E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0553861242355E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8400315472903E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5097446621883E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596818049974E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472413340E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8656584376310E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1463946035425E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378185359E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502540136E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3418640387056E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.0687156514284E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.7587517743583E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979827703E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9655695523177E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6836646781668E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661219329E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523297139E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776427130E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2768015121374E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5069042876617E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661220023E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523297319E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776598446E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2767993643974E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5068118595309E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5849,29 +5503,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0681720427778E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235175642068E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7432456161347E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0686250617686E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235444460058E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7436333155015E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7213161976876E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668003203061E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8734652994862E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7214392339526E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668228641368E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8739495022452E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625517441311E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9166195377252E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4008645329673E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8272812516990E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625504079357E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9166185799115E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4009400800399E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8272812549117E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4505975779099E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2500386293406E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6809758313479E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8026020681501E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4505975190546E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2500350654210E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6811240252322E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8025983941197E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4827966529131E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5159090184031E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9421815332458E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4827962317258E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5159061673416E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9424707147290E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5880,26 +5534,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     5
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945457394E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083193200E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417944703013E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770804210E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075023288078E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546216834E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.0611177970474E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2507507964553E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0258392994211E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0158959998239E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0733654980685E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5670986344299E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688226336986E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355959752E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535214652726E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859535780E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945423002E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083029219E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417943914343E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770526303E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075019978342E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546632187E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.0611177972871E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2507508244586E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0258392920310E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0158958261752E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0733640778142E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5670986343356E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688227250260E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355247374E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535212914374E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859535642E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947146923263E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068548366173E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846874332109E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2551448766293E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068549629026E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846873904064E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2551448089191E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8932370761583E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6799986886272E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.7941203446030E-01
@@ -5925,16 +5579,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0853947013489E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2944037231979E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4438385083419E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4957462594537E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282923805E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704953250E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616012030E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205944879153E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165600364E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897167150E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750516987E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696635205E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5985774800126E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4957464098279E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282919931E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704950847E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616386674E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205939756265E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165600226E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897167026E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750390701E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696232678E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5985773829796E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8657880972414E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0404134715766E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688853482276E-08
@@ -5968,89 +5622,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.20012499907984E-01  1.21310980036511E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.00015725806016E+00
+ cg2d: Sum(rhs),rhsMax =  -8.59042374055238E-01  1.21310756350857E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.00015367122284E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.53654307985334E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53656882009818E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942705183E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271661496681E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478709445465E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685261958879E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6636135607121E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0248300255996E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541733400E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555210725407E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547411554636E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7823627285465E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465043575200E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4807822649774E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830677644376E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926272921291E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873315296839E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046827473E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565055150E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4225824306721E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179386226261E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145356698316E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942960962E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271797311689E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478806225066E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685285025033E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6637977965284E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0259161559300E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541687201E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555134797084E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547431524331E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7824176002143E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465043575463E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4817211673655E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830786518281E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926325409445E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873851013695E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046824292E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565039753E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4217681999772E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179391653094E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145355634100E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192840140288E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880812149E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764894E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518612376E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553107715727E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689419470055E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410367180225E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031539E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185106037687E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1192320120134E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2993663694807E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0694726236378E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661666318267E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609628945592E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310948066206E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880816911E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764890E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518611928E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553149975536E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689419470061E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410364560306E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031616E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185105870762E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1192245319126E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2993680730220E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0690719167556E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661632627048E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609641584170E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310930543521E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413323769388E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1309077147007E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1874573646539E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.6713720752057E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0977178717458E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725506088216E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711210111122E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974585294805E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525521119196E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282621932868E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3651372396750E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8370223913933E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8838170071448E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.1085654964801E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453477809E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0860393236253E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0442255730860E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9139888370808E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3858989445520E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8787461330170E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808973012E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324246368809E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5654772042330E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177167284E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018213767E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992481889706E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.3692082965883E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3541843193575E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980078924E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1071804512562E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.8803882152651E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413322304772E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1309103082882E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1875742094198E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.6712626030986E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0980049773845E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725595334623E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711230905127E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974049577791E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525520363546E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282166321294E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3678297523328E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8374201171866E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8853670810552E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.1085945391545E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453479819E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0871867034506E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0443851494711E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9149363092678E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3858977304006E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8788112833153E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808965116E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324477640578E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5655712082508E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177159047E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018205381E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992469855724E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.3698389222394E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3541989569258E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980078926E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1075559612577E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.8806137810628E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629616415E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523960980E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230148623583E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149948610567E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2102488738766E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629617352E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523961197E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230148845459E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149929624808E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2101609269225E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6061,29 +5715,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0319402165181E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849188318109E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5783097447108E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0322841989359E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849417527448E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5787361495371E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7254127291132E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180204540294E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7450245857400E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7256531567807E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180481127894E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7456139640403E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550169876460E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142986483431E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3758732237080E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8268173253719E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550147128904E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142972115911E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3759642673940E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8268173286163E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4431170669139E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480686063409E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6675610321082E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7993114477027E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738900715356E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131654740143E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9269849339759E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4431169792643E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480641238807E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6677396501725E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7993069954691E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738894707760E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131614478268E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9273504277200E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6092,26 +5746,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0533610355212E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.0751292909875E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.1920978964803E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8121410529023E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6143336135247E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.9754450216534E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.6406961715387E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2475183254527E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0785986876601E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.1017497768873E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0425523058869E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5630237586576E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618379193460E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594410676E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585908490795E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171384884E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0533610297026E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.0751292914040E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.1920978236449E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8121410402650E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6143335943718E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.9754450745616E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.6406961718443E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2475183425877E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0785986861128E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.1017497495473E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0425509036791E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5630237585668E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618379100029E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594147667E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585907940984E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171384512E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1941211875677E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413624457E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346970928E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955648205E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413398426E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346685305E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955797442E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9209654059797E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6549918731801E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.7045845211988E-01
@@ -6137,16 +5791,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0853361081149E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2903940562447E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4433086702889E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4892373729992E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0379666252623E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692125787E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503490982577E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177228338941E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794717725E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007331149E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508372112E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867281265E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6172929940612E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4892376459153E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0379666247758E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692237824E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503491770433E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177224603250E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794717354E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007330761E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508394715E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867064830E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6172929656896E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8649514126894E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0452754971591E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688702188661E-08
@@ -6180,89 +5834,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.46889216589065E-01  1.19643084184519E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.42689743468363E-01
+ cg2d: Sum(rhs),rhsMax =  -9.93281344523042E-01  1.19642857671107E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.42681738545532E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.50650568652083E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.50657093879882E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217254679605E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719433610378E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0272942490252E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323747771123E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6590737926490E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5563482205762E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237943017E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4855008342748E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897788105129E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5529801672968E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588131847304E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2706232289067E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5638979131742E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582248632052E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2162585231953E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005447838E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237652005E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3921689664372E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503789542019E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138452846350E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192003518495E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554768246E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820972E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644691613E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9927011031760E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686687532160E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439365122671E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773863E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326485719E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989613969667E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962426384871E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237586576E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695411454177E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586492738488E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880487754048E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217255009556E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719599473921E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0273058011820E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323780510137E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6592919996900E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5593753702634E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237835565E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4854943023628E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897810730962E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5530452915444E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588131848637E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2718602630044E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5639071999583E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582298789362E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2163126770615E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005440768E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237618020E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3916115113210E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503793507573E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138450585812E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192003518503E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554775465E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820789E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644691372E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9927057719158E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686687532166E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439362840448E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773912E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326320801E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989533953318E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962449245121E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237585668E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695363614307E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586511524412E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880471883983E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415258347915E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284226097868E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1519842728181E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721998567510E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0834202645362E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420182786342E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456670987521E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902402914519E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820802258E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860902453567E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1906330230139E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8721499700827E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9730914479829E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.3236139833806E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074179723E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1033968375463E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0977289009963E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0614879884653E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0188197871592E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8038775087146E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462879342E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6242888766917E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7950480610609E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893506563202E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204864421E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430863405085E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9022258340870E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.7555833744430E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980325991E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1823202747401E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0129285022779E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415255622500E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284268964354E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521172204644E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721414228684E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0837335290346E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420236357128E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456700533150E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902316109753E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820658270E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860459936392E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1932659975281E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8725350851900E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9748361488522E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.3236139944882E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074182346E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1045338089232E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0978874221138E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0626205363346E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0188177900418E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8066792927899E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462859199E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6243054118318E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7951538168621E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893860702541E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204843074E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430857015281E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9032139284800E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.7555987190730E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980325994E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1827287823092E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0132246852828E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761401788E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525020837E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228685470495E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867045813593E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9352658481411E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761403072E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525021077E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228685744160E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867033618150E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9346575626291E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6273,29 +5927,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5651344952538E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328572367401E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3454992831274E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5676216961826E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328755238703E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3461054566347E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6909669632771E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529434898902E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4805077514377E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6912729428511E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529741472216E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4811405764577E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465976562460E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120203210846E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3693977238282E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8263657235874E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465945779352E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120184842735E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3695067638978E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8263657268392E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357570156816E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461921445666E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6546449679040E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960453001533E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649925205755E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5105249753872E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9113383545470E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357569207015E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461867790350E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6548596560414E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960394127656E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649915375518E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5105194825351E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9117922717874E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6304,26 +5958,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1024633420394E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.9099627986049E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.0390492433383E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9160983145918E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6924952855180E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   7.3777814140913E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9564202348687E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2150175251965E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1976381293709E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295601258E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124052922230E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5589638244338E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902938739E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020476892E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676965009962E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263100727E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935326777510E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614698691E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510759225E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557589686286E-11
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1024633358141E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.9099628159468E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.0390491503063E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9160983058007E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6924953514964E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   7.3777813863273E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9564202349128E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2150175398329E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1976381287577E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295746872E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124039002695E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5589638243596E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902678032E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020358404E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676964810087E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263099914E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935326777509E-06
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614067104E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510524764E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557590193443E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9486937358010E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6299850577329E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.6150486977946E-01
@@ -6349,16 +6003,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0852775148810E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2872206082251E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4428924291636E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828126125454E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187950907E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125017453E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477968455857E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150373982772E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433443030E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204528265E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732645642E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585891134E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495581445E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828129849342E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187945636E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125084771E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477969398595E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150370338141E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433442275E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204527273E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732708800E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585774590E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495460832E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8641147281375E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0501375227415E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688550895045E-08
@@ -6392,89 +6046,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.07163930097040E+00  1.18154306531811E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.79619305093942E-01
+ cg2d: Sum(rhs),rhsMax =  -1.12530006886069E+00  1.18154085852529E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.79604998809564E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.63002906235179E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.62997211571649E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744049141E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430416663015E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954813235566E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316035322115E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6539532502284E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0948083043173E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174881937E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279764720371E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802479258554E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184587451165E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401972712825E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8645037530306E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249516803573E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751651095314E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8592849334184E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182460938E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221930209E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4785195958656E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5980770516792E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926356249528E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190755067681E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013005193E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144974E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772148340E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368749783911E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744428391E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430630752265E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954936236825E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316073183037E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6542023465795E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0982221272274E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174686624E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279699614737E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802506410044E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184657015961E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401972716785E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8660397961926E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249570950075E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751695548867E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8593493178116E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182446770E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221871843E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4811859507218E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5980774239508E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926353450666E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190755067678E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013010156E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144674E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772148177E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368792198676E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684631335866E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467138134827E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471389E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534636823E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803896136597E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929052691131E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5589638244338E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512291409249E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591356643914E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644485632510E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467135714543E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471401E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534492813E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803819856115E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929083218009E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5589638243596E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512270444822E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591373266620E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644632726052E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316192677E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261774969109E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521177431463E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834880748073E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0686889374843E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099013880380E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217401387260E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1168936059826E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890831426E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041609833235E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0050536051244E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9781684124419E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1372587004791E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522192059010E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423054699E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0845930690300E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2167341580302E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2289402968212E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7271265332008E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2780430894470E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286172811301E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9056308998742E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4680600683147E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4027759132001E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361422481149E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228883210974E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.3881769238969E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9530970603763E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980569234E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2704623430256E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0989614626103E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316241994E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261771581509E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1523092670668E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834643161026E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0690212786165E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099035259808E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217437833014E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1169247442182E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890611455E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041349530654E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0077830364605E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9785468369225E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1398480017901E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522392275198E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423055540E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0858027075971E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2168843654967E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2300573572439E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7271257398371E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2804626645172E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286555905004E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9070229059085E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4681204540303E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4028141012502E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361808218341E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228881856383E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.3895817951412E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9531123357145E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980569238E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2711889827737E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0993283495296E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000835023E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261434E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228397939195E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872334523569E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3278903076638E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000836835E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261701E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228398266971E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872284906065E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3276481551867E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6485,278 +6139,290 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2472961010053E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679207384468E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9959723884241E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2489783526474E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679351956634E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9966311085247E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6324083857105E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744168135454E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0136905154269E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6327428697719E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744476624374E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0137374440955E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399681187247E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099251637105E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3408725409458E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266841298E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399639495385E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099227644781E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3409979202498E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266874089E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285203782921E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443908024707E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6421982561711E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927940643434E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561954001976E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079865178436E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8953510046117E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285202884565E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443845490714E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6424469665771E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927871112480E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561940420794E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079793967223E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8959002568141E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT         8 ckptA
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) == cost_profiles: begin ==
-(PID.TID 0000.0001) == cost_profiles: end   ==
+(PID.TID 0000.0001) == profiles_cost: begin ==
+(PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.116966764041153D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.178494336630211D+05 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.295461100671364D+05
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.111803527416655D+04
-(PID.TID 0000.0001)  global fc =  0.295461100671364D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  1.16966788110521E+04  1  1.00E+00 (thetaatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.78494807821327E+04  2  1.00E+00 (saltatlas)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.11803803139429E+03
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   2.95461595931848E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   173.52026906237006
-(PID.TID 0000.0001)         System time:   12.111337155103683
-(PID.TID 0000.0001)     Wall clock time:   190.94166302680969
+(PID.TID 0000.0001)           User time:   91.385783310979605
+(PID.TID 0000.0001)         System time:   1.2350300541147590
+(PID.TID 0000.0001)     Wall clock time:   94.947281122207642
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4.5002089776098728
-(PID.TID 0000.0001)         System time:   2.4259709417819977
-(PID.TID 0000.0001)     Wall clock time:   7.2815248966217041
+(PID.TID 0000.0001)           User time:   2.4778129886835814
+(PID.TID 0000.0001)         System time:  0.21174800163134933
+(PID.TID 0000.0001)     Wall clock time:   2.6937949657440186
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   169.02000522613525
-(PID.TID 0000.0001)         System time:   9.6853058338165283
-(PID.TID 0000.0001)     Wall clock time:   183.66003012657166
+(PID.TID 0000.0001)           User time:   88.907944202423096
+(PID.TID 0000.0001)         System time:   1.0232800543308258
+(PID.TID 0000.0001)     Wall clock time:   92.253453969955444
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   11.213326930999756
-(PID.TID 0000.0001)         System time:   4.0189146995544434
-(PID.TID 0000.0001)     Wall clock time:   15.416032791137695
+(PID.TID 0000.0001)           User time:   5.8153679370880127
+(PID.TID 0000.0001)         System time:  0.40388797223567963
+(PID.TID 0000.0001)     Wall clock time:   6.2213039398193359
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   157.80664062500000
-(PID.TID 0000.0001)         System time:   5.6663622856140137
-(PID.TID 0000.0001)     Wall clock time:   168.24393415451050
+(PID.TID 0000.0001)           User time:   83.092553138732910
+(PID.TID 0000.0001)         System time:  0.61939007043838501
+(PID.TID 0000.0001)     Wall clock time:   86.032130002975464
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8532695770263672
-(PID.TID 0000.0001)         System time:   1.1106491088867188E-002
-(PID.TID 0000.0001)     Wall clock time:   1.8919718265533447
+(PID.TID 0000.0001)           User time:  0.83727836608886719
+(PID.TID 0000.0001)         System time:   1.8703937530517578E-004
+(PID.TID 0000.0001)     Wall clock time:  0.83750915527343750
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5847167968750000E-003
-(PID.TID 0000.0001)         System time:   2.6845932006835938E-004
-(PID.TID 0000.0001)     Wall clock time:   5.8588981628417969E-003
+(PID.TID 0000.0001)           User time:   3.0250549316406250E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.0236244201660156E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   152.04429244995117
-(PID.TID 0000.0001)         System time:   4.0123305320739746
-(PID.TID 0000.0001)     Wall clock time:   157.65521168708801
+(PID.TID 0000.0001)           User time:   80.046506881713867
+(PID.TID 0000.0001)         System time:  0.47535306215286255
+(PID.TID 0000.0001)     Wall clock time:   80.624016046524048
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   152.04415321350098
-(PID.TID 0000.0001)         System time:   4.0123252868652344
-(PID.TID 0000.0001)     Wall clock time:   157.65506815910339
+(PID.TID 0000.0001)           User time:   80.046436309814453
+(PID.TID 0000.0001)         System time:  0.47535306215286255
+(PID.TID 0000.0001)     Wall clock time:   80.623946905136108
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7697906494140625
-(PID.TID 0000.0001)         System time:   1.5830993652343750E-004
-(PID.TID 0000.0001)     Wall clock time:   2.7728245258331299
+(PID.TID 0000.0001)           User time:  0.99443149566650391
+(PID.TID 0000.0001)         System time:   1.9669532775878906E-006
+(PID.TID 0000.0001)     Wall clock time:  0.99471712112426758
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4251537322998047
-(PID.TID 0000.0001)         System time:   5.4712295532226562E-002
-(PID.TID 0000.0001)     Wall clock time:   1.5234668254852295
+(PID.TID 0000.0001)           User time:  0.26002025604248047
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:  0.26008844375610352
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1679973602294922
-(PID.TID 0000.0001)         System time:   5.7645797729492188E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4533376693725586
+(PID.TID 0000.0001)           User time:  0.45521068572998047
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.45733141899108887
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.1674976348876953
-(PID.TID 0000.0001)         System time:   5.7632923126220703E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4528529644012451
+(PID.TID 0000.0001)           User time:  0.45388126373291016
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.45600891113281250
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   9.3460083007812500E-005
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.9420547485351562E-005
+(PID.TID 0000.0001)           User time:   4.7683715820312500E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.7683715820312500E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.15634918212890625
-(PID.TID 0000.0001)         System time:   1.0972023010253906E-002
-(PID.TID 0000.0001)     Wall clock time:  0.17174077033996582
+(PID.TID 0000.0001)           User time:   8.9335441589355469E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.9352846145629883E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10628890991210938
-(PID.TID 0000.0001)         System time:   2.6988983154296875E-004
-(PID.TID 0000.0001)     Wall clock time:  0.10662603378295898
+(PID.TID 0000.0001)           User time:   2.8714179992675781E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8736352920532227E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   28.639062881469727
-(PID.TID 0000.0001)         System time:  0.20505666732788086
-(PID.TID 0000.0001)     Wall clock time:   29.418332576751709
+(PID.TID 0000.0001)           User time:   13.834168434143066
+(PID.TID 0000.0001)         System time:   3.8950443267822266E-003
+(PID.TID 0000.0001)     Wall clock time:   13.842002868652344
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   7.7056198120117188
-(PID.TID 0000.0001)         System time:   5.2281379699707031E-002
-(PID.TID 0000.0001)     Wall clock time:   7.8048000335693359
+(PID.TID 0000.0001)           User time:   3.9239578247070312
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9249224662780762
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   7.0710582733154297
-(PID.TID 0000.0001)         System time:   4.4823169708251953E-002
-(PID.TID 0000.0001)     Wall clock time:   7.1406469345092773
+(PID.TID 0000.0001)           User time:   3.6115322113037109
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6124591827392578
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   6.1297397613525391
-(PID.TID 0000.0001)         System time:   7.5087547302246094E-002
-(PID.TID 0000.0001)     Wall clock time:   6.6881949901580811
+(PID.TID 0000.0001)           User time:   3.0398483276367188
+(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
+(PID.TID 0000.0001)     Wall clock time:   3.0401666164398193
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   28.772338867187500
-(PID.TID 0000.0001)         System time:   4.5954227447509766E-002
-(PID.TID 0000.0001)     Wall clock time:   28.899775266647339
+(PID.TID 0000.0001)           User time:   16.469201087951660
+(PID.TID 0000.0001)         System time:   3.7090778350830078E-003
+(PID.TID 0000.0001)     Wall clock time:   16.477412223815918
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2260723114013672
-(PID.TID 0000.0001)         System time:   3.5467147827148438E-003
-(PID.TID 0000.0001)     Wall clock time:   1.2328228950500488
+(PID.TID 0000.0001)           User time:  0.50016975402832031
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.50017571449279785
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3197345733642578
-(PID.TID 0000.0001)         System time:   1.5244483947753906E-002
-(PID.TID 0000.0001)     Wall clock time:   4.3614666461944580
+(PID.TID 0000.0001)           User time:   2.4183092117309570
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.4194130897521973
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.58784103393554688
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.58785700798034668
+(PID.TID 0000.0001)           User time:  0.31035518646240234
+(PID.TID 0000.0001)         System time:   1.6033649444580078E-005
+(PID.TID 0000.0001)     Wall clock time:  0.31039357185363770
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3104114532470703
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.3135838508605957
+(PID.TID 0000.0001)           User time:  0.56855869293212891
+(PID.TID 0000.0001)         System time:   3.3974647521972656E-005
+(PID.TID 0000.0001)     Wall clock time:  0.56861662864685059
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.3795776367187500E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.3817472457885742E-002
+(PID.TID 0000.0001)           User time:   3.3044815063476562E-002
+(PID.TID 0000.0001)         System time:   2.0265579223632812E-006
+(PID.TID 0000.0001)     Wall clock time:   3.3058404922485352E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9169406890869141
-(PID.TID 0000.0001)         System time:   4.4498443603515625E-002
-(PID.TID 0000.0001)     Wall clock time:   1.9647758007049561
+(PID.TID 0000.0001)           User time:  0.41590023040771484
+(PID.TID 0000.0001)         System time:   1.1913955211639404E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42816734313964844
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   31.039337158203125
-(PID.TID 0000.0001)         System time:   6.4766407012939453E-002
-(PID.TID 0000.0001)     Wall clock time:   31.289303779602051
+(PID.TID 0000.0001)           User time:   16.703849792480469
+(PID.TID 0000.0001)         System time:   3.8880109786987305E-003
+(PID.TID 0000.0001)     Wall clock time:   16.712599992752075
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   9.0599060058593750E-005
+(PID.TID 0000.0001)           User time:   3.7193298339843750E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9815902709960938E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.3383331298828125
-(PID.TID 0000.0001)         System time:   4.7054290771484375E-003
-(PID.TID 0000.0001)     Wall clock time:   6.3559491634368896
+(PID.TID 0000.0001)           User time:   3.1059923171997070
+(PID.TID 0000.0001)         System time:   1.5974044799804688E-005
+(PID.TID 0000.0001)     Wall clock time:   3.1126337051391602
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
-(PID.TID 0000.0001)         System time:   5.2452087402343750E-006
-(PID.TID 0000.0001)     Wall clock time:   8.2492828369140625E-005
+(PID.TID 0000.0001)           User time:   4.3869018554687500E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.3869018554687500E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.3504219055175781
-(PID.TID 0000.0001)         System time:   1.9460525512695312
-(PID.TID 0000.0001)     Wall clock time:   8.3870100975036621
+(PID.TID 0000.0001)           User time:   3.8459224700927734
+(PID.TID 0000.0001)         System time:  0.21990597248077393
+(PID.TID 0000.0001)     Wall clock time:   4.0748059749603271
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3364181518554688
-(PID.TID 0000.0001)         System time:   1.5584478378295898
-(PID.TID 0000.0001)     Wall clock time:   4.1768958568572998
+(PID.TID 0000.0001)           User time:   1.4075088500976562
+(PID.TID 0000.0001)         System time:  0.23193597793579102
+(PID.TID 0000.0001)     Wall clock time:   1.7034130096435547
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.65492248535156250
-(PID.TID 0000.0001)         System time:  0.19482421875000000
-(PID.TID 0000.0001)     Wall clock time:   1.2437920570373535
+(PID.TID 0000.0001)           User time:  0.38598632812500000
+(PID.TID 0000.0001)         System time:   3.1870961189270020E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42749404907226562
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.2561035156250000E-004
-(PID.TID 0000.0001)         System time:   4.0054321289062500E-005
-(PID.TID 0000.0001)     Wall clock time:   6.7400932312011719E-004
+(PID.TID 0000.0001)           User time:   3.8909912109375000E-004
+(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
+(PID.TID 0000.0001)     Wall clock time:   3.8695335388183594E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.2443695068359375
-(PID.TID 0000.0001)         System time:   1.4460229873657227
-(PID.TID 0000.0001)     Wall clock time:   7.4406640529632568
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   1.8157424926757812
+(PID.TID 0000.0001)         System time:  0.11195898056030273
+(PID.TID 0000.0001)     Wall clock time:   4.1360750198364258
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.4296112060546875
-(PID.TID 0000.0001)         System time:   1.2420768737792969
-(PID.TID 0000.0001)     Wall clock time:   6.2908709049224854
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   1.3996353149414062
+(PID.TID 0000.0001)         System time:   9.1961026191711426E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6358230113983154
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.81468200683593750
-(PID.TID 0000.0001)         System time:  0.20394325256347656
-(PID.TID 0000.0001)     Wall clock time:   1.1497368812561035
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.41608428955078125
+(PID.TID 0000.0001)         System time:   1.9997954368591309E-002
+(PID.TID 0000.0001)     Wall clock time:   2.5002331733703613
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   0.0000000000000000
-(PID.TID 0000.0001)         System time:   1.7299652099609375E-003
-(PID.TID 0000.0001)     Wall clock time:   2.1998882293701172E-003
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   9.9945068359375000E-004
+(PID.TID 0000.0001)         System time:   1.4066696166992188E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0058879852294922E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6895,9 +6561,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          37144
+(PID.TID 0000.0001) //            No. barriers =          37158
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          37144
+(PID.TID 0000.0001) //     Total barrier spins =          37158
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.ecco_v4.txt
+++ b/global_oce_llc90/results/output.ecco_v4.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -231,7 +231,7 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=300,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-12,
+(PID.TID 0000.0001) > cg2dTargetResWunit=2.46E-10,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -605,7 +605,6 @@
 (PID.TID 0000.0001) ># | Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) ># =====================================================================
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) ># GGL90taveFreq = 345600000.,
 (PID.TID 0000.0001) ># GGL90dumpFreq = 86400.,
 (PID.TID 0000.0001) ># GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) ># GGL90diffTKEh=3.e3,
@@ -625,9 +624,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) GGL90dumpFreq =   /* GGL90 state write out interval ( s ). */
 (PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
@@ -669,6 +665,9 @@
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) adMxlMaxFlag =   /* Flag for limiting mixing-length method in AD-mode */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
@@ -777,7 +776,7 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEuseMetricTerms = .TRUE.,
+(PID.TID 0000.0001) >      SEAICEselectMetricTerms= 1,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
 (PID.TID 0000.0001) >#take 33% out of (1-albedo)
@@ -786,12 +785,12 @@
 (PID.TID 0000.0001) >      SEAICE_drySnowAlb  = 0.90,
 (PID.TID 0000.0001) >      SEAICE_wetSnowAlb  = 0.8 ,
 (PID.TID 0000.0001) >#default albedos
-(PID.TID 0000.0001) >      SEAICE_dryIceAlb_south   = 0.75
-(PID.TID 0000.0001) >      SEAICE_wetIceAlb_south   = 0.66
-(PID.TID 0000.0001) >      SEAICE_drySnowAlb_south  = 0.84
-(PID.TID 0000.0001) >      SEAICE_wetSnowAlb_south  = 0.7
+(PID.TID 0000.0001) >      SEAICE_dryIceAlb_south   = 0.75,
+(PID.TID 0000.0001) >      SEAICE_wetIceAlb_south   = 0.66,
+(PID.TID 0000.0001) >      SEAICE_drySnowAlb_south  = 0.84,
+(PID.TID 0000.0001) >      SEAICE_wetSnowAlb_south  = 0.7,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -878,6 +877,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: opening data.ecco
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ecco
 (PID.TID 0000.0001) // =======================================================
@@ -1329,7 +1341,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1878,80 +1894,6 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 7) = thetaclim
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_T_atlas.bin
-(PID.TID 0000.0001)  model file = m_theta_mon
-(PID.TID 0000.0001)  error file = sigma_T_atlas2_eccollc.bin
-(PID.TID 0000.0001)  preprocess = clim
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 8) = saltclim
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_S_atlas.bin
-(PID.TID 0000.0001)  model file = m_salt_mon
-(PID.TID 0000.0001)  error file = sigma_S_atlas2_eccollc.bin
-(PID.TID 0000.0001)  preprocess = clim
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  2
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost(11) = sshv4-mdt
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = mdt_pak09.bin
-(PID.TID 0000.0001)  model file =
-(PID.TID 0000.0001)  error file = sigma_MDT_glob_eccollc.bin
-(PID.TID 0000.0001)  posprocess = smooth
-(PID.TID 0000.0001)  gencost_flag = -1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  skip barfile write =  T
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost(15) = sshv4-lsc
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  model file =
-(PID.TID 0000.0001)  error file = slaerr_largescale_r5.err
-(PID.TID 0000.0001)  posprocess = smooth
-(PID.TID 0000.0001)  gencost_flag = -1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  skip barfile write =  T
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost(16) = sshv4-gmsl
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  model file =
-(PID.TID 0000.0001)  error file =
-(PID.TID 0000.0001)  gencost_flag = -1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  skip barfile write =  T
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost(17) = sss_repeat
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_S_atlas.bin
-(PID.TID 0000.0001)  model file = m_salt_mon
-(PID.TID 0000.0001)  error file = sigma_surf_0p5.bin
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  0
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  3
-(PID.TID 0000.0001)  skip barfile write =  T
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // insitu profiles model sampling >>> START <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
@@ -2006,6 +1948,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseLSRflex  = /* with residual norm criterion */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
 (PID.TID 0000.0001)                   F
@@ -2088,8 +2033,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -2160,25 +2105,28 @@
 (PID.TID 0000.0001) SEAICEadvSnow = /* advect snow layer together with ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEmultiDimAdvection = /* multidimadvec */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEadvScheme   = /* advection scheme for ice */
 (PID.TID 0000.0001)                      30
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchArea   = /* advection scheme for area */
+(PID.TID 0000.0001) SEAICEadvSchArea  = /* advection scheme for area */
 (PID.TID 0000.0001)                      30
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchHeff   = /* advection scheme for thickness */
+(PID.TID 0000.0001) SEAICEadvSchHeff  = /* advection scheme for thickness */
 (PID.TID 0000.0001)                      30
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchSnow   = /* advection scheme for snow */
+(PID.TID 0000.0001) SEAICEadvSchSnow  = /* advection scheme for snow */
 (PID.TID 0000.0001)                      30
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhArea   = /* diffusivity (m^2/s) for area */
+(PID.TID 0000.0001) SEAICEdiffKhArea  = /* diffusivity (m^2/s) for area */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhHeff   = /* diffusivity (m^2/s) for heff */
+(PID.TID 0000.0001) SEAICEdiffKhHeff  = /* diffusivity (m^2/s) for heff */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhSnow   = /* diffusivity (m^2/s) for snow */
+(PID.TID 0000.0001) SEAICEdiffKhSnow  = /* diffusivity (m^2/s) for snow */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) DIFF1             = /* parameter used in advect.F [m/s] */
@@ -2269,6 +2217,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
@@ -2373,16 +2324,10 @@
 (PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
@@ -2411,469 +2356,81 @@
 (PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   3 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =      1203786
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          312
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          312
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          283
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =        11544
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         23088
-(PID.TID 0000.0001) ctrl-wet 8: atmos        23088
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    10           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    11           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    12           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    13           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    14           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    15           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   50     7220976
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3       59874       58517       58725           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4       59387       58040       58258           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5       58882       57536       57754           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6       58399       57057       57276           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7       58052       56735       56936           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8       57781       56461       56669           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9       57530       56212       56416           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10       57283       55964       56154           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11       57022       55702       55883           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12       56818       55497       55681           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13       56634       55322       55509           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14       56430       55125       55312           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15       56238       54935       55117           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   16       55975       54689       54858           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   17       55703       54421       54600           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   18       55358       54075       54251           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   19       54964       53666       53853           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   20       54471       53205       53372           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   21       53952       52716       52877           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   22       53489       52249       52409           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   23       52892       51633       51797           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   24       52223       50961       51129           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   25       51696       50480       50635           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   26       51259       50075       50241           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   27       50929       49774       49935           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   28       50664       49532       49678           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   29       50438       49306       49450           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   30       50187       49035       49179           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   31       49964       48805       48937           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   32       49700       48530       48662           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   33       49431       48260       48383           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   34       49176       47993       48108           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   35       48854       47652       47764           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   36       48501       47264       47375           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   37       48098       46846       46951           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   38       47523       46253       46362           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   39       46849       45558       45657           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   40       45984       44670       44751           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   41       44793       43419       43459           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   42       42984       41497       41533           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   43       40302       38691       38718           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   44       36689       35007       35032           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   45       31681       30069       29999           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   46       25595       24028       24031           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   47       18224       16890       16872           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   48       11407       10397       10351           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   49        4597        3913        3912           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   50         818         624         622           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3       59874       58517       58725
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4       59387       58040       58258
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5       58882       57536       57754
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6       58399       57057       57276
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7       58052       56735       56936
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8       57781       56461       56669
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9       57530       56212       56416
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10       57283       55964       56154
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11       57022       55702       55883
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12       56818       55497       55681
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13       56634       55322       55509
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14       56430       55125       55312
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15       56238       54935       55117
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   16       55975       54689       54858
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   17       55703       54421       54600
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   18       55358       54075       54251
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   19       54964       53666       53853
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   20       54471       53205       53372
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   21       53952       52716       52877
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   22       53489       52249       52409
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   23       52892       51633       51797
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   24       52223       50961       51129
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   25       51696       50480       50635
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   26       51259       50075       50241
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   27       50929       49774       49935
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   28       50664       49532       49678
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   29       50438       49306       49450
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   30       50187       49035       49179
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   31       49964       48805       48937
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   32       49700       48530       48662
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   33       49431       48260       48383
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   34       49176       47993       48108
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   35       48854       47652       47764
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   36       48501       47264       47375
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   37       48098       46846       46951
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   38       47523       46253       46362
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   39       46849       45558       45657
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   40       45984       44670       44751
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   41       44793       43419       43459
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   42       42984       41497       41533
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   43       40302       38691       38718
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   44       36689       35007       35032
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   45       31681       30069       29999
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   46       25595       24028       24031
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   47       18224       16890       16872
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   48       11407       10397       10351
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   49        4597        3913        3912
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   50         818         624         622
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
@@ -2884,41 +2441,46 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Total number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------------
-(PID.TID 0000.0001)  snx*sny*nr =    45000
+(PID.TID 0000.0001)  sNx*sNy*Nr =    45000
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 011544 010207 011460
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 041559 041310 041343
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 039915 038420 039722
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0004 0001 035457 033982 035227
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0005 0001 040378 040035 040082
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0006 0001 040418 040096 040138
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0007 0001 040462 040067 040100
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0008 0001 040877 040589 040319
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0009 0001 031231 030937 030957
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0010 0001 020622 020046 018422
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0011 0001 039018 038680 038425
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0012 0001 019781 019699 019576
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001   11544   10207   11460
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001   41559   41310   41343
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001   39915   38420   39722
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 004 001   35457   33982   35227
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 005 001   40378   40035   40082
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 006 001   40418   40096   40138
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 007 001   40462   40067   40100
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 008 001   40877   40589   40319
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 009 001   31231   30937   30957
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 010 001   20622   20046   18422
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 011 001   39018   38680   38425
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 012 001   19781   19699   19576
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2926,74 +2488,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   367
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   283 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   285 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    85 sIceLoad
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    78 MXLDEPTH
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   367 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   312 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceQnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceFWflx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   332 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   340 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   341 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   342 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   343 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    48 WVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   265 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   266 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   136 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   137 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   133 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   143 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   144 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   140 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
-(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
-(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
-(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
-(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
-(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
-(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
-(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
-(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
-(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
-(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
-(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
-(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
-(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
-(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
-(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
-(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
+(PID.TID 0000.0001)   set mate pointer for diag #   332  ADVxHEFF , Parms: UU      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVyHEFF , Parms: VV      M1 , mate:   332
+(PID.TID 0000.0001)   set mate pointer for diag #   334  DFxEHEFF , Parms: UU      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFyEHEFF , Parms: VV      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   340  ADVxSNOW , Parms: UU      M1 , mate:   341
+(PID.TID 0000.0001)   set mate pointer for diag #   341  ADVySNOW , Parms: VV      M1 , mate:   340
+(PID.TID 0000.0001)   set mate pointer for diag #   342  DFxESNOW , Parms: UU      M1 , mate:   343
+(PID.TID 0000.0001)   set mate pointer for diag #   343  DFyESNOW , Parms: VV      M1 , mate:   342
+(PID.TID 0000.0001)   set mate pointer for diag #   297  SIuice   , Parms: UU      M1 , mate:   298
+(PID.TID 0000.0001)   set mate pointer for diag #   298  SIvice   , Parms: VV      M1 , mate:   297
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   265  GM_PsiX  , Parms: UU      LR , mate:   266
+(PID.TID 0000.0001)   set mate pointer for diag #   266  GM_PsiY  , Parms: VV      LR , mate:   265
+(PID.TID 0000.0001)   set mate pointer for diag #   136  DFxE_TH  , Parms: UU      MR , mate:   137
+(PID.TID 0000.0001)   set mate pointer for diag #   137  DFyE_TH  , Parms: VV      MR , mate:   136
+(PID.TID 0000.0001)   set mate pointer for diag #   133  ADVx_TH  , Parms: UU      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   134  ADVy_TH  , Parms: VV      MR , mate:   133
+(PID.TID 0000.0001)   set mate pointer for diag #   143  DFxE_SLT , Parms: UU      MR , mate:   144
+(PID.TID 0000.0001)   set mate pointer for diag #   144  DFyE_SLT , Parms: VV      MR , mate:   143
+(PID.TID 0000.0001)   set mate pointer for diag #   140  ADVx_SLT , Parms: UU      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   141  ADVy_SLT , Parms: VV      MR , mate:   140
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -3008,12 +2570,12 @@
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
 (PID.TID 0000.0001)  Levels:      21.  22.  23.  24.  25.  26.  27.  28.  29.  30.  31.  32.  33.  34.  35.  36.  37.  38.  39.  40.
 (PID.TID 0000.0001)  Levels:      41.  42.  43.  44.  45.  46.  47.  48.  49.  50.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     825 levels (numDiags =    3000 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use       0 levels (diagSt_size=    2500 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found   0 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4584096177006E-04
@@ -3029,7 +2591,7 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   9.3876998486639E-05
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.9559575367967E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  7.1522409280111305E-05
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.112781640300954E-06 (Area=3.5801386115E+14)
+(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.105154116076021E-06 (Area=1.4537802370E+12)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -3380,7 +2942,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -3460,17 +3022,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -3478,6 +3030,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       1
@@ -3496,6 +3058,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -3550,6 +3113,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3640,7 +3206,7 @@
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-12
+(PID.TID 0000.0001)                 2.460000000000000E-10
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -3652,7 +3218,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -4792,6 +4358,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.580138611494435E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 6.226703613420189E+09
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 6.064600000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 2.406992000000000E+06
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -4819,11 +4394,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+02
@@ -4879,6 +4457,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4886,6 +4467,81 @@
 (PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
+(PID.TID 0000.0001) ECCO_CHECK:  --> Starts to check ECCO set-up
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 7) = thetaclim
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_T_atlas.bin
+(PID.TID 0000.0001)  model file = m_theta_mon
+(PID.TID 0000.0001)  error file = sigma_T_atlas2_eccollc.bin
+(PID.TID 0000.0001)  preprocess = clim
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 8) = saltclim
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_S_atlas.bin
+(PID.TID 0000.0001)  model file = m_salt_mon
+(PID.TID 0000.0001)  error file = sigma_S_atlas2_eccollc.bin
+(PID.TID 0000.0001)  preprocess = clim
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  2
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost(11) = sshv4-mdt
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = mdt_pak09.bin
+(PID.TID 0000.0001)  model file =
+(PID.TID 0000.0001)  error file = sigma_MDT_glob_eccollc.bin
+(PID.TID 0000.0001)  posprocess = smooth
+(PID.TID 0000.0001)  gencost_flag = -1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  skip barfile WRITE =  T
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost(15) = sshv4-lsc
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  model file =
+(PID.TID 0000.0001)  error file = slaerr_largescale_r5.err
+(PID.TID 0000.0001)  posprocess = smooth
+(PID.TID 0000.0001)  gencost_flag = -1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  skip barfile WRITE =  T
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost(16) = sshv4-gmsl
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  model file =
+(PID.TID 0000.0001)  error file =
+(PID.TID 0000.0001)  gencost_flag = -1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  skip barfile WRITE =  T
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost(17) = sss_repeat
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_S_atlas.bin
+(PID.TID 0000.0001)  model file = m_salt_mon
+(PID.TID 0000.0001)  error file = sigma_surf_0p5.bin
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  0
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  3
+(PID.TID 0000.0001)  skip barfile WRITE =  T
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) ECCO_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -5324,7 +4980,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01131476956519E+00  1.10183783642738E+00
+ cg2d: Sum(rhs),rhsMax =   3.01672307255695E+00  1.10183783642738E+00
 (PID.TID 0000.0001)      cg2d_init_res =   4.03291087967738E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      97
 (PID.TID 0000.0001)      cg2d_last_res =   6.88051360107281E-06
@@ -5521,7 +5177,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01096285026427E+00  1.09717250638400E+00
+ cg2d: Sum(rhs),rhsMax =   3.02263726615829E+00  1.09717250638400E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.75526144676127E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      95
 (PID.TID 0000.0001)      cg2d_last_res =   6.79765838843589E-06
@@ -5718,7 +5374,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01036950130346E+00  1.09443701669866E+00
+ cg2d: Sum(rhs),rhsMax =   3.02924515908735E+00  1.09443701669866E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.32213134550256E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
 (PID.TID 0000.0001)      cg2d_last_res =   7.05928771128775E-06
@@ -5915,7 +5571,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01123698530932E+00  1.08987441748664E+00
+ cg2d: Sum(rhs),rhsMax =   3.03676145643997E+00  1.08987441748664E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.28364955361420E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      92
 (PID.TID 0000.0001)      cg2d_last_res =   6.70987508246740E-06
@@ -6112,7 +5768,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01331887035770E+00  1.08661842749350E+00
+ cg2d: Sum(rhs),rhsMax =   3.04496430127163E+00  1.08661842749350E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.24939789284725E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      91
 (PID.TID 0000.0001)      cg2d_last_res =   6.74173369554545E-06
@@ -6309,7 +5965,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01630776289169E+00  1.08470790816857E+00
+ cg2d: Sum(rhs),rhsMax =   3.05356772993964E+00  1.08470790816857E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.17388417699739E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      90
 (PID.TID 0000.0001)      cg2d_last_res =   6.40586663997318E-06
@@ -6506,7 +6162,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.01995412191042E+00  1.08353186428219E+00
+ cg2d: Sum(rhs),rhsMax =   3.06234665490071E+00  1.08353186428219E+00
 (PID.TID 0000.0001)      cg2d_init_res =   3.10512009916359E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      87
 (PID.TID 0000.0001)      cg2d_last_res =   7.00108281322553E-06
@@ -6627,251 +6283,263 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT         9 ckptA
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) == cost_profiles: begin ==
-(PID.TID 0000.0001) == cost_profiles: end   ==
+(PID.TID 0000.0001) == profiles_cost: begin ==
+(PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.427572450015610D+07 7
-(PID.TID 0000.0001)  --> f_gencost = 0.490822322919029D+07 8
-(PID.TID 0000.0001)  --> f_gencost = 0.101769702990439D+0617
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.918394772934639D+07
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.151257848014580D+07
-(PID.TID 0000.0001)  global fc =  0.918394772934639D+07
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  4.27572450015610E+06  7  1.00E+00 (thetaclim)
+(PID.TID 0000.0001)  --> f_gencost  =  4.90822322919029E+06  8  1.00E+00 (saltclim)
+(PID.TID 0000.0001)  --> f_gencost  =  1.01769702990439E+05 17  0.00E+00 (sss_repeat)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.51257848014580E+06
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   9.18394772934639E+06
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   179.25060348957777
-(PID.TID 0000.0001)         System time:   15.415907554328442
-(PID.TID 0000.0001)     Wall clock time:   218.28228402137756
+(PID.TID 0000.0001)           User time:   93.809989653062075
+(PID.TID 0000.0001)         System time:   1.6152600487694144
+(PID.TID 0000.0001)     Wall clock time:   97.225008010864258
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5.1993158385157585
-(PID.TID 0000.0001)         System time:   3.5040230229496956
-(PID.TID 0000.0001)     Wall clock time:   8.9087638854980469
+(PID.TID 0000.0001)           User time:   2.6877329964190722
+(PID.TID 0000.0001)         System time:  0.28040500171482563
+(PID.TID 0000.0001)     Wall clock time:   2.9974210262298584
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   174.05123329162598
-(PID.TID 0000.0001)         System time:   11.911805629730225
-(PID.TID 0000.0001)     Wall clock time:   209.37342000007629
+(PID.TID 0000.0001)           User time:   91.122237682342529
+(PID.TID 0000.0001)         System time:   1.3348470628261566
+(PID.TID 0000.0001)     Wall clock time:   94.227556943893433
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.757159709930420
-(PID.TID 0000.0001)         System time:   6.2747375965118408
-(PID.TID 0000.0001)     Wall clock time:   37.418164968490601
+(PID.TID 0000.0001)           User time:   6.6008169651031494
+(PID.TID 0000.0001)         System time:  0.57933202385902405
+(PID.TID 0000.0001)     Wall clock time:   7.1902389526367188
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   158.29395675659180
-(PID.TID 0000.0001)         System time:   5.6370096206665039
-(PID.TID 0000.0001)     Wall clock time:   171.95510792732239
+(PID.TID 0000.0001)           User time:   84.521397590637207
+(PID.TID 0000.0001)         System time:  0.75551307201385498
+(PID.TID 0000.0001)     Wall clock time:   87.037298917770386
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8798465728759766
-(PID.TID 0000.0001)         System time:   2.3565292358398438E-003
-(PID.TID 0000.0001)     Wall clock time:   2.1898152828216553
+(PID.TID 0000.0001)           User time:  0.86217117309570312
+(PID.TID 0000.0001)         System time:   6.0200691223144531E-006
+(PID.TID 0000.0001)     Wall clock time:  0.86326169967651367
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.3501129150390625E-003
-(PID.TID 0000.0001)         System time:   3.2424926757812500E-004
-(PID.TID 0000.0001)     Wall clock time:   5.6767463684082031E-003
+(PID.TID 0000.0001)           User time:   2.8696060180664062E-003
+(PID.TID 0000.0001)         System time:   2.9981136322021484E-005
+(PID.TID 0000.0001)     Wall clock time:   2.9053688049316406E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   151.14856338500977
-(PID.TID 0000.0001)         System time:   3.4913473129272461
-(PID.TID 0000.0001)     Wall clock time:   157.13636374473572
+(PID.TID 0000.0001)           User time:   81.041268348693848
+(PID.TID 0000.0001)         System time:  0.60754495859146118
+(PID.TID 0000.0001)     Wall clock time:   82.318573236465454
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   151.14838409423828
-(PID.TID 0000.0001)         System time:   3.4913406372070312
-(PID.TID 0000.0001)     Wall clock time:   157.13621520996094
+(PID.TID 0000.0001)           User time:   81.041195869445801
+(PID.TID 0000.0001)         System time:  0.60754495859146118
+(PID.TID 0000.0001)     Wall clock time:   82.318496942520142
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6277103424072266
-(PID.TID 0000.0001)         System time:   1.9931793212890625E-004
-(PID.TID 0000.0001)     Wall clock time:   2.6307477951049805
+(PID.TID 0000.0001)           User time:  0.99051284790039062
+(PID.TID 0000.0001)         System time:   2.3961067199707031E-005
+(PID.TID 0000.0001)     Wall clock time:  0.99114942550659180
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3719215393066406
-(PID.TID 0000.0001)         System time:   2.8581619262695312E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4040780067443848
+(PID.TID 0000.0001)           User time:  0.25780582427978516
+(PID.TID 0000.0001)         System time:   3.9330124855041504E-003
+(PID.TID 0000.0001)     Wall clock time:  0.27108311653137207
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5137138366699219
-(PID.TID 0000.0001)         System time:  0.11807537078857422
-(PID.TID 0000.0001)     Wall clock time:   2.0836420059204102
+(PID.TID 0000.0001)           User time:  0.52492904663085938
+(PID.TID 0000.0001)         System time:   2.4333953857421875E-002
+(PID.TID 0000.0001)     Wall clock time:  0.55233931541442871
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.5132198333740234
-(PID.TID 0000.0001)         System time:  0.11803627014160156
-(PID.TID 0000.0001)     Wall clock time:   2.0831711292266846
+(PID.TID 0000.0001)           User time:  0.52364158630371094
+(PID.TID 0000.0001)         System time:   2.4319946765899658E-002
+(PID.TID 0000.0001)     Wall clock time:  0.55105519294738770
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.0681152343750000E-004
-(PID.TID 0000.0001)         System time:   1.3351440429687500E-005
-(PID.TID 0000.0001)     Wall clock time:   1.3399124145507812E-004
+(PID.TID 0000.0001)           User time:   4.8637390136718750E-005
+(PID.TID 0000.0001)         System time:   2.0265579223632812E-006
+(PID.TID 0000.0001)     Wall clock time:   4.4345855712890625E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.19662857055664062
-(PID.TID 0000.0001)         System time:   1.1291503906250000E-003
-(PID.TID 0000.0001)     Wall clock time:  0.20941781997680664
+(PID.TID 0000.0001)           User time:   9.0488433837890625E-002
+(PID.TID 0000.0001)         System time:   3.2401084899902344E-004
+(PID.TID 0000.0001)     Wall clock time:   9.1626882553100586E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11429214477539062
-(PID.TID 0000.0001)         System time:   2.1266937255859375E-004
-(PID.TID 0000.0001)     Wall clock time:  0.11480116844177246
+(PID.TID 0000.0001)           User time:   2.8638839721679688E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8656005859375000E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   30.809169769287109
-(PID.TID 0000.0001)         System time:   8.1671714782714844E-002
-(PID.TID 0000.0001)     Wall clock time:   31.052325248718262
+(PID.TID 0000.0001)           User time:   15.595914840698242
+(PID.TID 0000.0001)         System time:   1.5965998172760010E-002
+(PID.TID 0000.0001)     Wall clock time:   15.666312932968140
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   9.6968517303466797
-(PID.TID 0000.0001)         System time:   1.9706726074218750E-002
-(PID.TID 0000.0001)     Wall clock time:   9.7551999092102051
+(PID.TID 0000.0001)           User time:   5.3109989166259766
+(PID.TID 0000.0001)         System time:   7.8080296516418457E-003
+(PID.TID 0000.0001)     Wall clock time:   5.3319787979125977
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   9.0752773284912109
-(PID.TID 0000.0001)         System time:   1.9259452819824219E-002
-(PID.TID 0000.0001)     Wall clock time:   9.1321492195129395
+(PID.TID 0000.0001)           User time:   5.0144567489624023
+(PID.TID 0000.0001)         System time:   7.7480077743530273E-003
+(PID.TID 0000.0001)     Wall clock time:   5.0277261734008789
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   5.7814502716064453
-(PID.TID 0000.0001)         System time:   2.1646499633789062E-002
-(PID.TID 0000.0001)     Wall clock time:   5.8599669933319092
+(PID.TID 0000.0001)           User time:   3.0462045669555664
+(PID.TID 0000.0001)         System time:   4.2370557785034180E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0879511833190918
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   28.244770050048828
-(PID.TID 0000.0001)         System time:   2.1521568298339844E-002
-(PID.TID 0000.0001)     Wall clock time:   28.379514932632446
+(PID.TID 0000.0001)           User time:   16.443055152893066
+(PID.TID 0000.0001)         System time:   6.6041946411132812E-005
+(PID.TID 0000.0001)     Wall clock time:   16.448317527770996
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.0042667388916016
-(PID.TID 0000.0001)         System time:   3.4332275390625000E-005
-(PID.TID 0000.0001)     Wall clock time:   1.0048360824584961
+(PID.TID 0000.0001)           User time:  0.51086902618408203
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.51116800308227539
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.4775314331054688
-(PID.TID 0000.0001)         System time:   3.0221939086914062E-003
-(PID.TID 0000.0001)     Wall clock time:   3.5611221790313721
+(PID.TID 0000.0001)           User time:   1.7131824493408203
+(PID.TID 0000.0001)         System time:   3.6659836769104004E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7351946830749512
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.61731910705566406
-(PID.TID 0000.0001)         System time:   2.8896331787109375E-004
-(PID.TID 0000.0001)     Wall clock time:  0.62029504776000977
+(PID.TID 0000.0001)           User time:  0.31047821044921875
+(PID.TID 0000.0001)         System time:   1.4799833297729492E-004
+(PID.TID 0000.0001)     Wall clock time:  0.31090807914733887
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2310047149658203
-(PID.TID 0000.0001)         System time:   1.0490417480468750E-005
-(PID.TID 0000.0001)     Wall clock time:   1.2317488193511963
+(PID.TID 0000.0001)           User time:  0.56517028808593750
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.56518459320068359
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.9732894897460938E-002
-(PID.TID 0000.0001)         System time:   1.1539459228515625E-004
-(PID.TID 0000.0001)     Wall clock time:   7.9875946044921875E-002
+(PID.TID 0000.0001)           User time:   3.6101341247558594E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6107301712036133E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1641292572021484
-(PID.TID 0000.0001)         System time:   3.4526824951171875E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1990919113159180
+(PID.TID 0000.0001)           User time:  0.45784378051757812
+(PID.TID 0000.0001)         System time:   4.0239691734313965E-003
+(PID.TID 0000.0001)     Wall clock time:  0.46220612525939941
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   30.432571411132812
-(PID.TID 0000.0001)         System time:   2.5956153869628906E-002
-(PID.TID 0000.0001)     Wall clock time:   30.771935224533081
+(PID.TID 0000.0001)           User time:   16.576998710632324
+(PID.TID 0000.0001)         System time:   2.7000904083251953E-005
+(PID.TID 0000.0001)     Wall clock time:   16.618823051452637
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   7.2717666625976562E-005
+(PID.TID 0000.0001)           User time:   2.6702880859375000E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9100646972656250E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.3388671875000000
-(PID.TID 0000.0001)         System time:   3.9072036743164062E-003
-(PID.TID 0000.0001)     Wall clock time:   6.3699591159820557
+(PID.TID 0000.0001)           User time:   3.2629222869873047
+(PID.TID 0000.0001)         System time:   3.2007694244384766E-005
+(PID.TID 0000.0001)     Wall clock time:   3.2637934684753418
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
-(PID.TID 0000.0001)         System time:   4.7683715820312500E-006
-(PID.TID 0000.0001)     Wall clock time:   7.8678131103515625E-005
+(PID.TID 0000.0001)           User time:   3.6239624023437500E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8623809814453125E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.1694145202636719
-(PID.TID 0000.0001)         System time:   1.7634897232055664
-(PID.TID 0000.0001)     Wall clock time:   9.2272875308990479
+(PID.TID 0000.0001)           User time:   3.7964420318603516
+(PID.TID 0000.0001)         System time:  0.29139202833175659
+(PID.TID 0000.0001)     Wall clock time:   4.2872366905212402
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0300712585449219
-(PID.TID 0000.0001)         System time:   1.4068727493286133
-(PID.TID 0000.0001)     Wall clock time:   4.3664622306823730
+(PID.TID 0000.0001)           User time:   1.3255062103271484
+(PID.TID 0000.0001)         System time:  0.26355397701263428
+(PID.TID 0000.0001)     Wall clock time:   1.9189450740814209
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.68118286132812500
-(PID.TID 0000.0001)         System time:  0.14794731140136719
-(PID.TID 0000.0001)     Wall clock time:  0.83621692657470703
+(PID.TID 0000.0001)           User time:  0.40284729003906250
+(PID.TID 0000.0001)         System time:   2.3898005485534668E-002
+(PID.TID 0000.0001)     Wall clock time:  0.43628311157226562
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   7.1716308593750000E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.2002410888671875E-004
+(PID.TID 0000.0001)           User time:   3.4332275390625000E-004
+(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
+(PID.TID 0000.0001)     Wall clock time:   3.4999847412109375E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   4.5725250244140625
-(PID.TID 0000.0001)         System time:   1.9948501586914062
-(PID.TID 0000.0001)     Wall clock time:   11.780397891998291
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   2.2083129882812500
+(PID.TID 0000.0001)         System time:  0.12400996685028076
+(PID.TID 0000.0001)     Wall clock time:   3.4123508930206299
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   3.7020721435546875
-(PID.TID 0000.0001)         System time:   1.5313825607299805
-(PID.TID 0000.0001)     Wall clock time:   8.5863080024719238
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   1.7896423339843750
+(PID.TID 0000.0001)         System time:  0.10796999931335449
+(PID.TID 0000.0001)     Wall clock time:   2.9772658348083496
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.87039184570312500
-(PID.TID 0000.0001)         System time:  0.46346282958984375
-(PID.TID 0000.0001)     Wall clock time:   3.1940279006958008
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.41864776611328125
+(PID.TID 0000.0001)         System time:   1.6039013862609863E-002
+(PID.TID 0000.0001)     Wall clock time:  0.43506789207458496
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.4801025390625000E-003
-(PID.TID 0000.0001)         System time:   1.2874603271484375E-004
-(PID.TID 0000.0001)     Wall clock time:   1.6160011291503906E-003
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   9.3841552734375000E-004
+(PID.TID 0000.0001)         System time:   1.7046928405761719E-005
+(PID.TID 0000.0001)     Wall clock time:   9.5605850219726562E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -7010,9 +6678,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          37820
+(PID.TID 0000.0001) //            No. barriers =          37818
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          37820
+(PID.TID 0000.0001) //     Total barrier spins =          37818
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.ecco_v4.txt
+++ b/global_oce_llc90/results/output.ecco_v4.txt
@@ -8,7 +8,7 @@
 (PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
+(PID.TID 0000.0001) // Build date:        Thu Apr 23 10:09:17 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -735,14 +735,16 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) ># SEAICE parameters
 (PID.TID 0000.0001) > &SEAICE_PARM01
-(PID.TID 0000.0001) >#the following is needed to recover old default values
-(PID.TID 0000.0001) >#since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
+(PID.TID 0000.0001) >#- the following is needed to recover old default values
+(PID.TID 0000.0001) >#  since PR116 (https://github.com/MITgcm/MITgcm/pull/116)
 (PID.TID 0000.0001) >      SEAICE_waterDrag=0.005344995140913508357982664,
 (PID.TID 0000.0001) >      SEAICEetaZmethod=0,
 (PID.TID 0000.0001) >      SEAICEscaleSurfStress=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEaddSnowMass=.FALSE.,
 (PID.TID 0000.0001) >      SEAICE_OLx=0,
 (PID.TID 0000.0001) >      SEAICE_OLy=0,
+(PID.TID 0000.0001) >#- to reproduce old results/defaults after PR-976
+(PID.TID 0000.0001) >      SEAICEselectMetricTerms= 1,
 (PID.TID 0000.0001) >#
 (PID.TID 0000.0001) >      SEAICEuseTILT=.FALSE.,
 (PID.TID 0000.0001) >      SEAICEpresH0=2.,
@@ -776,15 +778,14 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEselectMetricTerms= 1,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
-(PID.TID 0000.0001) >#take 33% out of (1-albedo)
+(PID.TID 0000.0001) >#- take 33% out of (1-albedo)
 (PID.TID 0000.0001) >      SEAICE_dryIceAlb   = 0.84,
 (PID.TID 0000.0001) >      SEAICE_wetIceAlb   = 0.78,
 (PID.TID 0000.0001) >      SEAICE_drySnowAlb  = 0.90,
 (PID.TID 0000.0001) >      SEAICE_wetSnowAlb  = 0.8 ,
-(PID.TID 0000.0001) >#default albedos
+(PID.TID 0000.0001) >#- default albedos
 (PID.TID 0000.0001) >      SEAICE_dryIceAlb_south   = 0.75,
 (PID.TID 0000.0001) >      SEAICE_wetIceAlb_south   = 0.66,
 (PID.TID 0000.0001) >      SEAICE_drySnowAlb_south  = 0.84,
@@ -793,7 +794,6 @@
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  SEAICE_READPARMS: finished reading data.seaice
 (PID.TID 0000.0001) SALT_PLUME_READPARMS: opening data.salt_plume
@@ -6309,237 +6309,237 @@
 (PID.TID 0000.0001) // End of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   93.809989653062075
-(PID.TID 0000.0001)         System time:   1.6152600487694144
-(PID.TID 0000.0001)     Wall clock time:   97.225008010864258
+(PID.TID 0000.0001)           User time:   95.510813582688570
+(PID.TID 0000.0001)         System time:   1.8721490073949099
+(PID.TID 0000.0001)     Wall clock time:   99.755676031112671
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2.6877329964190722
-(PID.TID 0000.0001)         System time:  0.28040500171482563
-(PID.TID 0000.0001)     Wall clock time:   2.9974210262298584
+(PID.TID 0000.0001)           User time:   2.7588488887995481
+(PID.TID 0000.0001)         System time:  0.33880701381713152
+(PID.TID 0000.0001)     Wall clock time:   3.1086161136627197
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   91.122237682342529
-(PID.TID 0000.0001)         System time:   1.3348470628261566
-(PID.TID 0000.0001)     Wall clock time:   94.227556943893433
+(PID.TID 0000.0001)           User time:   92.751937627792358
+(PID.TID 0000.0001)         System time:   1.5333369970321655
+(PID.TID 0000.0001)     Wall clock time:   96.647026062011719
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.6008169651031494
-(PID.TID 0000.0001)         System time:  0.57933202385902405
-(PID.TID 0000.0001)     Wall clock time:   7.1902389526367188
+(PID.TID 0000.0001)           User time:   6.9400277137756348
+(PID.TID 0000.0001)         System time:  0.54751396179199219
+(PID.TID 0000.0001)     Wall clock time:   7.5016801357269287
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   84.521397590637207
-(PID.TID 0000.0001)         System time:  0.75551307201385498
-(PID.TID 0000.0001)     Wall clock time:   87.037298917770386
+(PID.TID 0000.0001)           User time:   85.811885833740234
+(PID.TID 0000.0001)         System time:  0.98582202196121216
+(PID.TID 0000.0001)     Wall clock time:   89.145327091217041
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.86217117309570312
-(PID.TID 0000.0001)         System time:   6.0200691223144531E-006
-(PID.TID 0000.0001)     Wall clock time:  0.86326169967651367
+(PID.TID 0000.0001)           User time:  0.87345123291015625
+(PID.TID 0000.0001)         System time:   3.8301944732666016E-004
+(PID.TID 0000.0001)     Wall clock time:  0.87429857254028320
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.8696060180664062E-003
-(PID.TID 0000.0001)         System time:   2.9981136322021484E-005
-(PID.TID 0000.0001)     Wall clock time:   2.9053688049316406E-003
+(PID.TID 0000.0001)           User time:   2.7284622192382812E-003
+(PID.TID 0000.0001)         System time:   5.0842761993408203E-005
+(PID.TID 0000.0001)     Wall clock time:   2.7775764465332031E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   81.041268348693848
-(PID.TID 0000.0001)         System time:  0.60754495859146118
-(PID.TID 0000.0001)     Wall clock time:   82.318573236465454
+(PID.TID 0000.0001)           User time:   82.250081062316895
+(PID.TID 0000.0001)         System time:  0.76661610603332520
+(PID.TID 0000.0001)     Wall clock time:   83.318542003631592
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   81.041195869445801
-(PID.TID 0000.0001)         System time:  0.60754495859146118
-(PID.TID 0000.0001)     Wall clock time:   82.318496942520142
+(PID.TID 0000.0001)           User time:   82.250024795532227
+(PID.TID 0000.0001)         System time:  0.76661509275436401
+(PID.TID 0000.0001)     Wall clock time:   83.318471431732178
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99051284790039062
-(PID.TID 0000.0001)         System time:   2.3961067199707031E-005
-(PID.TID 0000.0001)     Wall clock time:  0.99114942550659180
+(PID.TID 0000.0001)           User time:  0.96989345550537109
+(PID.TID 0000.0001)         System time:   8.5115432739257812E-005
+(PID.TID 0000.0001)     Wall clock time:  0.97023606300354004
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25780582427978516
-(PID.TID 0000.0001)         System time:   3.9330124855041504E-003
-(PID.TID 0000.0001)     Wall clock time:  0.27108311653137207
+(PID.TID 0000.0001)           User time:  0.27200603485107422
+(PID.TID 0000.0001)         System time:   4.9054622650146484E-005
+(PID.TID 0000.0001)     Wall clock time:  0.27224779129028320
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.52492904663085938
-(PID.TID 0000.0001)         System time:   2.4333953857421875E-002
-(PID.TID 0000.0001)     Wall clock time:  0.55233931541442871
+(PID.TID 0000.0001)           User time:  0.58813190460205078
+(PID.TID 0000.0001)         System time:   3.1380951404571533E-002
+(PID.TID 0000.0001)     Wall clock time:  0.65025877952575684
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.52364158630371094
-(PID.TID 0000.0001)         System time:   2.4319946765899658E-002
-(PID.TID 0000.0001)     Wall clock time:  0.55105519294738770
+(PID.TID 0000.0001)           User time:  0.58684921264648438
+(PID.TID 0000.0001)         System time:   3.1374990940093994E-002
+(PID.TID 0000.0001)     Wall clock time:  0.64898729324340820
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.8637390136718750E-005
-(PID.TID 0000.0001)         System time:   2.0265579223632812E-006
-(PID.TID 0000.0001)     Wall clock time:   4.4345855712890625E-005
+(PID.TID 0000.0001)           User time:   4.2915344238281250E-005
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   5.0544738769531250E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.0488433837890625E-002
-(PID.TID 0000.0001)         System time:   3.2401084899902344E-004
-(PID.TID 0000.0001)     Wall clock time:   9.1626882553100586E-002
+(PID.TID 0000.0001)           User time:  0.11060523986816406
+(PID.TID 0000.0001)         System time:   1.2040138244628906E-005
+(PID.TID 0000.0001)     Wall clock time:  0.11110925674438477
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8638839721679688E-002
+(PID.TID 0000.0001)           User time:   3.2488822937011719E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8656005859375000E-002
+(PID.TID 0000.0001)     Wall clock time:   3.2494544982910156E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   15.595914840698242
-(PID.TID 0000.0001)         System time:   1.5965998172760010E-002
-(PID.TID 0000.0001)     Wall clock time:   15.666312932968140
+(PID.TID 0000.0001)           User time:   16.215882301330566
+(PID.TID 0000.0001)         System time:   8.3059668540954590E-003
+(PID.TID 0000.0001)     Wall clock time:   16.294086217880249
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   5.3109989166259766
-(PID.TID 0000.0001)         System time:   7.8080296516418457E-003
-(PID.TID 0000.0001)     Wall clock time:   5.3319787979125977
+(PID.TID 0000.0001)           User time:   5.5139293670654297
+(PID.TID 0000.0001)         System time:   4.2510032653808594E-003
+(PID.TID 0000.0001)     Wall clock time:   5.5387492179870605
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   5.0144567489624023
-(PID.TID 0000.0001)         System time:   7.7480077743530273E-003
-(PID.TID 0000.0001)     Wall clock time:   5.0277261734008789
+(PID.TID 0000.0001)           User time:   5.1885261535644531
+(PID.TID 0000.0001)         System time:   4.2260289192199707E-003
+(PID.TID 0000.0001)     Wall clock time:   5.2031192779541016
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.0462045669555664
-(PID.TID 0000.0001)         System time:   4.2370557785034180E-003
-(PID.TID 0000.0001)     Wall clock time:   3.0879511833190918
+(PID.TID 0000.0001)           User time:   3.0441589355468750
+(PID.TID 0000.0001)         System time:   3.9459466934204102E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0945291519165039
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.443055152893066
-(PID.TID 0000.0001)         System time:   6.6041946411132812E-005
-(PID.TID 0000.0001)     Wall clock time:   16.448317527770996
+(PID.TID 0000.0001)           User time:   16.761844635009766
+(PID.TID 0000.0001)         System time:   3.5589933395385742E-004
+(PID.TID 0000.0001)     Wall clock time:   16.775043725967407
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.51086902618408203
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.51116800308227539
+(PID.TID 0000.0001)           User time:  0.52013397216796875
+(PID.TID 0000.0001)         System time:   7.9870223999023438E-006
+(PID.TID 0000.0001)     Wall clock time:  0.52034044265747070
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7131824493408203
-(PID.TID 0000.0001)         System time:   3.6659836769104004E-003
-(PID.TID 0000.0001)     Wall clock time:   1.7351946830749512
+(PID.TID 0000.0001)           User time:   1.8853092193603516
+(PID.TID 0000.0001)         System time:   4.0190219879150391E-003
+(PID.TID 0000.0001)     Wall clock time:   1.8912630081176758
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31047821044921875
-(PID.TID 0000.0001)         System time:   1.4799833297729492E-004
-(PID.TID 0000.0001)     Wall clock time:  0.31090807914733887
+(PID.TID 0000.0001)           User time:  0.31275272369384766
+(PID.TID 0000.0001)         System time:   1.9967555999755859E-005
+(PID.TID 0000.0001)     Wall clock time:  0.31285691261291504
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56517028808593750
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.56518459320068359
+(PID.TID 0000.0001)           User time:  0.60251998901367188
+(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
+(PID.TID 0000.0001)     Wall clock time:  0.60259628295898438
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6101341247558594E-002
+(PID.TID 0000.0001)           User time:   3.5999298095703125E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6107301712036133E-002
+(PID.TID 0000.0001)     Wall clock time:   3.6012172698974609E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45784378051757812
-(PID.TID 0000.0001)         System time:   4.0239691734313965E-003
-(PID.TID 0000.0001)     Wall clock time:  0.46220612525939941
+(PID.TID 0000.0001)           User time:  0.41740131378173828
+(PID.TID 0000.0001)         System time:   1.6017019748687744E-002
+(PID.TID 0000.0001)     Wall clock time:  0.43351268768310547
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.576998710632324
-(PID.TID 0000.0001)         System time:   2.7000904083251953E-005
-(PID.TID 0000.0001)     Wall clock time:   16.618823051452637
+(PID.TID 0000.0001)           User time:   16.651686668395996
+(PID.TID 0000.0001)         System time:   1.2036919593811035E-002
+(PID.TID 0000.0001)     Wall clock time:   16.693977832794189
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6702880859375000E-005
+(PID.TID 0000.0001)           User time:   3.6239624023437500E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.9100646972656250E-005
+(PID.TID 0000.0001)     Wall clock time:   4.1961669921875000E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2629222869873047
-(PID.TID 0000.0001)         System time:   3.2007694244384766E-005
-(PID.TID 0000.0001)     Wall clock time:   3.2637934684753418
+(PID.TID 0000.0001)           User time:   3.0970554351806641
+(PID.TID 0000.0001)         System time:   1.8000602722167969E-005
+(PID.TID 0000.0001)     Wall clock time:   3.0976185798645020
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6239624023437500E-005
+(PID.TID 0000.0001)           User time:   4.3869018554687500E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8623809814453125E-005
+(PID.TID 0000.0001)     Wall clock time:   3.8862228393554688E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7964420318603516
-(PID.TID 0000.0001)         System time:  0.29139202833175659
-(PID.TID 0000.0001)     Wall clock time:   4.2872366905212402
+(PID.TID 0000.0001)           User time:   3.9324779510498047
+(PID.TID 0000.0001)         System time:  0.38705295324325562
+(PID.TID 0000.0001)     Wall clock time:   4.3962290287017822
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3255062103271484
-(PID.TID 0000.0001)         System time:  0.26355397701263428
-(PID.TID 0000.0001)     Wall clock time:   1.9189450740814209
+(PID.TID 0000.0001)           User time:   1.3765907287597656
+(PID.TID 0000.0001)         System time:  0.30705994367599487
+(PID.TID 0000.0001)     Wall clock time:   1.7577621936798096
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.40284729003906250
-(PID.TID 0000.0001)         System time:   2.3898005485534668E-002
-(PID.TID 0000.0001)     Wall clock time:  0.43628311157226562
+(PID.TID 0000.0001)           User time:  0.41219329833984375
+(PID.TID 0000.0001)         System time:   1.6003012657165527E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42830204963684082
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.4332275390625000E-004
-(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
-(PID.TID 0000.0001)     Wall clock time:   3.4999847412109375E-004
+(PID.TID 0000.0001)           User time:   3.2806396484375000E-004
+(PID.TID 0000.0001)         System time:   5.9604644775390625E-006
+(PID.TID 0000.0001)     Wall clock time:   3.3187866210937500E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   2.2083129882812500
-(PID.TID 0000.0001)         System time:  0.12400996685028076
-(PID.TID 0000.0001)     Wall clock time:   3.4123508930206299
+(PID.TID 0000.0001)           User time:   2.2673187255859375
+(PID.TID 0000.0001)         System time:  0.20276105403900146
+(PID.TID 0000.0001)     Wall clock time:   4.5153059959411621
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7896423339843750
-(PID.TID 0000.0001)         System time:  0.10796999931335449
-(PID.TID 0000.0001)     Wall clock time:   2.9772658348083496
+(PID.TID 0000.0001)           User time:   1.8400115966796875
+(PID.TID 0000.0001)         System time:  0.18677806854248047
+(PID.TID 0000.0001)     Wall clock time:   4.0529899597167969
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.41864776611328125
-(PID.TID 0000.0001)         System time:   1.6039013862609863E-002
-(PID.TID 0000.0001)     Wall clock time:  0.43506789207458496
+(PID.TID 0000.0001)           User time:  0.42728424072265625
+(PID.TID 0000.0001)         System time:   1.5982985496520996E-002
+(PID.TID 0000.0001)     Wall clock time:  0.46229887008666992
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   9.3841552734375000E-004
-(PID.TID 0000.0001)         System time:   1.7046928405761719E-005
-(PID.TID 0000.0001)     Wall clock time:   9.5605850219726562E-004
+(PID.TID 0000.0001)           User time:   3.1890869140625000E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.1890869140625000E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================

--- a/global_oce_llc90/results/output.ecmwf.txt
+++ b/global_oce_llc90/results/output.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68v
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Wed Feb 28 18:23:35 EST 2024
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -227,7 +227,7 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=300,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-12,
+(PID.TID 0000.0001) > cg2dTargetResWunit=2.46E-10,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -606,7 +606,6 @@
 (PID.TID 0000.0001) ># | Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) ># =====================================================================
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) ># GGL90taveFreq = 345600000.,
 (PID.TID 0000.0001) ># GGL90dumpFreq = 86400.,
 (PID.TID 0000.0001) ># GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) ># GGL90diffTKEh=3.e3,
@@ -626,9 +625,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) GGL90dumpFreq =   /* GGL90 state write out interval ( s ). */
 (PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
@@ -863,6 +859,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: opening data.ecco
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ecco
 (PID.TID 0000.0001) // =======================================================
@@ -1134,7 +1143,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1825,8 +1838,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 2.500000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -2010,6 +2023,9 @@
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       7
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)     7 @  1.428571428571428E-01              /* K =  1:  7 */
 (PID.TID 0000.0001)     ;
@@ -2112,16 +2128,10 @@
 (PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
@@ -2150,469 +2160,81 @@
 (PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   3 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =      1203786
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          312
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          312
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          283
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =        11544
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         23088
-(PID.TID 0000.0001) ctrl-wet 8: atmos        23088
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    10           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    11           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    12           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    13           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    14           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    15           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   50     7220976
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3       59874       58517       58725           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4       59387       58040       58258           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5       58882       57536       57754           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6       58399       57057       57276           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7       58052       56735       56936           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8       57781       56461       56669           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9       57530       56212       56416           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10       57283       55964       56154           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11       57022       55702       55883           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12       56818       55497       55681           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13       56634       55322       55509           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14       56430       55125       55312           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15       56238       54935       55117           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   16       55975       54689       54858           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   17       55703       54421       54600           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   18       55358       54075       54251           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   19       54964       53666       53853           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   20       54471       53205       53372           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   21       53952       52716       52877           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   22       53489       52249       52409           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   23       52892       51633       51797           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   24       52223       50961       51129           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   25       51696       50480       50635           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   26       51259       50075       50241           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   27       50929       49774       49935           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   28       50664       49532       49678           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   29       50438       49306       49450           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   30       50187       49035       49179           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   31       49964       48805       48937           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   32       49700       48530       48662           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   33       49431       48260       48383           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   34       49176       47993       48108           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   35       48854       47652       47764           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   36       48501       47264       47375           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   37       48098       46846       46951           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   38       47523       46253       46362           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   39       46849       45558       45657           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   40       45984       44670       44751           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   41       44793       43419       43459           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   42       42984       41497       41533           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   43       40302       38691       38718           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   44       36689       35007       35032           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   45       31681       30069       29999           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   46       25595       24028       24031           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   47       18224       16890       16872           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   48       11407       10397       10351           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   49        4597        3913        3912           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   50         818         624         622           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3       59874       58517       58725
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4       59387       58040       58258
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5       58882       57536       57754
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6       58399       57057       57276
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7       58052       56735       56936
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8       57781       56461       56669
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9       57530       56212       56416
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10       57283       55964       56154
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11       57022       55702       55883
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12       56818       55497       55681
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13       56634       55322       55509
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14       56430       55125       55312
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15       56238       54935       55117
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   16       55975       54689       54858
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   17       55703       54421       54600
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   18       55358       54075       54251
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   19       54964       53666       53853
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   20       54471       53205       53372
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   21       53952       52716       52877
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   22       53489       52249       52409
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   23       52892       51633       51797
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   24       52223       50961       51129
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   25       51696       50480       50635
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   26       51259       50075       50241
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   27       50929       49774       49935
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   28       50664       49532       49678
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   29       50438       49306       49450
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   30       50187       49035       49179
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   31       49964       48805       48937
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   32       49700       48530       48662
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   33       49431       48260       48383
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   34       49176       47993       48108
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   35       48854       47652       47764
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   36       48501       47264       47375
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   37       48098       46846       46951
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   38       47523       46253       46362
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   39       46849       45558       45657
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   40       45984       44670       44751
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   41       44793       43419       43459
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   42       42984       41497       41533
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   43       40302       38691       38718
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   44       36689       35007       35032
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   45       31681       30069       29999
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   46       25595       24028       24031
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   47       18224       16890       16872
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   48       11407       10397       10351
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   49        4597        3913        3912
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   50         818         624         622
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
@@ -2627,37 +2249,42 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 011544 010207 011460
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 041559 041310 041343
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 039915 038420 039722
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0004 0001 035457 033982 035227
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0005 0001 040378 040035 040082
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0006 0001 040418 040096 040138
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0007 0001 040462 040067 040100
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0008 0001 040877 040589 040319
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0009 0001 031231 030937 030957
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0010 0001 020622 020046 018422
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0011 0001 039018 038680 038425
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0012 0001 019781 019699 019576
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001   11544   10207   11460
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001   41559   41310   41343
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001   39915   38420   39722
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 004 001   35457   33982   35227
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 005 001   40378   40035   40082
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 006 001   40418   40096   40138
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 007 001   40462   40067   40100
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 008 001   40877   40589   40319
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 009 001   31231   30937   30957
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 010 001   20622   20046   18422
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 011 001   39018   38680   38425
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 012 001   19781   19699   19576
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2665,74 +2292,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   367
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   272 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   275 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   277 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   283 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   285 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   304 SIatmFW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   324 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   332 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   289 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    85 sIceLoad
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    78 MXLDEPTH
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   367 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   312 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceQnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceFWflx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   332 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   340 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   341 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   342 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   343 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   257 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    48 WVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   265 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   266 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   136 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   137 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   133 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   143 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   144 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   140 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   324  ADVxHEFF , Parms: UU      M1 , mate:   325
-(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVyHEFF , Parms: VV      M1 , mate:   324
-(PID.TID 0000.0001)   set mate pointer for diag #   326  DFxEHEFF , Parms: UU      M1 , mate:   327
-(PID.TID 0000.0001)   set mate pointer for diag #   327  DFyEHEFF , Parms: VV      M1 , mate:   326
-(PID.TID 0000.0001)   set mate pointer for diag #   332  ADVxSNOW , Parms: UU      M1 , mate:   333
-(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVySNOW , Parms: VV      M1 , mate:   332
-(PID.TID 0000.0001)   set mate pointer for diag #   334  DFxESNOW , Parms: UU      M1 , mate:   335
-(PID.TID 0000.0001)   set mate pointer for diag #   335  DFyESNOW , Parms: VV      M1 , mate:   334
-(PID.TID 0000.0001)   set mate pointer for diag #   289  SIuice   , Parms: UU      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #   290  SIvice   , Parms: VV      M1 , mate:   289
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   257  GM_PsiX  , Parms: UU      LR , mate:   258
-(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiY  , Parms: VV      LR , mate:   257
-(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
-(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
-(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
-(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
-(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
-(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
-(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
+(PID.TID 0000.0001)   set mate pointer for diag #   332  ADVxHEFF , Parms: UU      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVyHEFF , Parms: VV      M1 , mate:   332
+(PID.TID 0000.0001)   set mate pointer for diag #   334  DFxEHEFF , Parms: UU      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFyEHEFF , Parms: VV      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   340  ADVxSNOW , Parms: UU      M1 , mate:   341
+(PID.TID 0000.0001)   set mate pointer for diag #   341  ADVySNOW , Parms: VV      M1 , mate:   340
+(PID.TID 0000.0001)   set mate pointer for diag #   342  DFxESNOW , Parms: UU      M1 , mate:   343
+(PID.TID 0000.0001)   set mate pointer for diag #   343  DFyESNOW , Parms: VV      M1 , mate:   342
+(PID.TID 0000.0001)   set mate pointer for diag #   297  SIuice   , Parms: UU      M1 , mate:   298
+(PID.TID 0000.0001)   set mate pointer for diag #   298  SIvice   , Parms: VV      M1 , mate:   297
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   265  GM_PsiX  , Parms: UU      LR , mate:   266
+(PID.TID 0000.0001)   set mate pointer for diag #   266  GM_PsiY  , Parms: VV      LR , mate:   265
+(PID.TID 0000.0001)   set mate pointer for diag #   136  DFxE_TH  , Parms: UU      MR , mate:   137
+(PID.TID 0000.0001)   set mate pointer for diag #   137  DFyE_TH  , Parms: VV      MR , mate:   136
+(PID.TID 0000.0001)   set mate pointer for diag #   133  ADVx_TH  , Parms: UU      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   134  ADVy_TH  , Parms: VV      MR , mate:   133
+(PID.TID 0000.0001)   set mate pointer for diag #   143  DFxE_SLT , Parms: UU      MR , mate:   144
+(PID.TID 0000.0001)   set mate pointer for diag #   144  DFyE_SLT , Parms: VV      MR , mate:   143
+(PID.TID 0000.0001)   set mate pointer for diag #   140  ADVx_SLT , Parms: UU      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   141  ADVy_SLT , Parms: VV      MR , mate:   140
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2747,12 +2374,12 @@
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
 (PID.TID 0000.0001)  Levels:      21.  22.  23.  24.  25.  26.  27.  28.  29.  30.  31.  32.  33.  34.  35.  36.  37.  38.  39.  40.
 (PID.TID 0000.0001)  Levels:      41.  42.  43.  44.  45.  46.  47.  48.  49.  50.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     825 levels (numDiags =    3000 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use       0 levels (diagSt_size=    2500 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found   0 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4584096177006E-04
@@ -2768,7 +2395,7 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   9.3876998486639E-05
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.9559575367967E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  7.1522409280111305E-05
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.112781640300954E-06 (Area=3.5801386115E+14)
+(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.105154116076021E-06 (Area=1.4537802370E+12)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -3119,7 +2746,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -3199,24 +2826,24 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectMetricTerms= /* Metric-Terms on/off flag (=0/1) */
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
 (PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) select3dCoriScheme= /* 3-D Coriolis on/off flag (=0/1) */
-(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       1
@@ -3235,6 +2862,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -3289,6 +2917,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3379,7 +3010,7 @@
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-12
+(PID.TID 0000.0001)                 2.460000000000000E-10
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -3391,7 +3022,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -4531,6 +4162,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.580138611494435E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 6.226703613420189E+09
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 6.064600000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 2.406992000000000E+06
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -4876,89 +4516,89 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -5.89131029542485E-02  1.31464562767967E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.47659184097983E+01
+ cg2d: Sum(rhs),rhsMax =  -5.89140516204759E-02  1.31464430486456E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.47659836370240E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     141
-(PID.TID 0000.0001)      cg2d_last_res =   6.64504169217172E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.64506082904171E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2250478315697E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5455732976386E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9817753638557E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0519207478993E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6314774991184E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5818548726696E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.3972130315981E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.8961508234066E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6938306225048E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.9088401249842E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.0885076532862E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9447510231671E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2333643289733E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5843239861311E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8353293559234E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5211289297432E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9057645208363E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6126830936676E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6920879403125E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2669265321213E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2250774858912E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5455737119153E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9818233788026E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0519212918957E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6315297255727E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5818549968409E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.4007815400268E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.8961407340341E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6938425416341E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.9088300259206E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.0885192875182E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9447436495395E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2333627273355E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5843277497163E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8353483974550E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5211289297434E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9057617573682E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6127427369456E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6920878380405E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2669233915718E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1233044478864E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006925518528E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920420050728E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366017375099E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3115588263009E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701869665076E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0265448229361E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611701426E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183711381139E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2447927493679E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.5233630322958E+03
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006925518286E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920420050545E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366017375270E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3115588881279E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701869665075E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0265447233098E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611701369E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183711433177E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2447932293714E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.5233619379673E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4511655522929E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -7.8223179880572E-01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0594230655395E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.4513907039252E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -7.8218577950735E-01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0594227507445E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.4513610813757E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.0351378290490E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7555696240491E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7866251408045E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5035437996820E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8440674953815E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9819496840634E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.5229079150176E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5381581076658E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.0197733189903E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7555691894310E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7866254080579E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5036033733093E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8440615776353E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9819507243961E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.5230451577455E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5381569299528E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.0197647064113E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7296464770212E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8157101102785E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3607567346659E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1376014487952E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.7558602866790E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.1571477067504E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.2199191369171E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.0636140788450E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1076657696290E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3629624925279E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6905447531546E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9549821108707E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6959232523547E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9430336393843E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5898795102755E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5949610050112E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6768536865956E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -6.8773112826834E-07
-(PID.TID 0000.0001) %MON ke_max                       =   2.0143529382742E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3543897484000E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8167594409082E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3609460247054E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1376192238624E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.7564168888665E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.1571511091293E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.2199235862291E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.0622993666782E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1076759272896E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3639808707676E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6905400786154E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9549808348860E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6959206392182E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9457909740421E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5898897256143E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5949584891739E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6768510734591E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -6.8770571882725E-07
+(PID.TID 0000.0001) %MON ke_max                       =   2.0170591744083E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3543995643591E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2537074617290E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.9078619491457E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2536262799494E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.9089261971882E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542349970012E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542349970251E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760527755546E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246676597836E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9324376148490E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4449211435859E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246676593569E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9324383852468E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4454680288111E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4967,31 +4607,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     1
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.9030179860934E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -9.2814802904096E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6959332273721E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   3.1716006915243E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5379547060326E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   7.7124247046527E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.3817821495339E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1646097156720E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.1123253225530E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3551488784830E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.9027976410772E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -9.2815475308318E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6915142447324E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   3.1718688496212E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5375743206952E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   7.7143451398072E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.3817860801969E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1644892069336E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.1128642572964E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3554101584226E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5636607853557E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9573036748536E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4342943335493E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8300420800631E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5636615607441E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9573039019293E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4343247707954E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8300420938059E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4873038884118E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2609776586644E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7146932217684E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8190934013099E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4873038322942E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2609767245650E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7147517977440E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8190910111795E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5181730293194E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5275717065748E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9461319404814E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5181730796114E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5275710254980E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9462326061068E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5010,16 +4650,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.3676690098333E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1243215476666E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5099646428395E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3787773657139E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.4790185087148E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   7.5589063208371E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3816907270898E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1070536097534E-01
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3787773654377E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.4790185087149E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   7.5589063465376E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3816907296301E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1070536214541E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9947461553270E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.0629814892892E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.3791687177788E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.4392311887329E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.1235932908712E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.3791687192546E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.4392311897482E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.1235932911805E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8558225299134E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   1.0088437682558E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0219492112999E+00
@@ -5035,16 +4675,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1082834772583E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7256856594827E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4949215076321E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2710385599656E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1404423392534E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7174446857941E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8102794377760E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0669512338684E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2710385599680E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1404423392578E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7174446854059E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8102794400445E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0669512364128E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2687483075050E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.0716540389606E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2175242203215E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7396207215409E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7260138369135E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.0716540391163E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2175242204691E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7396207229149E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7260138431567E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.5566883251364E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -2.0080626496280E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6749569332377E-08
@@ -5078,89 +4718,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.21095513586948E-01  1.26290284251614E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.86195385989181E+00
+ cg2d: Sum(rhs),rhsMax =  -1.19688486635188E-01  1.26290039336226E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.86194901966413E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.41811178650990E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.41810111120125E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.4916000277181E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5341242313240E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.0576431214604E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0406772113331E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7160971382287E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8845833668852E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0349212380448E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5572982602047E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1625870939976E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5832551467472E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7709801379655E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5539404919106E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7319432282102E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2065448729499E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4121168475175E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8992772067857E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3234476889508E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3697809142933E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6218458628604E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1026217616674E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.4916083240376E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5341286394237E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.0578065470911E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0406778434068E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7162193527306E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8845838178572E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0352557067617E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5572967270154E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1625913197733E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5832431784956E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7710204833805E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5538791320226E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7319236671587E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2065457264705E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4121545118978E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8992772067893E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3234476889855E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3698317929361E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6218467992600E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1026221703838E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1213683154668E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002439202647E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307598653E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365804698879E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3029168591301E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699647638153E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0297875014246E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610891757E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183483013152E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2172887568662E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3807252618252E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.4790185087148E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -3.5238120014495E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1220920776950E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.2747379391497E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002439203207E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307598253E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365804699329E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3029170768322E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699647638151E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0297872773455E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610891714E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183483020406E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2172871220557E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3806214443639E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.4790185087149E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -3.5237274972250E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1220922117650E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.2745581507375E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.1565804996112E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7870024405885E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8702984923517E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.4983496700301E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7226327934585E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6477670862724E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7918553404942E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5407435081879E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.7417774635765E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7870020560167E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8702987274190E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.4985225184040E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7226247858035E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6474972903373E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7921852226924E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5407424604806E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.7411433592239E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5899234024015E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2967158278030E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4291686043222E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1054586499976E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9044558208276E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2975240760430E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4294363601113E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1055054737660E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9048669851907E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.0806687658770E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9273030279997E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4468228820338E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1182944591080E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.5528796375663E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0939243118305E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.3091744346515E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7531643916967E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9966861639605E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2049775929071E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6606458692216E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7479031013764E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4568661922595E-05
-(PID.TID 0000.0001) %MON ke_max                       =   4.8734063393706E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3888814545909E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349978876145E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4337350981631E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.0864797540363E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4462849254527E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1183102339951E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.5539427755138E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0965467681066E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.3104126994360E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7532049487796E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9992705551804E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2049209349524E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6606893541811E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7479436370724E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4568725064938E-05
+(PID.TID 0000.0001) %MON ke_max                       =   4.8780133970881E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3888871306869E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349978876146E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4340300448275E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.0874772511261E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541846684194E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526217680E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243370870970E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1814536385344E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4169168106273E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541846685110E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526217662E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243370890704E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1814545340190E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4169478414800E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5169,31 +4809,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     2
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   9.4516435016105E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.2939047019251E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8997000772466E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.1351290258638E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7402252935287E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0931634686392E+00
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.6811021908879E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.6586535938641E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.5373950626608E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4034451052289E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   9.4517609650786E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.2939691411632E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8211395914305E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.1370722466705E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7407539475785E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0931924915522E+00
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.6810610405776E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.6612282472277E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.5395678466941E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4035783418251E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5553270458601E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9558380528591E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4450525330861E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8303186811567E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5553276391669E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9558377590263E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4451293600320E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8303187105513E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4843128391310E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607772731111E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6910885243886E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8187537986007E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5047423300169E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5223487292615E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9098907491043E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4843126584249E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607745429863E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6912248930182E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8187448763248E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5047422172168E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5223457729906E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9101505541713E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5212,16 +4852,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6627740987673E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1380292359207E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8647225187899E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4784767500348E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.7084629272690E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   4.9588260084143E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5559065225964E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2921785196662E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9897065761925E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4784767492732E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.7084629272701E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   4.9588257102397E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5559065251890E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2921783691649E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9897065761924E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.0707600314396E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7379182347822E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6722394093239E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2715482830115E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7379181953976E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6722394214771E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2715482810571E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.9662385819350E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   6.7645036785843E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0288462093920E+00
@@ -5237,16 +4877,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1077737181743E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7235707829470E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943555151673E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2931647028121E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2088942451846E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7415531821666E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8363761349811E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0742931102369E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2931647028203E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2088942452120E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7415531833980E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8363761191190E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0742930422302E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2646032027147E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1711878428966E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2285726687699E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7563030712621E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8070271980138E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1711878434119E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2285726648315E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7563030681170E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8070271146787E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8974578178756E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.0040313248140E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6501756512671E-08
@@ -5280,89 +4920,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.83549478403450E-01  1.22135094009642E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.46408814010186E+00
+ cg2d: Sum(rhs),rhsMax =  -1.79846042118140E-01  1.22134604221502E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.46406753623172E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.97338875922790E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.97333052912414E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9894470147064E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1516416425381E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.1023186113915E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8296422031633E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6655487958304E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2117620775369E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2014374276601E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0535543895978E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4754292425593E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8852919737187E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.2363136816851E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0587377573807E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6753162152052E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5636292070084E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6972236172774E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351248392783E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438935913086E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6510530666253E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3674125492935E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9580123082983E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1198300696384E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001666238401E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307699458E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365644985710E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2549101998581E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697287354662E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0332726805976E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610458401E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183305065101E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1882174931644E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3907772055809E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.7084629272690E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.1089946330656E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3079228100284E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1740493338081E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9894472617826E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1516516021007E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.1025675237472E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8296430334592E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6657374818890E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2121742522497E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2015551110950E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0535501347166E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4754360484053E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8853306351716E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.2361244310937E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0587384279786E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6753477513522E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5636311458469E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6973101869843E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351248392942E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438935914186E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6510444904735E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3674138339227E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9580159673837E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1198300696375E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001666226909E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307698999E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365644986572E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2549104340722E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697287354658E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0332725839920E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610458411E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183305031900E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1882153337021E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3905941630858E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.7084629272701E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.1089375023244E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3079231741125E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1739455162782E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.0593549145477E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8183887429670E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0822005495697E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8481151477620E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6585643817189E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6583555862573E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7026974420431E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5423659777341E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.4297810373235E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8183887297628E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0822004864371E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8484095125097E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6585630484902E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6578821528380E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7029417916108E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5423647477800E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.4293267524684E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7707957663300E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.4415386340948E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4254619180804E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1044415347001E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4701475362249E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.4427091658100E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4258716768006E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1044989072211E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4696944461730E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.2153963510475E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4076876459203E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8481763582619E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1371941800854E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.0841219829562E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3651479013073E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5478912612776E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7984765531628E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2833325874965E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5865087591169E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8786037709560E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9717955980284E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4565491905007E-05
-(PID.TID 0000.0001) %MON ke_max                       =   6.6128497428497E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3093695101689E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349978986265E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5251184966645E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.5830864803005E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8472842421178E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1372133841747E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.0854061543629E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3660287175436E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5565386491881E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7984765532231E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2842419103134E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5863429937430E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8786037710190E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9717955980918E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4565621904181E-05
+(PID.TID 0000.0001) %MON ke_max                       =   6.6169254302184E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3093819675325E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349978986271E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5252847249847E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.5834374514912E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541286058891E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524680316E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239637546814E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3273170155818E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6014015012297E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541286060065E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524680313E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239637642970E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3273170475086E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6013701458443E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5371,31 +5011,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   7.8554163168436E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.6457137058478E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.0892128071264E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7023558990222E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8590183226439E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   8.1116915539274E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.9555949844649E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4550508737149E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.1491691857117E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4247119284001E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   7.8486234992960E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.6457144016200E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.0414383734692E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7043223728035E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8615493892800E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   8.1117414948192E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.9555923663387E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4504016879320E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.1503556944008E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4245596805914E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5462195772379E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9543246461731E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4518021513363E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8305960383609E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5462191525472E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9543234916853E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4519209479411E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8305960839805E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4813632304825E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606647331935E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6724928075376E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8183190865082E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4813629627396E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606596786173E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6726962753078E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8182992609085E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4911415055013E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5173071787913E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8860952065415E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4911411271732E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5173006451313E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8865034476762E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5414,16 +5054,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.9578791877013E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1587407852827E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.4837461086138E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5816987868386E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -8.9304796726564E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.4057222389392E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8167486420337E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5759868598730E-01
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5816987827334E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -8.9304796726687E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.4057204027878E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8167486551626E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5759867556353E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9834911056969E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1862228750185E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.1048807596960E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0382910134896E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5164973336928E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.1048805076034E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0382910374242E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5164973332112E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   3.1023215152125E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.4405696746102E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0357432074842E+00
@@ -5439,16 +5079,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1072639590902E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7228877080768E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943211487414E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3152906999754E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2836928126029E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7656153139332E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8805374304820E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0846464819328E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3152906999907E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2836928126932E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7656152741699E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8805373913199E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0846464068818E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2673489980902E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2989438759824E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2404424180094E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7871477167728E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9311217049484E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2989438766403E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2404423928002E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7871477291659E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9311216796575E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.2382273106148E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6253943692965E-08
@@ -5482,89 +5122,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.46898163999131E-01  1.19788998424225E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.22205288441562E+00
+ cg2d: Sum(rhs),rhsMax =  -2.40005906457826E-01  1.19788297505574E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.22201794223906E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.66646499817671E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.66621635082819E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0022978419732E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1299847229920E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.2147102597245E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4160322154657E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6581273835735E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4283990993364E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2351013524500E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8395490671688E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7120726851213E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.0542942657325E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3132629863357E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.6829209887546E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1048417510657E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8071061689867E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.8637720057182E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303499393655E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093734152853E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1246412711487E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2795572388644E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161594885300E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0022978971686E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1299918192160E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.2147445358824E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4160334780253E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6584005993840E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4285343599218E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2348132656024E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8395404119372E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7120793429858E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.0543770910814E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3141193822337E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.6833580747708E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1048494989750E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8071103185675E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.8639102661530E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303499394513E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093734158085E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1245838133680E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2795586703660E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161598624233E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190094577669E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000937114397E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920367870087E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365532120270E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1895614885539E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694842628181E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0369484401540E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610198116E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183158556065E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1607936909301E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3877141108307E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.9304796726564E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.6146521357478E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.5859424289631E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1432818018944E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000937096784E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920367869571E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365532121681E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1895605492909E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694842628172E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0369494166770E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610198146E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183158528586E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1607910430787E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3874677893888E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.9304796726687E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.6145562868470E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.5859421751258E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1430177494870E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -9.2659486649252E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8497570406617E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3884714366603E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.5152540140308E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6234374252514E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6334287636810E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7030075595727E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5573846722040E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.3111007208834E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8497564584204E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3884716129153E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.5157611685854E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6234356167860E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6327947880545E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7032758119277E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5573784963670E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.3101044031847E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.9027013207119E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1821593861094E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4250229394929E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1054039455335E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.9439402526122E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1826879336508E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4255117392415E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1054509645565E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.9426120084526E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3501239362180E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5651624980893E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0294354433115E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1540408491676E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7390021835994E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5277605290569E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.2233739190075E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653690731046E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.5434488472620E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4668089684743E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636475327126E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3793467783009E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0487305673663E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.1988941558410E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1223296964981E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979095269E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5239988148526E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.6834835138968E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0275105060902E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1540644060893E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7408046638346E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5253366682595E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.2238452435040E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653690733623E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.5412228420127E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4675505426470E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636475329814E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3793467785744E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0487330759296E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.1997946559273E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1223476735473E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979095277E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5239910307419E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.6826243429860E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540891260351E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524200490E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236052207132E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9119097964335E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6066328277554E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540891261651E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524200570E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236052403324E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9119080408268E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6065725478963E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5573,31 +5213,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7626968911349E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9079292211593E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -8.9684818592570E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9516350612282E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9285334073866E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   8.8052718345681E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -6.1638621079023E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2467782750727E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.5341471128677E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4595500602329E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7632020891897E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9079447905405E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -8.9566201571909E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9535697141897E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9284738587451E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   8.8051743116044E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -6.1637924601700E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2383713730635E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.5356807345447E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4618743901449E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5378107091126E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9528035784658E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4731846167332E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8308739458741E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5378088473597E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9528014034320E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4733564138381E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8308740081282E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4784252885694E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606735860577E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6557973949787E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8174914965608E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4772155788186E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5123352060982E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8640776737531E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4784249171322E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606659070311E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6560887118682E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8174618311634E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4772151335526E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5123236667828E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8646949054774E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5616,16 +5256,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.8739079370912E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1469991562767E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5013990350101E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.5891368288390E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.9814992266057E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5441516708340E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2817273128142E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0058955779972E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5013990200199E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -7.5891368288968E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.9815020109478E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5441516981387E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2817272965571E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0058955779971E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.3119253644247E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8844548933772E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7879766181038E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3143029501801E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8844545089824E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7879766554715E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3143029512949E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8848542238091E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.3040566798063E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0151300912066E+00
@@ -5641,16 +5281,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1055539123253E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7073963366029E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4901468161263E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3168717700817E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1720930267660E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7634497723415E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8413649034777E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0809026985918E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3168717701170E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1720930269827E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7634496940722E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8413648281029E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0809026132884E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2760420250701E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022403145662E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2390604895744E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7428643986755E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8252087509934E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022403144793E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2390604511349E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7428644298623E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8252088123471E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -5684,89 +5324,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -3.08735031686486E-01  1.18137213367246E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.16206542304483E+00
+ cg2d: Sum(rhs),rhsMax =  -2.97742219301352E-01  1.18136806742891E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.16199255980500E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.46559633693677E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.46547943353972E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0568913892046E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3441844201180E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5069264310204E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7914317368276E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6433997717891E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7723242275619E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2027553620177E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1020035349976E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9167655757630E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1192537941629E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3510568228494E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6845061582714E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3940647160760E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9917072180494E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.9032869810166E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896440929428E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243043384909E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9155300946858E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6252614217287E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0857873853921E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1187092658300E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000030736453E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920459821584E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365515687833E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1261961289356E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692241849461E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0406924953689E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610107982E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183037760513E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1362270524501E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3857909411798E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5891368288390E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3348538078524E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2919256997653E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.0410668191186E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0568914611171E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3443002331539E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5069659715291E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7914337548741E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6437774803047E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7766224397490E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2022143110926E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1019930712575E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9167712781425E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1193686948248E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3513903868384E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6852947242566E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3940783040307E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9917135616531E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.9034672335712E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896440932067E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243043399561E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9154448056448E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6252632652533E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0857879096156E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1187092658342E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000030710847E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920459821068E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365515689670E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1261949886291E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692241849446E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0406960911471E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610108022E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183037816029E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1362250848284E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3854909201861E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5891368288968E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3348477057277E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2919261593888E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.0408537358629E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.1497703549041E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949176838400E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0597315966404E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9051778250280E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6387090850411E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6384668043650E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.3525122295340E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5197748061114E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.0150197018058E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949176524975E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0597314377133E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9059611386477E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6387160396942E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6376920021870E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.3526627022226E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5197703299798E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.0142011564182E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7960612181076E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1115376676524E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4080985089783E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0769064903921E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.5345419111634E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1120836156092E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4084828695510E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0769527326940E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.5318258758821E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3447743192386E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4286717469416E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8727176565952E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1411901282383E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3722637109880E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8474633109278E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1118849982558E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222392628894E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2935160749493E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.5146760945598E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344239866918E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679757024162E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3482480591896E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.0439834308060E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.8654033680817E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979204276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5391069424890E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.5870169994186E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4291134422033E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8700367655060E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1412151609163E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3747066801166E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8476482555828E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1136377304479E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222392636836E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2893354529975E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.5149657309789E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344239875206E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679757032578E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3482522466315E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.0437487268732E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.8654260235483E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979204288E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5389024997003E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.5854034053936E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540678112423E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524611149E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232563178807E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2824301066172E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4460596758288E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540678114310E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524611307E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232563472726E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2824267787255E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4459843388276E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5775,31 +5415,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.9057642465060E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9494242853826E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -9.1859541762004E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   5.0110773860994E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9743930660468E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   9.3865082519834E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.1503701739096E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.2697513859781E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6799712035036E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5356332678341E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.9061053631640E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9490117556483E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -9.1997141654685E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   5.0127375337298E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9743449121668E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   9.3855011472002E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.1508332265356E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1796222295592E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6816100420629E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5358048088490E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5290659591355E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9513331501670E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4613892128662E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8311528996485E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5290624451058E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9513299101232E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4616111661819E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8311529787119E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4755812483160E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2608039239109E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6402613459840E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8170822922944E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4645238281512E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079870495208E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8425507504581E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4755808296647E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607935584596E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6406635748570E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8170457902006E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4645230433287E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079691365598E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8434464056343E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5818,16 +5458,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7899366864812E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1419459236811E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.4517337306647E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4235379737354E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3824595094500E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3098765891927E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3764461407763E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1144207361722E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0268554198417E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4382817221067E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6749886819962E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6849618695731E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052625211832E-10
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4235379577071E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3824595097354E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3098792189418E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3764461924179E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1144208016852E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0268554198432E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4382817221068E-06
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6749883194329E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6849619203872E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052625241180E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.6673869324057E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.1954436301909E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9945169749291E+00
@@ -5843,16 +5483,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1038438655604E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6937182364123E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4865810313694E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3184530963538E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281934571722E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7615790337752E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8168204431980E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0797338016375E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437416469E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510434061412E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2387745266332E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7130066327039E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7587926267133E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3184530964184E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281934575939E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7615789324731E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8168203270595E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0797337161957E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437416477E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510434056961E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2387744903768E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7130066859586E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7587927743171E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.4886747942940E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6668061282529E-08
@@ -5886,89 +5526,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -3.67124383349909E-01  1.19856141485443E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.10761298220898E+00
+ cg2d: Sum(rhs),rhsMax =  -3.52587480157008E-01  1.19855749451445E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.10752047697384E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     127
-(PID.TID 0000.0001)      cg2d_last_res =   7.07373093130632E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.07363617490756E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442197652535E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4344292212407E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.7845098355846E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9824192195149E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6349537789641E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3192797195287E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0946824238642E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9316398293088E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0890708516120E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0697902135824E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9145272613810E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5645658691142E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2416264575451E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1184791234605E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8213484323538E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199447976582E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763002207161E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.5765671625766E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6269379644089E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154892554069E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1178154506793E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998915697313E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920566332870E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365586891719E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0613841700622E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689476169953E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0444046753966E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610161447E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182928944546E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1140278996875E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3794689448493E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3824595094500E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8029904712992E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1089806343599E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9807825974701E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442198166644E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4345565059978E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.7845548939293E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9824222046860E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6354373600168E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3246028840807E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0940110554042E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9316302561697E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0890761806101E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0699399077914E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9150045556204E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5657848315344E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2416434268758E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1184863332441E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8215776859682E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199447982928E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763002235152E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.5755425381968E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6269401807627E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154900256143E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1178154506836E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998915673985E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920566332277E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365586894216E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0613841728561E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689476169931E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0444125769068E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610161495E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182929181057E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1140247279450E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3791251789481E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3824595097354E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8029831710688E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1089818553382E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9810886579937E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400438505361E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437632879382E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6249220456244E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6784535876151E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6318692036850E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.9342589804604E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4923769556344E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.8716909248584E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400438173719E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437630732486E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6259264445515E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6784583325970E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6309787146070E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.9344166986206E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4923816162553E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.8723548037349E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0515911070090E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3905908385208E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0551187090103E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2123653588985E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0522192404372E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3909156294945E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0551608102692E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2091851591945E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3394247022593E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4098954494528E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7348012366618E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1350518358565E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1797510891120E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5376323886145E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0201087931799E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775559218191E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.4584521710886E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.1505983185897E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995474445315E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8464971351527E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5069820702889E-04
-(PID.TID 0000.0001) %MON ke_max                       =   6.1282694555068E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4724261179117E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979308893E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4372392232633E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2647075102444E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4103276922723E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7318847310878E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1350781736538E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1818186739797E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5381923828758E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0218569646577E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775559237470E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.4532646044622E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.1576353634910E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995474465442E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8464971371962E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5069881563313E-04
+(PID.TID 0000.0001) %MON ke_max                       =   6.1275381039337E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4724518231493E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979308908E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4380288785603E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2627052659351E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540648081644E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525594327E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229868472857E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6160496148214E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1495506046651E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540648084570E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525594528E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229868866701E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6160453048313E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1494624919035E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5977,31 +5617,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7429735624198E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8979605301569E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.9127845480489E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9633047023896E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9771104628006E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   9.9421426333613E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -8.1518335645278E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   6.1107906063248E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.7333515633849E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6058173836086E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7429374337762E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8972966250028E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.9457498029771E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9646506462470E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9769321283462E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   9.9430121280081E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -8.1526570895000E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   6.0041899993219E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.7350719352716E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6060091039449E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5219297985482E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9500024222217E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4622174984522E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8314328708416E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5219244204720E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9499978781234E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4625016118900E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8314329670568E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4728440030360E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2610166902784E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6257865516878E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8166942519417E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4534498879043E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5045537509924E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8224627130068E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4728435459670E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2610036684906E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6262996444967E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8166566984709E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4534484419154E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5045287385380E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8236498070391E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6020,16 +5660,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3500515164678E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302680092597E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0583640148646E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3355261666951E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0884470358148E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437045503E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3500514938900E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302680100153E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0583641758498E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3355262408929E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0884472751310E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437045508E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5653315588947E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4759936726886E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7343127579331E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2032120784154E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4759934434907E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7343128185127E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2032120804415E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -6045,16 +5685,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1021338187955E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3200352991647E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461429310792E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7598662650127E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8073111794385E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0811390566945E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946589469E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881864899893E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2395356838993E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6977774166093E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7306650171534E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3200352992506E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461429317252E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7598661493427E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8073110088421E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0811389698423E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946589481E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881864883307E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2395356609795E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6977774862085E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7306652798671E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -6088,89 +5728,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.22137672259934E-01  1.21492575811368E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.04172801272288E+00
+ cg2d: Sum(rhs),rhsMax =  -4.04590174088916E-01  1.21492254456750E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.04163917221775E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.44830980857840E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.44825196492215E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379035232371E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3803124483930E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.0476980705290E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0467000270849E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6331902653584E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6427038702860E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.2809600575377E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4645467206963E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2227079527093E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.8822191833190E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.0296109021894E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2979336237918E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5177986412375E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1850143434247E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6140956132130E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291311137067E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8471807906149E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.1748190587727E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5582452374327E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154606521005E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960864922E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997576950588E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920670881857E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365734709196E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0006459357956E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686527096987E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0480703162666E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610245152E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182832214623E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0944936635410E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3685990367217E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302680092597E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.2658834720539E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0655868804234E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9329307045926E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379036163834E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3804467408099E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.0477567010733E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0467035691150E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6337680492292E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6489138381423E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.2740678467845E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4645384525242E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2227135341360E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.8824127114251E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.0302526428270E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2996742019079E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5178157980026E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1850210679423E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6143887591723E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291311149129E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8471807951107E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.1648189365912E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5582477282902E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154616648039E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960864915E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997576925836E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920670880966E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365734712352E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0006486083975E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686527096960E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0480849582757E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610245182E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182832588646E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0944887623682E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3682215702630E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302680100153E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.2658679355039E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0655913015661E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9338891525196E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.2856876703622E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851619432631E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821109589041E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.7199675789036E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7144939198890E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6130946459703E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.5227970488390E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4737233925397E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.7297361000005E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851619094192E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821106955902E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.7211328119950E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7144954768806E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6121141519285E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.5231849875305E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4737576265619E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.7322128900794E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5334456274282E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9865064748666E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3736292575422E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0409769403102E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0370212759715E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9873879533787E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3739357441560E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0410150099290E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0351255161780E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3340750852800E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4133710033010E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6077647936402E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1357151167724E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1750603992805E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3673980191276E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5621483347985E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6384415218371E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.1712631021654E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.4693156591864E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7661306967455E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9224445279508E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5502588791621E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.6447810705495E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8788228032301E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979408272E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3886799907008E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7678913392218E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4138057731549E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6045378631524E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1357421868209E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1775650026308E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3700366398297E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5642110574173E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6384415255600E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.1659375909726E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.4741256684842E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7661307006336E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9224445318978E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5502664482813E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.6441647943810E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8788493287998E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979408288E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3894599431338E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7658358524689E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540780998999E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526964971E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228350400945E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0826645504266E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.3454950599134E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540781003406E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526965204E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228350885388E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0826595423108E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.3446779833343E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6179,31 +5819,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7467820177374E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7634605976506E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.6213306025308E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7711046368620E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9028453882356E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0569477817895E+00
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.0214013174970E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   3.3878151710197E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6583746030147E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5886822583126E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7601354374605E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7627268355294E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.6734194227098E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7722338686208E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9027703981827E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0570686291629E+00
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.0226685187963E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   3.2707825447646E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6601122975067E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5888845607904E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5141966695369E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9486213270707E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4722028140663E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8317138123150E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5141897608912E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9486158002151E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4725683121106E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8317139261900E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4702129373109E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2612873624375E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6128880889229E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8163159175323E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4702123215836E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2612718438483E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6135047439352E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8162768728596E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4439366416074E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5019194802600E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8043930183407E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4439353386842E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5018873053405E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8058480863044E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6222,16 +5862,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6219941852612E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1521402093961E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6116067776970E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2786433630050E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953776614E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4791079553480E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4270482234921E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2066445887357E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104033640E-07
-(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6931169388106E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2873766318160E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9333993694902E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084731117368E-10
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2786433324025E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953776577E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4791080458674E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4270483095276E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2066450548808E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104033654E-07
+(PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6931169388107E-06
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2873764835971E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9333994392587E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084731119757E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.2324523495989E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.4407348923388E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9532907423740E+00
@@ -6247,16 +5887,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1004237720306E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6718525851041E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4812919343602E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3216182455569E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651281178591E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7582926263135E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8129967750602E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0851077898082E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2970735740696E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539357848246E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2413346380089E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6974236374625E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7418741327508E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3216182456521E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651281186958E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7582924898452E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8129965362377E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0851077031950E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2970735740708E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539357818471E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2413346231870E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6974237237704E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7418745740955E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.7391222779732E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.3183406187123E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7082178872092E-08
@@ -6290,89 +5930,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.73573952290485E-01  1.23048202335438E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.72655641910886E-01
+ cg2d: Sum(rhs),rhsMax =  -4.53523902339107E-01  1.23047996869711E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.72550947979282E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.61659367942146E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.61754188287246E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484079555472E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2539118863086E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2953552438290E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0454761193596E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6316106029327E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7678297618098E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4574223301979E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9102506004732E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3095206640604E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0554406461389E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4397179596436E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.9186765639563E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2746492780377E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2034154811132E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0302462489831E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256000060118E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224105072945E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0972318289970E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5990648947109E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0947528093970E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154934366062E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996010930601E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920765867257E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365949600538E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9462843634966E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684477676947E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0516538714898E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610286280E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182746332937E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0770062180014E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3534098409843E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953776614E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7240752692563E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1691673261122E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8751712829474E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484080671835E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2540328303929E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2954255184359E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0454797841382E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6322602664450E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7747818022384E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4517966565050E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9102428595644E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3095265312956E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0554663814845E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4397179593305E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.9210081191907E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2746635400150E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2034213539320E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0302830724716E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256000080035E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224105127779E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0980622895127E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5990677638800E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0947543797097E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154934366063E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996010899948E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920765866079E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365949604463E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9462883284671E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684477676945E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0516783130919E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610286282E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182746806458E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0769915079430E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3530084862828E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953776577E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7240611319903E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1691678421243E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8753234598494E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302644593960E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8899445714937E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1727165768149E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7469590201673E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5825847794657E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.0788675368142E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4628583459518E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5311399756153E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302639101887E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8899446887111E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1739525276947E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7469562227888E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5815396747668E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.0792003629305E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4628607884670E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5312932412824E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8780577338121E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3567612590916E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0346231957333E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0843228330080E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8794673699109E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3570658015386E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0346577993951E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0827369487187E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3287254683007E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.3985387924377E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4904990348619E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1427508797768E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.4113274567864E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7949403008144E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7504592051977E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9510012190310E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7622419730574E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.0321607320949E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.2057470988049E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2373115612845E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5281108690157E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.1436668523538E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.0747688304462E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979502497E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2869578878929E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2240516662831E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.3989679352437E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4871316997719E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1427782329610E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.4137902073704E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7949466570837E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7505546411805E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9510683452096E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7578950966643E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.0325702292846E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.2058147782110E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2373799050741E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5281193690228E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.1456980825824E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.0747946734492E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979502518E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2876036047406E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2223739030565E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541021469790E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760528507874E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228025148268E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.5985544139167E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.7737570585088E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541021476111E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760528508153E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228025698506E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.5984996425533E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.7731413911341E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6381,280 +6021,292 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   9.0485760460058E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.5617833389146E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.0838781544010E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.4837989685506E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8296813656210E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0707209560405E+00
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.7396135919965E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.9650675641145E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.4875910810080E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6028966314547E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   9.0634354073064E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.5611631709752E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.1489689975491E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.4846820873223E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8291362058306E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0708727592457E+00
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.7414177008977E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.8424668655428E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.4891487159527E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6030034173014E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5067446042708E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9472901611953E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4907639503664E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8319956080549E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5067370236000E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9472839586974E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4911793680953E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8319957400816E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4677081966535E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2615818725958E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6019849447325E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8159447880960E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.7105054312138E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4357827532750E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4998744534344E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7892151786464E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4677074530118E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2615641063907E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6026884440797E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8159042896602E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4357813468587E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4998353555009E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7909201636563E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT         8 ckptA
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) == cost_profiles: begin ==
-(PID.TID 0000.0001) == cost_profiles: end   ==
+(PID.TID 0000.0001) == profiles_cost: begin ==
+(PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.121119834242293D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.208944906208757D+05 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.330064740451050D+05
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.143319027143287D+04
-(PID.TID 0000.0001)  global fc =  0.330064740451050D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  1.21119195798602E+04  1  1.00E+00 (thetaatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  2.08958220993274E+04  2  1.00E+00 (saltatlas)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.43361503881918E+03
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   3.30077416791876E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   206.51053757593036
-(PID.TID 0000.0001)         System time:   10.280211951583624
-(PID.TID 0000.0001)     Wall clock time:   226.39590120315552
+(PID.TID 0000.0001)           User time:   101.63780805934221
+(PID.TID 0000.0001)         System time:   1.3736010454595089
+(PID.TID 0000.0001)     Wall clock time:   103.30646586418152
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   4.5791052021086216
-(PID.TID 0000.0001)         System time:   2.5102180577814579
-(PID.TID 0000.0001)     Wall clock time:   10.085091114044189
+(PID.TID 0000.0001)           User time:   2.6923229042440653
+(PID.TID 0000.0001)         System time:  0.29737798683345318
+(PID.TID 0000.0001)     Wall clock time:   3.0001740455627441
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   201.93136024475098
-(PID.TID 0000.0001)         System time:   7.7699470520019531
-(PID.TID 0000.0001)     Wall clock time:   216.31070399284363
+(PID.TID 0000.0001)           User time:   98.945453405380249
+(PID.TID 0000.0001)         System time:   1.0762120485305786
+(PID.TID 0000.0001)     Wall clock time:   100.30625581741333
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   10.739284992218018
-(PID.TID 0000.0001)         System time:   3.1052939891815186
-(PID.TID 0000.0001)     Wall clock time:   13.883486986160278
+(PID.TID 0000.0001)           User time:   5.8239722251892090
+(PID.TID 0000.0001)         System time:  0.42243403196334839
+(PID.TID 0000.0001)     Wall clock time:   6.3778529167175293
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   191.19201183319092
-(PID.TID 0000.0001)         System time:   4.6646342277526855
-(PID.TID 0000.0001)     Wall clock time:   202.42716097831726
+(PID.TID 0000.0001)           User time:   93.121467590332031
+(PID.TID 0000.0001)         System time:  0.65377801656723022
+(PID.TID 0000.0001)     Wall clock time:   93.928385972976685
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8553495407104492
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.8729155063629150
+(PID.TID 0000.0001)           User time:  0.83652305603027344
+(PID.TID 0000.0001)         System time:   2.8496980667114258E-004
+(PID.TID 0000.0001)     Wall clock time:  0.83738994598388672
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.2499771118164062E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.2721500396728516E-003
+(PID.TID 0000.0001)           User time:   2.8457641601562500E-003
+(PID.TID 0000.0001)         System time:   3.7014484405517578E-005
+(PID.TID 0000.0001)     Wall clock time:   2.8848648071289062E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   185.00198841094971
-(PID.TID 0000.0001)         System time:   3.3427696228027344
-(PID.TID 0000.0001)     Wall clock time:   189.08000493049622
+(PID.TID 0000.0001)           User time:   90.087476730346680
+(PID.TID 0000.0001)         System time:  0.54945701360702515
+(PID.TID 0000.0001)     Wall clock time:   90.718245029449463
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   185.00177288055420
-(PID.TID 0000.0001)         System time:   3.3427686691284180
-(PID.TID 0000.0001)     Wall clock time:   189.07978796958923
+(PID.TID 0000.0001)           User time:   90.087392807006836
+(PID.TID 0000.0001)         System time:  0.54945600032806396
+(PID.TID 0000.0001)     Wall clock time:   90.718173742294312
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6807689666748047
-(PID.TID 0000.0001)         System time:   4.0578842163085938E-004
-(PID.TID 0000.0001)     Wall clock time:   2.6847465038299561
+(PID.TID 0000.0001)           User time:  0.99890041351318359
+(PID.TID 0000.0001)         System time:   1.9401311874389648E-004
+(PID.TID 0000.0001)     Wall clock time:  0.99915480613708496
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1468734741210938
-(PID.TID 0000.0001)         System time:   1.3816356658935547E-002
-(PID.TID 0000.0001)     Wall clock time:   1.1728188991546631
+(PID.TID 0000.0001)           User time:  0.25966930389404297
+(PID.TID 0000.0001)         System time:   1.7046928405761719E-005
+(PID.TID 0000.0001)     Wall clock time:  0.25974416732788086
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6819591522216797
-(PID.TID 0000.0001)         System time:  0.10492515563964844
-(PID.TID 0000.0001)     Wall clock time:   1.9680907726287842
+(PID.TID 0000.0001)           User time:  0.59866333007812500
+(PID.TID 0000.0001)         System time:   2.3675978183746338E-002
+(PID.TID 0000.0001)     Wall clock time:  0.62314319610595703
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.6814680099487305
-(PID.TID 0000.0001)         System time:  0.10490989685058594
-(PID.TID 0000.0001)     Wall clock time:   1.9676427841186523
+(PID.TID 0000.0001)           User time:  0.59742259979248047
+(PID.TID 0000.0001)         System time:   2.3670017719268799E-002
+(PID.TID 0000.0001)     Wall clock time:  0.62190365791320801
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.4686584472656250E-004
-(PID.TID 0000.0001)         System time:   3.8146972656250000E-006
-(PID.TID 0000.0001)     Wall clock time:   1.4591217041015625E-004
+(PID.TID 0000.0001)           User time:   4.1961669921875000E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6239624023437500E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.27859306335449219
-(PID.TID 0000.0001)         System time:   3.0493736267089844E-003
-(PID.TID 0000.0001)     Wall clock time:  0.28204607963562012
+(PID.TID 0000.0001)           User time:   9.3695640563964844E-002
+(PID.TID 0000.0001)         System time:   2.9402971267700195E-004
+(PID.TID 0000.0001)     Wall clock time:   9.4022035598754883E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11509704589843750
-(PID.TID 0000.0001)         System time:   3.0088424682617188E-004
-(PID.TID 0000.0001)     Wall clock time:  0.11541128158569336
+(PID.TID 0000.0001)           User time:   2.8830528259277344E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8847694396972656E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   55.848529815673828
-(PID.TID 0000.0001)         System time:  0.13112306594848633
-(PID.TID 0000.0001)     Wall clock time:   56.071371078491211
+(PID.TID 0000.0001)           User time:   23.979264259338379
+(PID.TID 0000.0001)         System time:   3.2422959804534912E-002
+(PID.TID 0000.0001)     Wall clock time:   24.068958997726440
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   32.914068222045898
-(PID.TID 0000.0001)         System time:   6.4495086669921875E-002
-(PID.TID 0000.0001)     Wall clock time:   33.034723997116089
+(PID.TID 0000.0001)           User time:   14.149434089660645
+(PID.TID 0000.0001)         System time:   8.5149407386779785E-003
+(PID.TID 0000.0001)     Wall clock time:   14.162211894989014
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   31.775609970092773
-(PID.TID 0000.0001)         System time:   6.1010360717773438E-002
-(PID.TID 0000.0001)     Wall clock time:   31.891997098922729
+(PID.TID 0000.0001)           User time:   13.610671997070312
+(PID.TID 0000.0001)         System time:   4.2898654937744141E-003
+(PID.TID 0000.0001)     Wall clock time:   13.619206190109253
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   6.6935977935791016
-(PID.TID 0000.0001)         System time:   2.8654575347900391E-002
-(PID.TID 0000.0001)     Wall clock time:   6.7420794963836670
+(PID.TID 0000.0001)           User time:   3.0444355010986328
+(PID.TID 0000.0001)         System time:   3.0404329299926758E-004
+(PID.TID 0000.0001)     Wall clock time:   3.0459451675415039
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   30.645812988281250
-(PID.TID 0000.0001)         System time:   1.1761665344238281E-002
-(PID.TID 0000.0001)     Wall clock time:   30.684752941131592
+(PID.TID 0000.0001)           User time:   16.465397834777832
+(PID.TID 0000.0001)         System time:   2.4092197418212891E-004
+(PID.TID 0000.0001)     Wall clock time:   16.470492124557495
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7655639648437500
-(PID.TID 0000.0001)         System time:   2.0170211791992188E-004
-(PID.TID 0000.0001)     Wall clock time:   1.7681758403778076
+(PID.TID 0000.0001)           User time:  0.33503055572509766
+(PID.TID 0000.0001)         System time:   6.9737434387207031E-006
+(PID.TID 0000.0001)     Wall clock time:  0.33504271507263184
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.1715049743652344
-(PID.TID 0000.0001)         System time:   3.7832260131835938E-003
-(PID.TID 0000.0001)     Wall clock time:   5.1783790588378906
+(PID.TID 0000.0001)           User time:   2.3973093032836914
+(PID.TID 0000.0001)         System time:   4.0020346641540527E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4063684940338135
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.58090591430664062
-(PID.TID 0000.0001)         System time:   4.4822692871093750E-005
-(PID.TID 0000.0001)     Wall clock time:  0.58142185211181641
+(PID.TID 0000.0001)           User time:  0.31028461456298828
+(PID.TID 0000.0001)         System time:   3.2961368560791016E-005
+(PID.TID 0000.0001)     Wall clock time:  0.31033396720886230
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2551193237304688
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.2567934989929199
+(PID.TID 0000.0001)           User time:  0.56422805786132812
+(PID.TID 0000.0001)         System time:   3.2007694244384766E-005
+(PID.TID 0000.0001)     Wall clock time:  0.56483292579650879
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.17474746704101562
-(PID.TID 0000.0001)         System time:   5.9127807617187500E-005
-(PID.TID 0000.0001)     Wall clock time:  0.17496585845947266
+(PID.TID 0000.0001)           User time:   3.2586097717285156E-002
+(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
+(PID.TID 0000.0001)     Wall clock time:   3.2597303390502930E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2463226318359375
-(PID.TID 0000.0001)         System time:   6.1990737915039062E-002
-(PID.TID 0000.0001)     Wall clock time:   1.3094782829284668
+(PID.TID 0000.0001)           User time:  0.43068122863769531
+(PID.TID 0000.0001)         System time:   4.0049552917480469E-003
+(PID.TID 0000.0001)     Wall clock time:  0.43472123146057129
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   32.574245452880859
-(PID.TID 0000.0001)         System time:   3.1006336212158203E-002
-(PID.TID 0000.0001)     Wall clock time:   32.646280288696289
+(PID.TID 0000.0001)           User time:   16.673438072204590
+(PID.TID 0000.0001)         System time:   4.5609474182128906E-004
+(PID.TID 0000.0001)     Wall clock time:   16.678849935531616
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.3923339843750000E-005
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   6.6041946411132812E-005
+(PID.TID 0000.0001)           User time:   3.0517578125000000E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.8146972656250000E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.2450866699218750
-(PID.TID 0000.0001)         System time:   4.1079521179199219E-003
-(PID.TID 0000.0001)     Wall clock time:   6.2525629997253418
+(PID.TID 0000.0001)           User time:   3.1525573730468750
+(PID.TID 0000.0001)         System time:   3.0398368835449219E-006
+(PID.TID 0000.0001)     Wall clock time:   3.1534171104431152
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6293945312500000E-005
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-006
-(PID.TID 0000.0001)     Wall clock time:   7.7486038208007812E-005
+(PID.TID 0000.0001)           User time:   3.0517578125000000E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.6001205444335938E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.7668075561523438
-(PID.TID 0000.0001)         System time:   1.6177067756652832
-(PID.TID 0000.0001)     Wall clock time:   8.4049293994903564
+(PID.TID 0000.0001)           User time:   3.7707881927490234
+(PID.TID 0000.0001)         System time:  0.23994696140289307
+(PID.TID 0000.0001)     Wall clock time:   4.0122189521789551
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.5337944030761719
-(PID.TID 0000.0001)         System time:   1.3583536148071289
-(PID.TID 0000.0001)     Wall clock time:   4.1984989643096924
+(PID.TID 0000.0001)           User time:   1.4462604522705078
+(PID.TID 0000.0001)         System time:  0.24395203590393066
+(PID.TID 0000.0001)     Wall clock time:   1.6904900074005127
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0426940917968750
-(PID.TID 0000.0001)         System time:  0.17190361022949219
-(PID.TID 0000.0001)     Wall clock time:   1.2212190628051758
+(PID.TID 0000.0001)           User time:  0.39550781250000000
+(PID.TID 0000.0001)         System time:   1.9937992095947266E-002
+(PID.TID 0000.0001)     Wall clock time:  0.41917300224304199
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.9509277343750000E-004
-(PID.TID 0000.0001)         System time:   2.5749206542968750E-005
-(PID.TID 0000.0001)     Wall clock time:   6.2203407287597656E-004
+(PID.TID 0000.0001)           User time:   3.5095214843750000E-004
+(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
+(PID.TID 0000.0001)     Wall clock time:   3.5595893859863281E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.2692718505859375
-(PID.TID 0000.0001)         System time:   1.1499052047729492
-(PID.TID 0000.0001)     Wall clock time:   10.230266094207764
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   1.7948532104492188
+(PID.TID 0000.0001)         System time:   8.4056019783020020E-002
+(PID.TID 0000.0001)     Wall clock time:   1.9463560581207275
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.5405273437500000
-(PID.TID 0000.0001)         System time:   1.0062913894653320
-(PID.TID 0000.0001)     Wall clock time:   9.3216531276702881
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   1.3833084106445312
+(PID.TID 0000.0001)         System time:   8.0062031745910645E-002
+(PID.TID 0000.0001)     Wall clock time:   1.5219299793243408
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.72868347167968750
-(PID.TID 0000.0001)         System time:  0.14361000061035156
-(PID.TID 0000.0001)     Wall clock time:  0.90855693817138672
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.41152191162109375
+(PID.TID 0000.0001)         System time:   3.9939880371093750E-003
+(PID.TID 0000.0001)     Wall clock time:  0.42441105842590332
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.2374877929687500E-002
-(PID.TID 0000.0001)         System time:   1.9073486328125000E-005
-(PID.TID 0000.0001)     Wall clock time:   1.2398004531860352E-002
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   1.2741088867187500E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.3580322265625000E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6793,9 +6445,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          58436
+(PID.TID 0000.0001) //            No. barriers =          58114
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          58436
+(PID.TID 0000.0001) //     Total barrier spins =          58114
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_oce_llc90/results/output.txt
+++ b/global_oce_llc90/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68p
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Fri Jun  9 13:37:06 EDT 2023
+(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -227,7 +227,7 @@
 (PID.TID 0000.0001) ># Elliptic solver parameters
 (PID.TID 0000.0001) > &PARM02
 (PID.TID 0000.0001) > cg2dMaxIters=300,
-(PID.TID 0000.0001) > cg2dTargetResWunit=1.E-12,
+(PID.TID 0000.0001) > cg2dTargetResWunit=2.46E-10,
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
 (PID.TID 0000.0001) ># Time stepping parameters
@@ -635,7 +635,6 @@
 (PID.TID 0000.0001) ># | Parameters for Gaspar et al. (1990)'s TKE vertical mixing scheme  |
 (PID.TID 0000.0001) ># =====================================================================
 (PID.TID 0000.0001) > &GGL90_PARM01
-(PID.TID 0000.0001) ># GGL90taveFreq = 345600000.,
 (PID.TID 0000.0001) ># GGL90dumpFreq = 86400.,
 (PID.TID 0000.0001) ># GGL90writeState=.FALSE.,
 (PID.TID 0000.0001) ># GGL90diffTKEh=3.e3,
@@ -655,9 +654,6 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) GGL90dumpFreq =   /* GGL90 state write out interval ( s ). */
 (PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GGL90taveFreq =   /* GGL90 averaging interval ( s ). */
-(PID.TID 0000.0001)                 1.234567000000000E+05
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GGL90mixingMAPS =   /* GGL90 IO flag */
 (PID.TID 0000.0001)                   F
@@ -699,6 +695,9 @@
 (PID.TID 0000.0001)                 1.000000000000000E-08
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlMaxFlag =   /* Flag for limiting mixing-length method */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) adMxlMaxFlag =   /* Flag for limiting mixing-length method in AD-mode */
 (PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) mxlSurfFlag =   /* GGL90 flag for near surface mixing */
@@ -812,11 +811,10 @@
 (PID.TID 0000.0001) >      SEAICEheatConsFix  = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_tempFrz0    = -1.96,
 (PID.TID 0000.0001) >      SEAICE_dTempFrz_dS = 0.,
-(PID.TID 0000.0001) >      SEAICEuseMetricTerms = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_no_slip     = .TRUE.,
 (PID.TID 0000.0001) >      SEAICE_clipVelocities = .TRUE.,
 (PID.TID 0000.0001) > /
-(PID.TID 0000.0001) >#
+(PID.TID 0000.0001) >
 (PID.TID 0000.0001) > &SEAICE_PARM02
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) >
@@ -903,6 +901,19 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_READPARMS: finished reading data.cost
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) lastinterval =   /* cost interval over which to average ( s ). */
+(PID.TID 0000.0001)                 2.592000000000000E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) cost_mask_file = /* file name of cost mask file */
+(PID.TID 0000.0001)               ''
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // cost configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ECCO_READPARMS: opening data.ecco
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.ecco
 (PID.TID 0000.0001) // =======================================================
@@ -1174,7 +1185,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1717,38 +1732,6 @@
 (PID.TID 0000.0001) // External forcing (EXF) configuration  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) etaday defined by gencost   0
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration >>> START <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 1) = thetaatlas
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_T_atlas.bin
-(PID.TID 0000.0001)  model file = m_theta_mon
-(PID.TID 0000.0001)  error file = some_T_sigma.bin
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  1
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) gencost( 2) = saltatlas
-(PID.TID 0000.0001) -------------
-(PID.TID 0000.0001)  data file = some_S_atlas.bin
-(PID.TID 0000.0001)  model file = m_salt_mon
-(PID.TID 0000.0001)  error file = some_S_sigma.bin
-(PID.TID 0000.0001)  gencost_flag =  1
-(PID.TID 0000.0001)  gencost_outputlevel =  1
-(PID.TID 0000.0001)  gencost_kLev_select =  1
-(PID.TID 0000.0001)  gencost_pointer3d =  2
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
-(PID.TID 0000.0001) // =======================================================
-(PID.TID 0000.0001) 
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // insitu profiles model sampling >>> START <<<
@@ -1805,6 +1788,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseLSR      = /* use default Picard-LSR solver */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEuseLSRflex  = /* with residual norm criterion */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEuseKrylov   = /* use Picard-Krylov solver */
 (PID.TID 0000.0001)                   F
@@ -1887,8 +1873,8 @@
 (PID.TID 0000.0001) SEAICE_waterTurnAngle  = /* ice-water turning angle */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEuseMetricTerms = /* use metric terms */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) SEAICEselectMetricTerms = /* metric terms selector for div(sigma) */
+(PID.TID 0000.0001)                       2
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_no_slip    = /* no slip boundary conditions */
 (PID.TID 0000.0001)                   T
@@ -1959,25 +1945,28 @@
 (PID.TID 0000.0001) SEAICEadvSnow = /* advect snow layer together with ice */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICEmultiDimAdvection = /* multidimadvec */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICEadvScheme   = /* advection scheme for ice */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchArea   = /* advection scheme for area */
+(PID.TID 0000.0001) SEAICEadvSchArea  = /* advection scheme for area */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchHeff   = /* advection scheme for thickness */
+(PID.TID 0000.0001) SEAICEadvSchHeff  = /* advection scheme for thickness */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEadvSchSnow   = /* advection scheme for snow */
+(PID.TID 0000.0001) SEAICEadvSchSnow  = /* advection scheme for snow */
 (PID.TID 0000.0001)                      33
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhArea   = /* diffusivity (m^2/s) for area */
+(PID.TID 0000.0001) SEAICEdiffKhArea  = /* diffusivity (m^2/s) for area */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhHeff   = /* diffusivity (m^2/s) for heff */
+(PID.TID 0000.0001) SEAICEdiffKhHeff  = /* diffusivity (m^2/s) for heff */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICEdiffKhSnow   = /* diffusivity (m^2/s) for snow */
+(PID.TID 0000.0001) SEAICEdiffKhSnow  = /* diffusivity (m^2/s) for snow */
 (PID.TID 0000.0001)                 4.000000000000000E+02
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) DIFF1             = /* parameter used in advect.F [m/s] */
@@ -2068,6 +2057,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_multDim    = /* number of ice categories (1 or 7) */
 (PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SEAICE_useMultDimSnow = /* use separate snow thickness for each category */
+(PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_PDF        = /* sea-ice distribution (-) */
 (PID.TID 0000.0001)                 1.000000000000000E+00,      /* K =  1 */
@@ -2172,16 +2164,10 @@
 (PID.TID 0000.0001) SEAICE_dumpFreq   = /* dump frequency */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_taveFreq   = /* time-averaging frequency */
-(PID.TID 0000.0001)                 0.000000000000000E+00
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_mon_stdio  = /* write monitor to std-outp */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SEAICE_dump_mdsio = /* write snap-shot   using MDSIO */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SEAICE_tave_mdsio = /* write TimeAverage using MDSIO */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
@@ -2210,469 +2196,81 @@
 (PID.TID 0000.0001) // Seaice configuration (SEAICE_PARM01) >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
+(PID.TID 0000.0001) CTRL_INIT_FIXED: ivar=   3 = number of CTRL variables defined
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) ctrl-wet 1:    nvarlength =      1203786
 (PID.TID 0000.0001) ctrl-wet 2: surface wet C =          312
 (PID.TID 0000.0001) ctrl-wet 3: surface wet W =          312
 (PID.TID 0000.0001) ctrl-wet 4: surface wet S =          283
-(PID.TID 0000.0001) ctrl-wet 4a:surface wet V =            0
 (PID.TID 0000.0001) ctrl-wet 5: 3D wet points =        11544
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     1           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     2           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     3           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     4           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     5           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     6           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     7           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     8           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =     9           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    10           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    11           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    12           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    13           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    14           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    15           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    16           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    17           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    18           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    19           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    20           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    21           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    22           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    23           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    24           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    25           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    26           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    27           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    28           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    29           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    30           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    31           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    32           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    33           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    34           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    35           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    36           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    37           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    38           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    39           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    40           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    41           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    42           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    43           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    44           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    45           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    46           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    47           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    48           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    49           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    50           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    51           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    52           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    53           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    54           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    55           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    56           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    57           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    58           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    59           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    60           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    61           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    62           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    63           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    64           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    65           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    66           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    67           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    68           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    69           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    70           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    71           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    72           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    73           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    74           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    75           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    76           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    77           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    78           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    79           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    80           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    81           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    82           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    83           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    84           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    85           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    86           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    87           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    88           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    89           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    90           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    91           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    92           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    93           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    94           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    95           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    96           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    97           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    98           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =    99           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   100           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   101           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   102           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   103           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   104           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   105           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   106           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   107           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   108           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   109           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   110           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   111           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   112           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   113           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   114           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   115           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   116           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   117           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   118           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   119           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   120           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   121           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   122           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   123           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   124           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   125           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   126           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   127           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   128           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   129           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   130           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   131           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   132           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   133           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   134           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   135           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   136           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   137           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   138           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   139           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   140           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   141           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   142           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   143           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   144           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   145           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   146           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   147           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   148           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   149           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   150           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   151           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   152           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   153           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   154           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   155           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   156           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   157           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   158           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   159           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   160           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   161           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   162           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   163           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   164           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   165           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   166           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   167           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   168           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   169           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   170           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   171           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   172           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   173           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   174           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   175           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   176           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   177           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   178           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   179           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   180           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   181           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   182           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   183           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   184           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   185           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   186           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   187           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   188           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   189           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   190           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   191           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   192           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   193           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   194           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   195           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   196           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   197           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   198           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   199           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   200           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   201           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   202           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   203           1
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   204           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   205           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   206           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   207           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   208           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   209           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   210           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   211           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   212           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   213           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   214           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   215           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   216           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   217           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   218           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   219           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   220           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   221           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   222           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   223           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   224           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   225           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   226           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   227           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   228           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   229           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   230           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   231           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   232           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   233           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   234           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   235           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   236           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   237           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   238           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   239           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   240           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   241           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   242           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   243           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   244           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   245           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   246           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   247           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   248           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   249           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   250           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   251           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   252           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   253           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   254           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   255           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   256           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   257           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   258           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   259           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   260           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   261           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   262           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   263           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   264           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   265           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   266           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   267           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   268           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   269           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   270           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   271           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   272           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   273           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   274           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   275           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   276           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   277           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   278           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   279           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   280           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   281           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   282           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   283           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   284           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   285           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   286           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   287           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   288           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   289           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   290           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   291           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   292           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   293           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   294           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   295           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   296           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   297           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   298           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   299           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   300           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   301           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   302           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   303           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   304           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   305           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   306           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   307           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   308           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   309           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   310           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   311           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   312           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   313           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   314           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   315           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   316           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   317           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   318           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   319           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   320           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   321           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   322           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   323           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   324           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   325           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   326           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   327           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   328           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   329           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   330           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   331           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   332           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   333           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   334           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   335           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   336           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   337           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   338           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   339           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   340           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   341           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   342           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   343           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   344           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   345           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   346           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   347           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   348           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   349           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   350           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   351           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   352           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   353           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   354           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   355           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   356           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   357           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   358           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   359           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   360           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   361           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   362           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   363           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   364           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   365           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   366           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   367           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   368           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   369           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   370           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   371           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   372           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   373           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   374           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   375           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   376           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   377           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   378           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   379           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   380           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   381           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   382           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   383           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   384           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   385           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   386           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   387           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   388           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   389           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   390           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   391           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   392           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   393           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   394           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   395           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   396           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   397           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   398           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   399           0
-(PID.TID 0000.0001) ctrl-wet 6: no recs for i =   400           0
-(PID.TID 0000.0001) ctrl-wet 7: flux         23088
-(PID.TID 0000.0001) ctrl-wet 8: atmos        23088
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     1           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     2           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     3           1
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     4           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     5           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     6           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     7           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     8           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =     9           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    10           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    11           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    12           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    13           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    14           0
+(PID.TID 0000.0001) ctrl-wet 6: no recs for ivar =    15           0
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl-wet 13: global nvarlength for Nr =   50     7220976
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    1       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    2       60646       59295       59493           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    3       59874       58517       58725           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    4       59387       58040       58258           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    5       58882       57536       57754           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    6       58399       57057       57276           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    7       58052       56735       56936           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    8       57781       56461       56669           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=    9       57530       56212       56416           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   10       57283       55964       56154           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   11       57022       55702       55883           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   12       56818       55497       55681           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   13       56634       55322       55509           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   14       56430       55125       55312           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   15       56238       54935       55117           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   16       55975       54689       54858           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   17       55703       54421       54600           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   18       55358       54075       54251           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   19       54964       53666       53853           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   20       54471       53205       53372           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   21       53952       52716       52877           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   22       53489       52249       52409           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   23       52892       51633       51797           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   24       52223       50961       51129           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   25       51696       50480       50635           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   26       51259       50075       50241           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   27       50929       49774       49935           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   28       50664       49532       49678           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   29       50438       49306       49450           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   30       50187       49035       49179           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   31       49964       48805       48937           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   32       49700       48530       48662           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   33       49431       48260       48383           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   34       49176       47993       48108           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   35       48854       47652       47764           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   36       48501       47264       47375           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   37       48098       46846       46951           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   38       47523       46253       46362           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   39       46849       45558       45657           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   40       45984       44670       44751           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   41       44793       43419       43459           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   42       42984       41497       41533           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   43       40302       38691       38718           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   44       36689       35007       35032           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   45       31681       30069       29999           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   46       25595       24028       24031           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   47       18224       16890       16872           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   48       11407       10397       10351           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   49        4597        3913        3912           0
-(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W/V k=   50         818         624         622           0
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
-(PID.TID 0000.0001) ctrl-wet -------------------------------------------------
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    1       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    2       60646       59295       59493
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    3       59874       58517       58725
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    4       59387       58040       58258
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    5       58882       57536       57754
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    6       58399       57057       57276
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    7       58052       56735       56936
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    8       57781       56461       56669
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=    9       57530       56212       56416
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   10       57283       55964       56154
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   11       57022       55702       55883
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   12       56818       55497       55681
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   13       56634       55322       55509
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   14       56430       55125       55312
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   15       56238       54935       55117
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   16       55975       54689       54858
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   17       55703       54421       54600
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   18       55358       54075       54251
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   19       54964       53666       53853
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   20       54471       53205       53372
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   21       53952       52716       52877
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   22       53489       52249       52409
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   23       52892       51633       51797
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   24       52223       50961       51129
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   25       51696       50480       50635
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   26       51259       50075       50241
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   27       50929       49774       49935
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   28       50664       49532       49678
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   29       50438       49306       49450
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   30       50187       49035       49179
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   31       49964       48805       48937
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   32       49700       48530       48662
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   33       49431       48260       48383
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   34       49176       47993       48108
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   35       48854       47652       47764
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   36       48501       47264       47375
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   37       48098       46846       46951
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   38       47523       46253       46362
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   39       46849       45558       45657
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   40       45984       44670       44751
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   41       44793       43419       43459
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   42       42984       41497       41533
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   43       40302       38691       38718
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   44       36689       35007       35032
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   45       31681       30069       29999
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   46       25595       24028       24031
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   47       18224       16890       16872
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   48       11407       10397       10351
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   49        4597        3913        3912
+(PID.TID 0000.0001) ctrl-wet 14: global nWet C/S/W k=   50         818         624         622
 (PID.TID 0000.0001) ctrl-wet -------------------------------------------------
 (PID.TID 0000.0001) ctrl_init_wet: no. of control variables:            3
 (PID.TID 0000.0001) ctrl_init_wet: control vector length:         7220976
@@ -2683,41 +2281,46 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Total number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------------
-(PID.TID 0000.0001)  snx*sny*nr =    45000
+(PID.TID 0000.0001)  sNx*sNy*Nr =    45000
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  Number of ocean points per tile:
 (PID.TID 0000.0001)  --------------------------------
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0001 0001 011544 010207 011460
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0002 0001 041559 041310 041343
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0003 0001 039915 038420 039722
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0004 0001 035457 033982 035227
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0005 0001 040378 040035 040082
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0006 0001 040418 040096 040138
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0007 0001 040462 040067 040100
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0008 0001 040877 040589 040319
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0009 0001 031231 030937 030957
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0010 0001 020622 020046 018422
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0011 0001 039018 038680 038425
-(PID.TID 0000.0001)  bi,bj,#(c/s/w): 0012 0001 019781 019699 019576
-(PID.TID 0000.0001) 
-(PID.TID 0000.0001)  Settings of generic controls:
-(PID.TID 0000.0001)  -----------------------------
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 001 001   11544   10207   11460
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 002 001   41559   41310   41343
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 003 001   39915   38420   39722
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 004 001   35457   33982   35227
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 005 001   40378   40035   40082
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 006 001   40418   40096   40138
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 007 001   40462   40067   40100
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 008 001   40877   40589   40319
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 009 001   31231   30937   30957
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 010 001   20622   20046   18422
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 011 001   39018   38680   38425
+(PID.TID 0000.0001)  bi,bj,#(c/s/w): 012 001   19781   19699   19576
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  1 is in use
 (PID.TID 0000.0001)       file       = xx_kapgm
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     1  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     1
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0201
-(PID.TID 0000.0001)       ncvarindex =  0301
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  2 is in use
 (PID.TID 0000.0001)       file       = xx_kapredi
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     2  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     2
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0202
-(PID.TID 0000.0001)       ncvarindex =  0302
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001)  -> 3d control, genarr3d no.  3 is in use
 (PID.TID 0000.0001)       file       = xx_diffkr
+(PID.TID 0000.0001)       ncvartype  = Arr3D
+(PID.TID 0000.0001)       index      =     3  (use this for pkg/grdchk)
+(PID.TID 0000.0001)       ncvarindex =     3
 (PID.TID 0000.0001)       weight     = wt_ones.bin
-(PID.TID 0000.0001)       index      =  0203
-(PID.TID 0000.0001)       ncvarindex =  0303
+(PID.TID 0000.0001) useCtrlCostContribution =  /* compute regularisation for gen. ctrls */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // control vector configuration  >>> END <<<
@@ -2725,74 +2328,74 @@
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   359
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   367
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   273 SIarea
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   276 SIheff
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   278 SIhsnow
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   280 SIarea
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   283 SIheff
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   285 SIhsnow
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 sIceLoad
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    77 MXLDEPTH
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   359 oceSPDep
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIatmQnt
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmFW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceQnet
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    84 oceFWflx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    80 oceTAUX
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    81 oceTAUY
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   325 ADVxHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   326 ADVyHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   327 DFxEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   328 DFyEHEFF
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVxSNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 ADVySNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFxESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   336 DFyESNOW
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   290 SIuice
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   291 SIvice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    85 sIceLoad
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    78 MXLDEPTH
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   367 oceSPDep
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   305 SIatmQnt
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   312 SIatmFW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    88 oceQnet
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    86 oceFWflx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    82 oceTAUX
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    83 oceTAUY
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   332 ADVxHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   333 ADVyHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   334 DFxEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   335 DFyEHEFF
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   340 ADVxSNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   341 ADVySNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   342 DFxESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   343 DFyESNOW
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   297 SIuice
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   298 SIvice
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    27 SALT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 VVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 WVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   258 GM_PsiX
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   259 GM_PsiY
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 DFxE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   135 DFyE_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   131 ADVx_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   132 ADVy_TH
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 DFxE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   142 DFyE_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   138 ADVx_SLT
-(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   139 ADVy_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    47 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #    48 WVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   265 GM_PsiX
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   266 GM_PsiY
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   136 DFxE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   137 DFyE_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   133 ADVx_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   134 ADVy_TH
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   143 DFxE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   144 DFyE_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   140 ADVx_SLT
+(PID.TID 0000.0001) SETDIAG: Allocate 50 x  1 Levels for Diagnostic #   141 ADVy_SLT
 (PID.TID 0000.0001)   space allocated for all diagnostics:     825 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    80  oceTAUX  , Parms: UU      U1 , mate:    81
-(PID.TID 0000.0001)   set mate pointer for diag #    81  oceTAUY  , Parms: VV      U1 , mate:    80
-(PID.TID 0000.0001)   set mate pointer for diag #   325  ADVxHEFF , Parms: UU      M1 , mate:   326
-(PID.TID 0000.0001)   set mate pointer for diag #   326  ADVyHEFF , Parms: VV      M1 , mate:   325
-(PID.TID 0000.0001)   set mate pointer for diag #   327  DFxEHEFF , Parms: UU      M1 , mate:   328
-(PID.TID 0000.0001)   set mate pointer for diag #   328  DFyEHEFF , Parms: VV      M1 , mate:   327
-(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVxSNOW , Parms: UU      M1 , mate:   334
-(PID.TID 0000.0001)   set mate pointer for diag #   334  ADVySNOW , Parms: VV      M1 , mate:   333
-(PID.TID 0000.0001)   set mate pointer for diag #   335  DFxESNOW , Parms: UU      M1 , mate:   336
-(PID.TID 0000.0001)   set mate pointer for diag #   336  DFyESNOW , Parms: VV      M1 , mate:   335
-(PID.TID 0000.0001)   set mate pointer for diag #   290  SIuice   , Parms: UU      M1 , mate:   291
-(PID.TID 0000.0001)   set mate pointer for diag #   291  SIvice   , Parms: VV      M1 , mate:   290
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   258  GM_PsiX  , Parms: UU      LR , mate:   259
-(PID.TID 0000.0001)   set mate pointer for diag #   259  GM_PsiY  , Parms: VV      LR , mate:   258
-(PID.TID 0000.0001)   set mate pointer for diag #   134  DFxE_TH  , Parms: UU      MR , mate:   135
-(PID.TID 0000.0001)   set mate pointer for diag #   135  DFyE_TH  , Parms: VV      MR , mate:   134
-(PID.TID 0000.0001)   set mate pointer for diag #   131  ADVx_TH  , Parms: UU      MR , mate:   132
-(PID.TID 0000.0001)   set mate pointer for diag #   132  ADVy_TH  , Parms: VV      MR , mate:   131
-(PID.TID 0000.0001)   set mate pointer for diag #   141  DFxE_SLT , Parms: UU      MR , mate:   142
-(PID.TID 0000.0001)   set mate pointer for diag #   142  DFyE_SLT , Parms: VV      MR , mate:   141
-(PID.TID 0000.0001)   set mate pointer for diag #   138  ADVx_SLT , Parms: UU      MR , mate:   139
-(PID.TID 0000.0001)   set mate pointer for diag #   139  ADVy_SLT , Parms: VV      MR , mate:   138
+(PID.TID 0000.0001)   set mate pointer for diag #    82  oceTAUX  , Parms: UU      U1 , mate:    83
+(PID.TID 0000.0001)   set mate pointer for diag #    83  oceTAUY  , Parms: VV      U1 , mate:    82
+(PID.TID 0000.0001)   set mate pointer for diag #   332  ADVxHEFF , Parms: UU      M1 , mate:   333
+(PID.TID 0000.0001)   set mate pointer for diag #   333  ADVyHEFF , Parms: VV      M1 , mate:   332
+(PID.TID 0000.0001)   set mate pointer for diag #   334  DFxEHEFF , Parms: UU      M1 , mate:   335
+(PID.TID 0000.0001)   set mate pointer for diag #   335  DFyEHEFF , Parms: VV      M1 , mate:   334
+(PID.TID 0000.0001)   set mate pointer for diag #   340  ADVxSNOW , Parms: UU      M1 , mate:   341
+(PID.TID 0000.0001)   set mate pointer for diag #   341  ADVySNOW , Parms: VV      M1 , mate:   340
+(PID.TID 0000.0001)   set mate pointer for diag #   342  DFxESNOW , Parms: UU      M1 , mate:   343
+(PID.TID 0000.0001)   set mate pointer for diag #   343  DFyESNOW , Parms: VV      M1 , mate:   342
+(PID.TID 0000.0001)   set mate pointer for diag #   297  SIuice   , Parms: UU      M1 , mate:   298
+(PID.TID 0000.0001)   set mate pointer for diag #   298  SIvice   , Parms: VV      M1 , mate:   297
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   265  GM_PsiX  , Parms: UU      LR , mate:   266
+(PID.TID 0000.0001)   set mate pointer for diag #   266  GM_PsiY  , Parms: VV      LR , mate:   265
+(PID.TID 0000.0001)   set mate pointer for diag #   136  DFxE_TH  , Parms: UU      MR , mate:   137
+(PID.TID 0000.0001)   set mate pointer for diag #   137  DFyE_TH  , Parms: VV      MR , mate:   136
+(PID.TID 0000.0001)   set mate pointer for diag #   133  ADVx_TH  , Parms: UU      MR , mate:   134
+(PID.TID 0000.0001)   set mate pointer for diag #   134  ADVy_TH  , Parms: VV      MR , mate:   133
+(PID.TID 0000.0001)   set mate pointer for diag #   143  DFxE_SLT , Parms: UU      MR , mate:   144
+(PID.TID 0000.0001)   set mate pointer for diag #   144  DFyE_SLT , Parms: VV      MR , mate:   143
+(PID.TID 0000.0001)   set mate pointer for diag #   140  ADVx_SLT , Parms: UU      MR , mate:   141
+(PID.TID 0000.0001)   set mate pointer for diag #   141  ADVy_SLT , Parms: VV      MR , mate:   140
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_2d_set1
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: state_3d_set1
@@ -2807,12 +2410,12 @@
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.  16.  17.  18.  19.  20.
 (PID.TID 0000.0001)  Levels:      21.  22.  23.  24.  25.  26.  27.  28.  29.  30.  31.  32.  33.  34.  35.  36.  37.  38.  39.  40.
 (PID.TID 0000.0001)  Levels:      41.  42.  43.  44.  45.  46.  47.  48.  49.  50.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     825 levels (numDiags =    3000 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define   0 regions:
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use       0 levels (diagSt_size=    2500 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) INI_GLOBAL_DOMAIN: Found   0 CS-corner Pts in the domain
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4584096177006E-04
@@ -2828,7 +2431,7 @@
 (PID.TID 0000.0001) %MON fCoriCos_mean                =   9.3876998486639E-05
 (PID.TID 0000.0001) %MON fCoriCos_sd                  =   3.9559575367967E-05
 (PID.TID 0000.0001) INI_CG2D: CG2D normalisation factor =  7.1522409280111305E-05
-(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.112781640300954E-06 (Area=3.5801386115E+14)
+(PID.TID 0000.0001) INI_CG2D: cg2dTolerance = 7.105154116076021E-06 (Area=1.4537802370E+12)
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model configuration
@@ -3179,7 +2782,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -3259,17 +2862,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -3277,6 +2870,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       1
@@ -3295,6 +2898,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -3349,6 +2953,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) balanceQnet  =  /* balance net heat-flux on/off flag */
 (PID.TID 0000.0001)                   F
@@ -3439,7 +3046,7 @@
 (PID.TID 0000.0001)                 1.000000000000000E-07
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dTargetResWunit =   /* CG2d target residual [W units] */
-(PID.TID 0000.0001)                 1.000000000000000E-12
+(PID.TID 0000.0001)                 2.460000000000000E-10
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dPreCondFreq =   /* Freq. for updating cg2d preconditioner */
 (PID.TID 0000.0001)                       1
@@ -3451,7 +3058,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -4591,6 +4198,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.580138611494435E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 6.226703613420189E+09
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 6.064600000000000E+04
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 2.406992000000000E+06
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hasWetCSCorners = /* Domain contains CS corners (True/False) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -4618,11 +4234,14 @@
 (PID.TID 0000.0001) GM_isopycK =    /* Background Isopyc. Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+03
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s] */
+(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_skewflx*K =  /* Background GM_SkewFlx Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) GM_advec*K =    /* Backg. GM-Advec(=Bolus) Diffusivity [m^2/s]*/
-(PID.TID 0000.0001)                 1.000000000000000E+03
+(PID.TID 0000.0001) GM_isoFac_calcK = /* Fraction of dynamic K added to Redi tensor */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_Kmin_horiz = /* Minimum Horizontal Diffusivity [m^2/s] */
 (PID.TID 0000.0001)                 1.000000000000000E+02
@@ -4678,6 +4297,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) EXF_CHECK: #define ALLOW_EXF
 (PID.TID 0000.0001) SEAICE_CHECK: #define ALLOW_SEAICE
 (PID.TID 0000.0001) SALT_PLUME_CHECK: #define SALT_PLUME
@@ -4685,7 +4307,39 @@
 (PID.TID 0000.0001) CTRL_CHECK:  <-- Ends Normally
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) COST_CHECK: #define ALLOW_COST
-(PID.TID 0000.0001) etaday defined by gencost   0
+(PID.TID 0000.0001) ECCO_CHECK:  --> Starts to check ECCO set-up
+(PID.TID 0000.0001) etagcm defined by gencost =  0
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration >>> START <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 1) = thetaatlas
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_T_atlas.bin
+(PID.TID 0000.0001)  model file = m_theta_mon
+(PID.TID 0000.0001)  error file = some_T_sigma.bin
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  1
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) gencost( 2) = saltatlas
+(PID.TID 0000.0001) -------------
+(PID.TID 0000.0001)  data file = some_S_atlas.bin
+(PID.TID 0000.0001)  model file = m_salt_mon
+(PID.TID 0000.0001)  error file = some_S_sigma.bin
+(PID.TID 0000.0001)  gencost_flag =  1
+(PID.TID 0000.0001)  gencost_outputlevel =  1
+(PID.TID 0000.0001)  gencost_kLev_select =  1
+(PID.TID 0000.0001)  gencost_pointer3d =  2
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // ECCO configuration  >>> END <<<
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
+(PID.TID 0000.0001) ECCO_CHECK:  <-- Ends Normally
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) GAD_CHECK: #define ALLOW_GENERIC_ADVDIFF
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Check Model config. (CONFIG_CHECK):
@@ -4908,89 +4562,89 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -1.38868621129551E-01  1.31387001713972E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.47389299189733E+01
+ cg2d: Sum(rhs),rhsMax =  -1.38868680054447E-01  1.31387004504432E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.47390262100532E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     141
-(PID.TID 0000.0001)      cg2d_last_res =   6.62021250346201E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.62022974473912E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.3130328769274E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5422872117642E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.0285728052409E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0506618704582E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6507755488133E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9899858168920E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.1283969442017E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9850527369661E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6833046269599E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.8633077905043E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.5993892178648E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.9482662959186E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2235836421112E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.6875153632726E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8259930288527E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.3130452151768E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5422900473291E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.0285757876142E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0506624095793E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6508314351239E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9899858167257E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.1283969442519E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9850365503626E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6833104199050E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.8632813117431E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.5993892177469E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.9482662961196E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2235823815576E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.6875123357380E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8260026108292E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5209619757452E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9082344844909E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6297957395996E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915858429145E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2677807136705E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9082151282428E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6298278560748E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915848274753E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2677751715508E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1235781719992E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006903056514E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920432876559E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366196409272E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3104770613652E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006903056076E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920432876564E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366196409247E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3104771105362E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701915445486E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0260376598364E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611386387E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183934921560E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451765072643E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3393999714201E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5566837045105E+03
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.3184513008250E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4490395725435E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9069071608360E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0260375504551E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611386363E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183934949425E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451765014272E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3394002370662E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5566837056038E+03
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.3184477062418E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4490396353558E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9068846870852E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1870783737789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402297965728E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1470635965091E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2189110474420E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   5.5245686266964E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5364679301274E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0090003934977E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8202602107389E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.4542952521939E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402297967042E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1470635881799E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2189591781047E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   5.5245693743014E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5364828572226E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0090012459599E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8202593424481E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.4542292578512E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4705513033302E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -8.8698331221292E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1981213942951E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1172481238959E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9667072786090E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1998962969883E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1172482340119E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9663977234940E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.9550665185239E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.1540750854849E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.8558596242676E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2927831155792E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.6002002154192E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6813355409559E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9573073025571E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7025053024496E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4735405270264E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9113469193102E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6017873690088E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6834357366905E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8547855157847E-07
-(PID.TID 0000.0001) %MON ke_max                       =   2.2633553577575E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4131722906335E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.8573390992873E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2927810262443E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.6007071025763E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6813322108671E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9573049065930E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7024786594348E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4735507203708E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9114053303613E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6017607774636E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6834090936757E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8547738133314E-07
+(PID.TID 0000.0001) %MON ke_max                       =   2.2633553576992E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4131737974996E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -6.9599703210919E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.5332528543872E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -6.9599990028029E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.5334556086761E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542347762477E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542347762446E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760527755546E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246700420307E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9343385720972E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6131474386726E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246700419086E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9343384337833E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6133898755793E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5001,29 +4655,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.5371020596990E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3417444357301E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7079361368153E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.5415783073617E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3417476499335E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7079198131571E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.0384835425795E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4138808340681E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.7596807382501E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.0386262697887E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4138857220188E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.7597213273079E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5072412369511E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9282251204265E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4216737968360E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8293906605135E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5072420033115E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9282253950364E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4216931225477E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8293906618174E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4827637550456E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2590250477096E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7392780159557E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8152458221589E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4827637522246E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2590240427009E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7393374825417E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8152456681090E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.7105054312138E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5171841443538E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5274366407068E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9933326648488E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5171841291493E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5274350712689E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9934380981997E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5034,24 +4688,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.5358413892982E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -9.0286728185089E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3951481864032E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1235890606392E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2834339599213E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3951481891995E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1235890606017E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2834339496567E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.0090203280816E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.1638464927919E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9456020208127E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3048203509657E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6777503892839E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0678378267418E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9486079634276E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.8586378990658E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7211888451379E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7052481699355E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8554984245110E-07
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9456020173233E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3048203509322E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6777503835930E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0678378328816E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9486079634032E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.8586380055547E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7211888488517E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7052481901976E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8554984245111E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9830721697300E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7967031673745E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2315548388867E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8064182232216E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7967031789078E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2315548399971E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8064182276904E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3693679918154E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.9665221975781E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.2496218946971E-02
@@ -5077,16 +4731,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1136747398460E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7683458659431E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4900239072660E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226482946614E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0741097395836E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867070141176E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7655600252190E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4326333408001E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2571323952519E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2505107179269E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0880832504003E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7879334912146E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2769331204191E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226481668246E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0741097395700E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867070163253E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7655600359613E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4326333764298E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2571323952520E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2505107179267E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0880832515536E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7879334918363E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2769331310969E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590865049111E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.4113024360293E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5531398293978E-08
@@ -5120,89 +4774,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.89207650950903E-01  1.27535774864827E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.83641865407638E+00
+ cg2d: Sum(rhs),rhsMax =  -2.85863273517481E-01  1.27535768940690E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.83643529889094E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.39424620964275E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39427402088865E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262376662395E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5171680801188E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468437351514E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0375517515402E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7367557597776E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2635037224615E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3848072839099E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766667313250E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598116162619E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318487742384E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4612559434672E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2013183687207E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481324545003E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184238360316E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010699548700E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8990034776967E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251798245795E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967192531916E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204602288511E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009258917352E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262792776567E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5171845862736E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468429324914E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0375520768526E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7368485120724E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2635037208215E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3848072840420E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766634748880E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598138616764E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318294712718E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4612559423083E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2013183711832E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481014180091E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184245065822E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010690990365E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8990034776956E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251798245818E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967177639381E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204593231223E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009178855306E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1221846198577E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002431435509E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920325945655E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150249627E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3016215404464E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0696401789330E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0287401465945E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610216795E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063465300E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203349192381E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3301822453753E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8315836676857E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.0426692566356E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4261366594756E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3927227914823E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002431433276E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920325945725E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150249569E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3016215760523E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0696401789327E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0287397585787E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610216802E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063442654E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203331918141E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3301824596430E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8315837721102E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.0426662534824E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4261366956319E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3927134534577E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1849455478432E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8404988283809E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1430905013218E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1982875155663E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7784013474279E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5035734351768E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1265612828096E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6693358688570E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.8262143098366E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8404988286605E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1430904182058E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1983928174239E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7783989405805E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5035915201604E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1265581360785E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6693331670435E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.8261923549851E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5179254362727E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -9.0136720875096E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.3121286398367E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1306653316324E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9761410792117E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.3144545274017E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1306700745556E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9764033293343E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.9976353440884E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.1602414877130E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.7942715215800E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3096056697130E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3501844255906E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8832817673992E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1412793005098E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7592803544116E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8941678545481E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2275956453778E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6666425959910E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7540183176685E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694754451181E-05
-(PID.TID 0000.0001) %MON ke_max                       =   2.7026108461264E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3999925380608E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.7958193456057E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3096168722875E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3507464548031E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8832988935680E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1412766094540E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7591245863386E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8942880426672E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2275957531403E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6664838827989E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7538624677090E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694765360369E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.7026108451937E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3999957307112E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979021026E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -9.7283070556239E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.3301766551003E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -9.7282419032544E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.3301755385977E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541841737610E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526005810E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243418964514E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791911007308E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364313685806E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541841737344E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526005832E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243419001326E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791902069405E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364247247452E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5213,29 +4867,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.2084972057648E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3964493948248E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.0670002512173E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.2666845091992E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3964648261109E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.0670873185291E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.3721456105428E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4983948384573E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0504157758039E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.3723698940452E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4984103409619E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0505175266908E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5005837523748E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9260957421873E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4096800471210E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8290270086083E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5005836242363E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9260954540206E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4097293706094E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8290270129646E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4748149957801E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2568536139603E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7212054774318E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8111626355753E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4748150088296E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2568509749522E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7213068171104E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8111621258294E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5043886993056E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5225938497702E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9640168154620E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5043885897402E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5225894832191E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9641890445679E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5246,24 +4900,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.6070752252851E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0721768894532E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4080401142754E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1683205123755E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6590444344776E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4080400663371E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1683205126007E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6590444380512E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.1828930560154E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2944199572625E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.6661604326489E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3564340237571E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0525238431827E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0632294159607E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9877363613978E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.5242984232674E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7276261417595E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7166724222112E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2944199572626E+00
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.6661604498065E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3564340237557E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0525238396646E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0632292207408E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9877363613513E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.5243005383055E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7276262074206E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7166725248640E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.8560368588294E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9845852817752E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.0210821368725E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2445530381394E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8739733153020E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.0210824265910E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2445530592108E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8739733837914E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4419044704080E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.1151399871527E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.5722890313975E-02
@@ -5289,16 +4943,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1140840707321E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7700841752415E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4912465616232E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157615073825E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0648186028795E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8854780190623E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627624918269E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4280610517883E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2468912299971E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -6.0639664185217E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1104960421479E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8185576306263E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3626269234736E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157609467114E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0648186028147E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8854780540290E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627626087299E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4280611737188E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2468912299992E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -6.0639664185213E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1104960711198E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8185576413115E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3626270028967E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590912547353E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.4010021173262E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5531116120526E-08
@@ -5332,89 +4986,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.36103301356161E-01  1.24223801417413E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.44235519189816E+00
+ cg2d: Sum(rhs),rhsMax =  -4.29323547138751E-01  1.24223791494558E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.44236805566375E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.97327335267369E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.97199908544985E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932696983759E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285240571256E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729410301361E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247169401675E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6820691712060E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883534916E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.7726823920712E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796597520474E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731509820413E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028325352413E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825300114E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318898644E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363315395436E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770046609774E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474852859927E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835950E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732047678E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641619416456E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645387390779E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519454000827E-08
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1207805418001E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659994557E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920324139776E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138324277E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524400247848E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932698181767E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285521412364E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729399943086E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247170635812E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6821926151564E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883466883E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.7726823919283E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796551193497E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731534362990E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028589244171E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825251092E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318993951E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363832979379E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770078310957E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474848166878E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835719E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732045993E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641240679181E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645386141407E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519389915332E-08
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1207805418010E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659990279E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920324139849E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138324219E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524402554808E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692030172818E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0316468452690E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609436456E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241272068E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931220605362E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3190714409649E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3996176116447E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025805508980E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4306290703278E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3795175204689E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0316460025480E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609436489E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241198571E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931204011945E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3190711080412E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3996110713171E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025548474850E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4306291687981E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3794898300208E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1828127219075E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407069220789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1398710012697E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1691595229775E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.8989852213026E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4639675004097E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0754281014985E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6506054230993E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7940351668305E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407069227348E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1398707893327E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1693298461210E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.8989783131319E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4639843185738E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0754274350273E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6506007669625E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7939590236620E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6030889502423E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0596231973745E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2750279377100E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1759858730742E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4238791671418E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2774328037690E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1759915798902E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4247143427443E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2704322309957E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.5633002257935E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3598188467078E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8778552325592E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4916559940519E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337264909974E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7973422511459E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209674571235E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758593827882E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8774211805260E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511512625E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635889189343E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.7367852948952E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3275597352284E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.5649122691536E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3598322636911E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8785567995030E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4917624497738E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337272191126E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7973422510606E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209752545897E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758271670522E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8774211804371E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511511738E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635938574918E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.7367852920508E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3275678907695E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979287383E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3712142783274E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2483229527798E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3711936407671E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2486409952468E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278305285E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524185475E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726010122E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236989570014E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6193062791124E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278304712E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524185540E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726111694E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236974211620E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6192724768184E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5425,29 +5079,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3341095672623E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196135995765E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1809073675249E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3987159629194E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196402361097E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1810293090928E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6966438302505E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158248659611E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1429380406268E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6969046840969E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158470420176E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1430086449031E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4925648992250E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9238704332020E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4040291812786E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8286763322779E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4925633215255E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9238692642015E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4041162463726E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8286763388691E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4670683118992E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2547240984744E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7030853346680E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8070831514916E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4670683303204E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2547194969561E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7032177997255E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8070816627074E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4915990376763E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5176950372529E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9345943159865E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4915988526895E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5176874089174E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9348026714388E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5456,26 +5110,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     3
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.7460812353986E+00
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.7460812353987E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.2880075472116E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4062809636279E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2505564859909E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   9.4822093470282E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.4555929386902E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.4614409161053E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.3279354348816E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4511363645966E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.0168655752319E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629901160661E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0274702988011E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   3.7985936851482E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7424648806072E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7565747501865E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9427654093935E-07
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4062808549059E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2505564861280E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   9.4822093260147E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.4555929386903E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.4614409161054E+00
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.3279354216276E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4511363644815E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.0168655740945E-04
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629898394828E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0274702987682E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   3.7985962792271E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7424649533177E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7565749166344E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9427654093929E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9860686757295E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.4299491214281E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2729065215247E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   6.0240568468223E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.4299494564189E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2729065315018E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   6.0240569130031E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.5385738615075E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.2700944862139E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.8949561680979E-02
@@ -5501,16 +5155,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144934016182E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7733491035386E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4927149202723E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5082757573105E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530591787637E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8840083706994E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7603722947613E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4230831454908E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6040624655520E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -7.3102205391973E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1513576354013E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8778109420426E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.5407306122073E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5082612175921E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530591785777E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8840084136931E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7603724575055E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4230833246403E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6040624655553E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -7.3102205391813E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1513576689004E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8778109370753E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.5407307030962E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590960045594E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3907017986231E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530833947075E-08
@@ -5544,89 +5198,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.81295744177836E-01  1.22564183554089E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.18649824272784E+00
+ cg2d: Sum(rhs),rhsMax =  -5.70534163392034E-01  1.22564170069960E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.18650860032171E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.70459354422790E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70451995527611E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284670698E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025084691781E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876544531963E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095703533499E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6715779215608E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532787914520E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959684265E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687227999651E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119878041193E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496107489700E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249366938E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067769195E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392455904148E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278616275811E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778890134316E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195455242E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274823793E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1061232471418E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746305387465E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151554971684E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284891059E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025476825903E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876508405283E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095706977185E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6717472770033E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532787918899E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959663348E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687168904656E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119897739487E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496590862892E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249251997E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067952596E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392523064507E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278668732587E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778900786491E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195453542E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274817028E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1060750534639E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746307051857E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151549454522E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1200643921829E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884008468E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692785E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150500990E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849176333676E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689786989405E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0346478241676E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608842191E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416238268E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666320394046E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123026860396E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097064713393E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5623037940063E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418854978886E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168629102633E-01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884005265E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692795E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150500876E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849177026248E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689786989403E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0346463232759E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608842230E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416090313E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666318761441E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123018640660E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097192517228E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5622835949435E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418858859577E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168407187806E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409094559967E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1368757790270E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1422014367214E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110338762608E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368176515923E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428892009140E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263080716488E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6026339648649E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.7300591272462E+00
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409094579651E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1368753725052E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1424656666738E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110279863140E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368297863293E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428818354445E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263044304629E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6025810526373E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.7300591272463E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.2780756577411E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2175322974259E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2588359723217E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2330714365552E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2200258332825E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2588427409100E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2341049887238E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.4344083006843E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.3716874297782E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442813385174E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8266158741548E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2225646572400E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7791805304877E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823280728E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479069438269E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3369911208247E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2633494684313E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937874345E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486171731319E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.9456878804675E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1606443916352E-04
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.4344083006844E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.3731914007749E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442954147264E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8269925851577E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2225667535001E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7772512749505E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823277950E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479069783452E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3371195108790E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2633494681444E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937871386E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486187303830E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.9456878734836E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1606567527671E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979547336E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1934696707652E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.1821025664391E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1935135326908E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.1824529928759E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881143666E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523419776E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196978658E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9110009633250E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6195360070981E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881143025E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523419879E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236197153012E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9109996098498E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6194980538525E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5637,29 +5291,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4793431444568E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457594005745E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2978111904779E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4205965286260E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457885054575E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2979108017996E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9076206362249E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8344959601688E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2605712593560E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9078956229604E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8345214393932E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2606289151498E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865638504088E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218608125962E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3806269283700E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8283388458671E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865603338680E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218585114442E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3807594717686E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8283388541418E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535083201E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527238777852E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6842267100262E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8030200906191E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223750616E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129192779070E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9047613609598E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535507789E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527170569950E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6844106104927E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8030172870301E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223307241E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129077817363E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9050474379728E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5668,26 +5322,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.5251081485483E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0471809665163E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3078856650378E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1771891327644E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6716141411067E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1721785446923E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2359021092171E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.5776641768296E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3767193946951E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2290686133513E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0628148883715E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9413896956428E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.2757075629174E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7263840968792E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7097703864282E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8786874982673E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.5251081485486E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0471809665164E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3078855052426E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1771891326093E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6716140722444E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1721785446926E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2359021092170E+00
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.5776641326991E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3767193944272E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2290685716566E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0628146769571E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9413896956199E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.2757080493277E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7263840941939E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7097706553424E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8786874982633E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9838424676698E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.9738504187365E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2447986147843E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8876042920064E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.9738504317695E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2447985835216E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8876043530365E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4147215850298E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0031143515055E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -3.8456600374457E-02
@@ -5713,16 +5367,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144890175230E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7673323849956E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4922282378209E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4999975361784E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0424568042931E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8827380926819E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7578707666520E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4184444747367E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4458961751342E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2407463870764E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1057226599300E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8344423759804E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3558377622139E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4999703975272E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0424568039431E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8827381023832E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7578708428518E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4184447529034E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4458961751416E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2407463870693E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1057226612333E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8344423365575E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3558378952770E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591007543835E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3804014799200E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530551773623E-08
@@ -5756,89 +5410,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.25727227787834E-01  1.21024823775801E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.12095605606742E+00
+ cg2d: Sum(rhs),rhsMax =  -7.09994961515039E-01  1.21024805243363E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.12094202470980E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.53868614311491E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53865909510528E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922114018E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3316623765525E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935142867305E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841978360104E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6519309074333E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965258414E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186462793E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324350114749E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180610814900E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9935626717680E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065585536E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868604999181E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359395160098E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197141275438E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742558843972E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790933051E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377438103E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687605909763E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194083780383E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842552338513E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192833239803E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496807E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446997001E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202810287E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200224911737E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0687575469330E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0376365963462E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608413594E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580279015E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420243954251E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029728705329E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990509273151E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312198040801E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282905586674E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928384573962E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922344697E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3317105615058E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935053129880E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841986965498E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6521641340693E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965261981E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186373020E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324285199670E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180630021134E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9936030931227E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065427823E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868605457898E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359467606895E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197200284488E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742510579847E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790930273E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377422314E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687098653135E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194085320028E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842546004214E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192833239805E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496589E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446996956E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202810301E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200227392952E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0687575469328E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0376344508642E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608413644E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580065810E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420273369946E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029713529405E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990384871958E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312120821848E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282903095384E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928050524447E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411051380789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1341272036317E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1285156551045E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3911809185282E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188864294835E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175826908514E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963920033567E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5678062638578E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.5073169292408E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0413476444913E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1088228608943E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861560929657E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4493487243618E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411051354301E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1341267062540E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1289019485074E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3911619099576E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188906390193E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175673671134E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963837002172E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5677205122348E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.5073169292410E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0413476444914E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1110924995024E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861656025455E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4504084398888E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2241321533690E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5740224429825E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795817694510E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8524431160551E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2624033258554E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6204983356874E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574530054E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745249611678E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9566291748648E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5353844478305E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6689883435354E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3480662349092E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.4761451477609E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.9248612058544E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979803213E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426494585891E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787477591197E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2241321533689E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5752943936875E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795964912628E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8528022129223E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2603260790102E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6232114142679E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574523481E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745313056608E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9567531920802E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5353844471445E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6689883428373E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3480693019124E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.4761451359859E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.9248761722063E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979803212E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426902283831E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787378182646E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665826645E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523573464E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771062514E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855814449492E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4561237633845E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665826057E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523573614E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771317530E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855804998131E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4560787201519E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5849,29 +5503,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0162030449647E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156245083497E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414239181925E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0116262787748E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156474090155E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414988147209E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0123522391793E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937384986024E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3027980148176E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0126116078133E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937660249227E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3028034260571E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796555326697E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198133966187E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3603644551071E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8280086640459E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796509178322E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198103393734E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3605462223622E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8280086738760E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519271717812E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2508408765300E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6647904478391E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7989733914994E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4661668769817E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5084813236922E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8738869345359E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519272816230E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2508319087258E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6650457159477E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7989692171325E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4661666461874E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5084656469796E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8742789245470E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5880,26 +5534,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     5
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3889986822667E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -8.7557819176677E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.1862432696323E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1353663240816E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2226672391130E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9743039644200E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.0704230365841E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8986288453581E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3384926285934E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.7112577898950E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629912665502E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8757679947322E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920800232962E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173325043974E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755719959128E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481742E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.3889986822671E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -8.7557819176683E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.1862430769913E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1353663236876E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2226671108985E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9743039644202E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.0704230365837E+00
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8986287488629E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3384926281702E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.7112577104558E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629911165213E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8757679947262E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920784933695E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173324438712E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755724594342E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481603E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9814667799294E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7081092348804E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2285801832767E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8080121588070E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7081089583893E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2285801248389E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8080122728731E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3352358384690E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8681139737310E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -4.7963639067935E-02
@@ -5925,16 +5579,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144846334278E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7626414634741E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4919559013695E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4913982162377E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547220015E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503680829E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225056100E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141808261614E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730611241E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9685992420746E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234363423E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8121389632971E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2372241239996E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4913728615871E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547215048E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503406044E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225177073E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141812637459E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730615704E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9685992421002E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234086932E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8121389058231E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2372243544299E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591055042077E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3701011612169E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530269600171E-08
@@ -5968,89 +5622,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.67149194116921E-01  1.20371037418158E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05918852555755E+00
+ cg2d: Sum(rhs),rhsMax =  -8.47514999923231E-01  1.20371012272577E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.05916353577405E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.60072508365575E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.60066741915739E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340770794E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215245389635E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895540525853E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755464069879E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6366049362456E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617086129E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345820842E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625853228592E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924740980637E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9230798284578E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006582022732E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518303548E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896863511017E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520046423320E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360713078394E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399149890E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455576586E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9408342108840E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217515529758E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133359152241E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1191979292709E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760074571E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525739030E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283390117E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518536545512E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0685358737428E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405660035872E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608120200E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734648715E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196727353694E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916870565923E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8729104566519E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511908708570E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203147077970E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400673284758E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340967916E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215687039230E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895369969404E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755478905760E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6368996971500E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617102737E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345732867E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625788482181E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924764363880E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9231080159569E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006581839259E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518790172E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896931285535E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520102348447E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360650642403E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399143889E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455547390E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9403254156837E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217513032903E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133350245959E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1191979292714E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760081610E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525738998E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283390297E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518541885153E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0685358737423E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405646936017E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608120269E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734357513E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196785778937E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916849916870E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8729104564604E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511950391749E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203141979628E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400569965801E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413085044861E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874723225E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1085738055500E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298774100040E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907235853645E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9895136640680E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693309886104E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276613203042E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.3668407825272E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.5617187280947E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9867974041393E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1447211673908E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0405925194237E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9655206104464E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.0530327881975E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8716666354805E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437586370645E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3748342246777E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2691737854473E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5453096231008E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625252647E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693650424465E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2447228049124E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509960306E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620908274E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081419303624E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.7885949866965E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.5517870911248E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980055921E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4304647942671E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4448039200468E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413084684673E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874774084E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1090873583197E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298867054453E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907321209228E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9894905632987E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693207390711E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276514887392E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.3668407825276E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.5617187280954E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9887405378209E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1447336542214E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0414263109453E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9655206104466E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -1.0530327881972E+00
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8729430372224E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437764997699E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3752049664280E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2691774808340E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5436656664028E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625236054E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693777948123E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2448355769668E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509942985E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620890680E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081466264482E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.7885949793142E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.5518033878180E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980055918E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4304439158458E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4447941806886E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633824300E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524311651E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230134559809E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237956377044E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610909539304E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633823827E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524311875E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230134906140E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237947130760E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610316403007E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6061,29 +5715,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2522558646058E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656654150882E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854240864296E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2488424531216E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656786911895E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854766443303E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0122557653083E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297274498487E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462579198432E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0125597640277E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297612723340E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462709763031E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734154435268E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178833892956E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3494466794933E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276856009030E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734117130595E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178805290432E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3496816420411E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276856122615E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444994004204E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2490567516763E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6457510965208E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7949467529213E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444996032545E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2490458675699E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6460705529570E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7949413001252E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4539554450920E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5043619440291E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8433400465434E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4539551700481E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5043422392156E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8438436151790E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6093,25 +5747,25 @@
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.2831318509792E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434050E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484232687517E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962362739E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600943434523E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9175555650671E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3287879803731E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.2423852062689E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3329377393591E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021697636126E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0634977156346E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655893347E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995817474404E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148222622337E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587902202622E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299332E-07
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434041E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484230637554E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962356442E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600941630121E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9175555650666E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3287879803635E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.2423850667889E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3329377388074E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021696537410E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0634975995556E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655891687E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995784501608E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148221590269E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587908337883E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299650E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9789290821009E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503313793413E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214313569171E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7690887631082E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503308573474E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214312824284E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7690889521271E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2726117910117E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7761128863488E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.7470677761413E-02
@@ -6137,16 +5791,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144802493326E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7592795785517E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4918980283005E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4832029776208E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0245718408878E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807420229659E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666937227E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101675985115E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373856386E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068078009E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733205455862E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074412145728E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765850610992E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4831824342526E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0245718403156E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807419617627E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666619294E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101680166305E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373863849E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068079415E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733204933868E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074411504662E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765853711559E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591102540318E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3598008425138E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529987426719E-08
@@ -6180,89 +5834,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.00592126168528E+00  1.20159697200379E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.97628045090659E-01
+ cg2d: Sum(rhs),rhsMax =  -9.83002431147267E-01  1.20159665199112E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.97597126902218E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.53030410193537E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53034303475336E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300733814450E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662266620638E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9753033183358E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413283853105E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6275225560855E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721055326871E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160062019487E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954952222682E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301633146774E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176852513225E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495111700E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870559216603E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705517930143E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230402539505E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3723917490219E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739654352E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771719301E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6248891265395E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564236437748E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126907648888E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190811894460E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381279961E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188727E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377347880E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894022209439E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0683073388660E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434312287334E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852221E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882528418E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991780730770E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769029048720E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655893347E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764878728097E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173623635784E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2239132407035E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300734047343E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662597323006E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9752810237838E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413304018479E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6278742502570E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721055392092E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160061843723E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954887761421E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301663105198E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176985944110E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495073596E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870575179125E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705575286107E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230448699737E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3724017354905E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739641823E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771665044E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6293182625842E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564228292281E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126894826202E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190811894468E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381289438E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188646E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377348269E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894029664255E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0683073388653E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434313727062E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852301E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882168097E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991861831291E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769002832294E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655891687E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764514810051E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173630500760E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2240301730765E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415102702953E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289558115579E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0706993085015E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208620679923E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644235892681E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9600999846033E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460081381312E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3862963225048E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415098916106E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289598394334E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0712984695820E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208735066317E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644295896960E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9600850100587E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460086650198E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3866200376241E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2667053449446E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.5828157462759E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8432088276719E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1314706672807E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9391516651528E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9061087909401E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.2507416138126E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2083269409728E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383441624300E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2090833593552E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8495895526355E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9732348335331E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452894845E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068346566374E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1519612112710E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711395884E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566452303E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541839864644E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9025276943427E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9793150535787E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980305113E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460619113304E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6833524563250E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.5828157462729E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8450808203792E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1314858212837E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9397471434188E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9061087909396E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.2507416138033E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2099011517696E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383651857680E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2095279373009E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8495942766976E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9734310459025E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452857533E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068517361720E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1520671929148E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711356929E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566412773E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541900831427E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9025277074620E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9793313668490E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980305107E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460066538431E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6840660502870E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765232433E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525442698E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228659805479E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948343865178E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4860127691799E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765232138E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525443013E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228660242780E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948331659521E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4853627729974E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6273,29 +5927,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6355332306810E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999373611344E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4296973006639E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6330338086945E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999432742291E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4297300826758E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9473469885989E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499002481620E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889120524610E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9477440607314E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499408066125E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889150983067E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672903464495E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160107904851E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3277815099237E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8273693243316E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672876872282E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160082468921E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3280729277564E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8273693372674E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371765947830E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473574595291E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6274321159728E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7909324212949E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371768443710E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473448605137E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6278144014888E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7909264973408E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420582688949E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5005237685378E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8140982404647E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420583381633E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5005006107571E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8147004845396E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6304,26 +5958,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.2371508581871E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7514785530382E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006525040223E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419513071E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659096914485E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0591191646476E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3794009108900E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572470299302E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460670448E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776766990345E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661035683928E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8363753843976E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962898074719E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185812771610E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662560384681E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419658896E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.2371508581862E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7514785530307E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006523148866E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419503391E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659094532726E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0591191646453E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3794009108728E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572468395939E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460664143E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776765659420E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661034390048E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8363753842843E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962848136268E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185811379909E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662567788764E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419677060E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9762180582361E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026214151812E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211145010551E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820071087746E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026206631151E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211144161635E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820073442682E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2409841947187E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8299208716971E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -6.6977716454892E-02
@@ -6349,16 +6003,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144758652374E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7572490584599E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4920546435694E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755389567996E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605615491E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799445477293E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508391570997E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063436500512E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873470792E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426819772E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885244439681E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196464257788E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820919446648E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755216052075E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605609985E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799444522377E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508390882231E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063438358264E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873483378E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426824185E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885243687615E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196463591286E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820923017133E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591150038559E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3495005238107E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529705253267E-08
@@ -6392,89 +6046,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.14222628914908E+00  1.19970674306433E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.23836019184499E-01
+ cg2d: Sum(rhs),rhsMax =  -1.11614458967144E+00  1.19970634895043E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.23811666966917E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.67498971084999E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.67490673634086E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291640306E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378324699810E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491902133006E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422591379299E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6186656904722E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167168312E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569591478E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408375545647E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229635357589E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372993177299E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916417186E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0765530564230E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305443710827E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454320641302E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018536702812E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740321322E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304656183076E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7346401368402E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6038990239578E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914841171317E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1189299556257E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766176572E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546396E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470786168E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352056042197E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0680752819200E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461824978019E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539504E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185024024798E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803575471761E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582352021978E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8363753843976E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118485362385E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189933933331E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155847097593E-01
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291870697E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378524894603E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491548960970E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422615065919E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6190618702548E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167305874E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569317648E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408310427202E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229668304302E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372992258789E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916520616E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0789875221634E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305489082809E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454357706092E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018579375609E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740298838E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304656104019E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7349555111392E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6038978596299E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914825511226E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1189299556269E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766191100E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546419E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470786623E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352063632039E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0680752819192E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461844784191E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539580E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185023628992E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803678121009E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582322257417E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8363753842843E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118758796073E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189927298719E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155957471098E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096970674E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267317624053E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0624629292086E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2098939253085E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214854378729E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261933747734E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240128996939E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291104454444E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.2357676847980E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850300E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6895545780395E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452627523333E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0520798151831E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096221242E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267321190075E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0632348719266E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2099053788155E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214897098815E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261561516956E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240011542306E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291533510128E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.2357676847972E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850236E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6914239242181E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452798581669E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0529402058388E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3752841738518E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5092881337342E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659195024229E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3004233594916E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5589072851872E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9074644257842E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630561483E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682181454397E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446750010041E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660697957044E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952320592439E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356203667734E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.1301078878759E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1984176403006E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550620E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9194145392478E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.9202318573333E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3752841738352E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5113958372010E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659439213176E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3007734528303E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5589122411111E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9085714316850E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630551716E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682356914007E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446348628021E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660503030605E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952123816478E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356274783117E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.1301079212630E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1984329894228E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550612E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9193546673521E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.9211413796511E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004636514E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526751796E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228357974248E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548740250703E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9262594542158E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004636499E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526752205E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228358492415E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548583146237E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9257525543636E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6485,278 +6139,290 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3182974036271E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235154864519E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794509651385E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3164948759711E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235171475991E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794595262334E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8464857897120E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613023400092E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376046609483E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8469459400496E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613427005015E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376223505513E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614063047771E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142080356702E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3242546592015E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8270594631784E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614043038957E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142056067831E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3245988622980E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8270594777539E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299746649107E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457182878244E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6103397695953E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7869283205139E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305267547927E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4969035852915E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7873139263875E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299750531195E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457041800467E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6107784451032E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7869219854306E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305270621870E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4968773981309E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7879764279702E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %CHECKPOINT         8 ckptA
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) == cost_profiles: begin ==
-(PID.TID 0000.0001) == cost_profiles: end   ==
+(PID.TID 0000.0001) == profiles_cost: begin ==
+(PID.TID 0000.0001) == profiles_cost: end   ==
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001)  --> f_gencost = 0.118384850545114D+05 1
-(PID.TID 0000.0001)  --> f_gencost = 0.183174381851149D+05 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 1
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 2
-(PID.TID 0000.0001)  --> f_genarr3d = 0.000000000000000D+00 3
-(PID.TID 0000.0001)  --> fc               = 0.301559232396262D+05
-(PID.TID 0000.0001)   early fc =  0.000000000000000D+00
-(PID.TID 0000.0001)   local fc =  0.128986339262774D+04
-(PID.TID 0000.0001)  global fc =  0.301559232396262D+05
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // Start of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
+(PID.TID 0000.0001)  --> f_gencost  =  1.18384997232580E+04  1  1.00E+00 (thetaatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.83176156478632E+04  2  1.00E+00 (saltatlas)
+(PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
+(PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
+(PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
+(PID.TID 0000.0001)   early fc =   0.00000000000000E+00
+(PID.TID 0000.0001)   local fc =   1.28993456297018E+03
+(PID.TID 0000.0001) Writing global cost function info to costfunction.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
+(PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
+(PID.TID 0000.0001)  global fc =   3.01561153711212E+04
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of S/R COST_FINAL
+(PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   192.42465613037348
-(PID.TID 0000.0001)         System time:   54.003030091524124
-(PID.TID 0000.0001)     Wall clock time:   292.58331894874573
+(PID.TID 0000.0001)           User time:   92.477321542799473
+(PID.TID 0000.0001)         System time:   1.4957150346599519
+(PID.TID 0000.0001)     Wall clock time:   94.342611789703369
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   5.7922270186245441
-(PID.TID 0000.0001)         System time:   2.3971491008996964
-(PID.TID 0000.0001)     Wall clock time:   10.320887804031372
+(PID.TID 0000.0001)           User time:   2.3163510616868734
+(PID.TID 0000.0001)         System time:  0.30846100300550461
+(PID.TID 0000.0001)     Wall clock time:   2.6285309791564941
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   186.63236904144287
-(PID.TID 0000.0001)         System time:   51.605838060379028
-(PID.TID 0000.0001)     Wall clock time:   282.26234793663025
+(PID.TID 0000.0001)           User time:   90.160944461822510
+(PID.TID 0000.0001)         System time:   1.1872490346431732
+(PID.TID 0000.0001)     Wall clock time:   91.714046955108643
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   23.607336521148682
-(PID.TID 0000.0001)         System time:   42.998184442520142
-(PID.TID 0000.0001)     Wall clock time:   96.644491910934448
+(PID.TID 0000.0001)           User time:   6.0291235446929932
+(PID.TID 0000.0001)         System time:  0.40018495917320251
+(PID.TID 0000.0001)     Wall clock time:   6.4312090873718262
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   163.02499580383301
-(PID.TID 0000.0001)         System time:   8.6076278686523438
-(PID.TID 0000.0001)     Wall clock time:   185.61780595779419
+(PID.TID 0000.0001)           User time:   84.131797790527344
+(PID.TID 0000.0001)         System time:  0.78706204891204834
+(PID.TID 0000.0001)     Wall clock time:   85.282819986343384
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7545814514160156
-(PID.TID 0000.0001)         System time:   8.7852478027343750E-003
-(PID.TID 0000.0001)     Wall clock time:   2.0238733291625977
+(PID.TID 0000.0001)           User time:  0.83638477325439453
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:  0.83668375015258789
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5694580078125000E-003
-(PID.TID 0000.0001)         System time:   6.4086914062500000E-004
-(PID.TID 0000.0001)     Wall clock time:   6.2093734741210938E-003
+(PID.TID 0000.0001)           User time:   2.8667449951171875E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8598308563232422E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   156.75225448608398
-(PID.TID 0000.0001)         System time:   5.7635650634765625
-(PID.TID 0000.0001)     Wall clock time:   167.63089489936829
+(PID.TID 0000.0001)           User time:   81.120486259460449
+(PID.TID 0000.0001)         System time:  0.64325398206710815
+(PID.TID 0000.0001)     Wall clock time:   81.986068248748779
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   156.75212287902832
-(PID.TID 0000.0001)         System time:   5.7635498046875000
-(PID.TID 0000.0001)     Wall clock time:   167.63074684143066
+(PID.TID 0000.0001)           User time:   81.120407104492188
+(PID.TID 0000.0001)         System time:  0.64325398206710815
+(PID.TID 0000.0001)     Wall clock time:   81.986000061035156
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6170368194580078
-(PID.TID 0000.0001)         System time:   6.4086914062500000E-003
-(PID.TID 0000.0001)     Wall clock time:   2.6518123149871826
+(PID.TID 0000.0001)           User time:  0.99564361572265625
+(PID.TID 0000.0001)         System time:   8.4936618804931641E-005
+(PID.TID 0000.0001)     Wall clock time:  0.99605679512023926
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4427108764648438
-(PID.TID 0000.0001)         System time:   3.6468505859375000E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6289408206939697
+(PID.TID 0000.0001)           User time:  0.25488281250000000
+(PID.TID 0000.0001)         System time:   3.9190649986267090E-003
+(PID.TID 0000.0001)     Wall clock time:  0.26841950416564941
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6831016540527344
-(PID.TID 0000.0001)         System time:  0.21703720092773438
-(PID.TID 0000.0001)     Wall clock time:   3.4260177612304688
+(PID.TID 0000.0001)           User time:  0.44970989227294922
+(PID.TID 0000.0001)         System time:   4.0299892425537109E-003
+(PID.TID 0000.0001)     Wall clock time:  0.45460057258605957
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.6826496124267578
-(PID.TID 0000.0001)         System time:  0.21699905395507812
-(PID.TID 0000.0001)     Wall clock time:   3.4255392551422119
+(PID.TID 0000.0001)           User time:  0.44845962524414062
+(PID.TID 0000.0001)         System time:   4.0280222892761230E-003
+(PID.TID 0000.0001)     Wall clock time:  0.45336008071899414
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.2016296386718750E-004
-(PID.TID 0000.0001)         System time:   1.5258789062500000E-005
-(PID.TID 0000.0001)     Wall clock time:   1.5425682067871094E-004
+(PID.TID 0000.0001)           User time:   3.3378601074218750E-005
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   4.5061111450195312E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.19026947021484375
-(PID.TID 0000.0001)         System time:   7.3509216308593750E-003
-(PID.TID 0000.0001)     Wall clock time:  0.43819952011108398
+(PID.TID 0000.0001)           User time:   8.8994979858398438E-002
+(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
+(PID.TID 0000.0001)     Wall clock time:   8.9005470275878906E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.5878601074218750E-002
-(PID.TID 0000.0001)         System time:   1.7929077148437500E-004
-(PID.TID 0000.0001)     Wall clock time:   9.6321105957031250E-002
+(PID.TID 0000.0001)           User time:   2.8727531433105469E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8748989105224609E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   31.620868682861328
-(PID.TID 0000.0001)         System time:  0.26361846923828125
-(PID.TID 0000.0001)     Wall clock time:   32.772032737731934
+(PID.TID 0000.0001)           User time:   15.369031906127930
+(PID.TID 0000.0001)         System time:   8.1000328063964844E-003
+(PID.TID 0000.0001)     Wall clock time:   15.381288051605225
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   10.798828125000000
-(PID.TID 0000.0001)         System time:   8.0821990966796875E-002
-(PID.TID 0000.0001)     Wall clock time:   11.128607988357544
+(PID.TID 0000.0001)           User time:   5.4815969467163086
+(PID.TID 0000.0001)         System time:   2.7000904083251953E-005
+(PID.TID 0000.0001)     Wall clock time:   5.4831340312957764
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   10.074234008789062
-(PID.TID 0000.0001)         System time:   7.4882507324218750E-002
-(PID.TID 0000.0001)     Wall clock time:   10.360017061233521
+(PID.TID 0000.0001)           User time:   5.1677360534667969
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   5.1692459583282471
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   5.8744697570800781
-(PID.TID 0000.0001)         System time:  0.10881042480468750
-(PID.TID 0000.0001)     Wall clock time:   6.5330054759979248
+(PID.TID 0000.0001)           User time:   3.0366601943969727
+(PID.TID 0000.0001)         System time:   4.0610432624816895E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0418250560760498
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   28.310768127441406
-(PID.TID 0000.0001)         System time:   3.4511566162109375E-002
-(PID.TID 0000.0001)     Wall clock time:   28.841952800750732
+(PID.TID 0000.0001)           User time:   16.494777679443359
+(PID.TID 0000.0001)         System time:   3.8540363311767578E-003
+(PID.TID 0000.0001)     Wall clock time:   16.515392065048218
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.9145927429199219
-(PID.TID 0000.0001)         System time:   5.6457519531250000E-004
-(PID.TID 0000.0001)     Wall clock time:   1.9405910968780518
+(PID.TID 0000.0001)           User time:  0.30253410339355469
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:  0.30254912376403809
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7038078308105469
-(PID.TID 0000.0001)         System time:   8.6212158203125000E-004
-(PID.TID 0000.0001)     Wall clock time:   4.7834656238555908
+(PID.TID 0000.0001)           User time:   2.4047451019287109
+(PID.TID 0000.0001)         System time:   3.9519667625427246E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4092507362365723
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56344223022460938
-(PID.TID 0000.0001)         System time:   4.6539306640625000E-004
-(PID.TID 0000.0001)     Wall clock time:  0.57146644592285156
+(PID.TID 0000.0001)           User time:  0.31227493286132812
+(PID.TID 0000.0001)         System time:   5.1081180572509766E-005
+(PID.TID 0000.0001)     Wall clock time:  0.31234622001647949
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.2236709594726562
-(PID.TID 0000.0001)         System time:   2.1324157714843750E-003
-(PID.TID 0000.0001)     Wall clock time:   1.2347440719604492
+(PID.TID 0000.0001)           User time:  0.56554698944091797
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.56582474708557129
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10396575927734375
-(PID.TID 0000.0001)         System time:   5.7220458984375000E-005
-(PID.TID 0000.0001)     Wall clock time:  0.10407519340515137
+(PID.TID 0000.0001)           User time:   3.3960342407226562E-002
+(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
+(PID.TID 0000.0001)     Wall clock time:   3.3971071243286133E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3430900573730469
-(PID.TID 0000.0001)         System time:   3.8562774658203125E-002
-(PID.TID 0000.0001)     Wall clock time:   1.4067502021789551
+(PID.TID 0000.0001)           User time:  0.42747306823730469
+(PID.TID 0000.0001)         System time:   4.0189623832702637E-003
+(PID.TID 0000.0001)     Wall clock time:  0.43152904510498047
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   30.723491668701172
-(PID.TID 0000.0001)         System time:   5.6011199951171875E-002
-(PID.TID 0000.0001)     Wall clock time:   31.209543943405151
+(PID.TID 0000.0001)           User time:   16.687347412109375
+(PID.TID 0000.0001)         System time:   7.9140067100524902E-003
+(PID.TID 0000.0001)     Wall clock time:   16.708460330963135
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.3405761718750000E-005
-(PID.TID 0000.0001)         System time:   1.1444091796875000E-005
-(PID.TID 0000.0001)     Wall clock time:   9.5129013061523438E-005
+(PID.TID 0000.0001)           User time:   2.6702880859375000E-005
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   4.1007995605468750E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.5896339416503906
-(PID.TID 0000.0001)         System time:   3.3264160156250000E-003
-(PID.TID 0000.0001)     Wall clock time:   6.6583981513977051
+(PID.TID 0000.0001)           User time:   3.1139574050903320
+(PID.TID 0000.0001)         System time:   4.3988227844238281E-005
+(PID.TID 0000.0001)     Wall clock time:   3.1151030063629150
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.2479248046875000E-005
-(PID.TID 0000.0001)         System time:   1.1444091796875000E-005
-(PID.TID 0000.0001)     Wall clock time:   6.6518783569335938E-005
+(PID.TID 0000.0001)           User time:   4.7683715820312500E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.9100646972656250E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.0749588012695312
-(PID.TID 0000.0001)         System time:   2.6128349304199219
-(PID.TID 0000.0001)     Wall clock time:   10.321323871612549
+(PID.TID 0000.0001)           User time:   3.6467838287353516
+(PID.TID 0000.0001)         System time:  0.32749503850936890
+(PID.TID 0000.0001)     Wall clock time:   4.0713934898376465
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3383598327636719
-(PID.TID 0000.0001)         System time:   2.4740676879882812
-(PID.TID 0000.0001)     Wall clock time:   5.0881698131561279
+(PID.TID 0000.0001)           User time:   1.3832950592041016
+(PID.TID 0000.0001)         System time:  0.27969193458557129
+(PID.TID 0000.0001)     Wall clock time:   1.7364521026611328
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.63180541992187500
-(PID.TID 0000.0001)         System time:   1.1138381958007812
-(PID.TID 0000.0001)     Wall clock time:   1.7518250942230225
+(PID.TID 0000.0001)           User time:  0.38261413574218750
+(PID.TID 0000.0001)         System time:   3.5899996757507324E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42853999137878418
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   9.0026855468750000E-004
-(PID.TID 0000.0001)         System time:   2.5177001953125000E-004
-(PID.TID 0000.0001)     Wall clock time:   1.1570453643798828E-003
+(PID.TID 0000.0001)           User time:   3.4332275390625000E-004
+(PID.TID 0000.0001)         System time:   6.0796737670898438E-006
+(PID.TID 0000.0001)     Wall clock time:   3.5214424133300781E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "ECCO_COST_DRIVER   [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.8592987060546875
-(PID.TID 0000.0001)         System time:   1.7203445434570312
-(PID.TID 0000.0001)     Wall clock time:   14.183081150054932
+(PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   1.7855911254882812
+(PID.TID 0000.0001)         System time:  0.10784792900085449
+(PID.TID 0000.0001)     Wall clock time:   2.0247499942779541
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL    [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   2.9331970214843750
-(PID.TID 0000.0001)         System time:   1.3833274841308594
-(PID.TID 0000.0001)     Wall clock time:   10.368959903717041
+(PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:   1.3925018310546875
+(PID.TID 0000.0001)         System time:   8.7903976440429688E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6015319824218750
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER [ECCO SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:  0.92604064941406250
-(PID.TID 0000.0001)         System time:  0.33700180053710938
-(PID.TID 0000.0001)     Wall clock time:   3.8140730857849121
+(PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
+(PID.TID 0000.0001)           User time:  0.39306640625000000
+(PID.TID 0000.0001)         System time:   1.9942998886108398E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42320013046264648
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
-(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [ADJOINT SPIN-DOWN]":
-(PID.TID 0000.0001)           User time:   1.5777587890625000E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.5799999237060547E-002
+(PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
+(PID.TID 0000.0001)           User time:   9.3078613281250000E-004
+(PID.TID 0000.0001)         System time:   1.6093254089355469E-005
+(PID.TID 0000.0001)     Wall clock time:   9.4699859619140625E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================
@@ -6895,9 +6561,9 @@
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          40996
+(PID.TID 0000.0001) //            No. barriers =          41010
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          40996
+(PID.TID 0000.0001) //     Total barrier spins =          41010
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_ocean.gm_k3d/code/GMREDI_OPTIONS.h
+++ b/global_ocean.gm_k3d/code/GMREDI_OPTIONS.h
@@ -34,9 +34,6 @@ C Note: need these to be defined for use as control (pkg/ctrl) parameters
 
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
-C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi
-C (which depends on tapering scheme)
-#undef OLD_VISBECK_CALC
 
 C This allows to use the GEOMETRIC formulation to compute K_GM
 #define GM_GEOM_VARIABLE_K

--- a/global_ocean.gm_res/code/GMREDI_OPTIONS.h
+++ b/global_ocean.gm_res/code/GMREDI_OPTIONS.h
@@ -1,10 +1,19 @@
-C CPP options file for GM/Redi package
-C Use this file for selecting options within the GM/Redi package
-
 #ifndef GMREDI_OPTIONS_H
 #define GMREDI_OPTIONS_H
 #include "PACKAGES_CONFIG.h"
 #include "CPP_OPTIONS.h"
+
+CBOP
+C !ROUTINE: GMREDI_OPTIONS.h
+C !INTERFACE:
+C #include "GMREDI_OPTIONS.h"
+
+C !DESCRIPTION:
+C *==================================================================*
+C | CPP options file for GM/Redi package:
+C | Control which optional features to compile in this package code.
+C *==================================================================*
+CEOP
 
 #ifdef ALLOW_GMREDI
 C     Package-specific Options & Macros go here
@@ -18,11 +27,16 @@ C #define GM_EXCLUDE_AC02_TAP
 C #define GM_EXCLUDE_TAPERING
 C #define GM_EXCLUDE_SUBMESO
 
+C Allows to read-in background 3-D Redi and GM diffusivity coefficients
+C Note: need these to be defined for use as control (pkg/ctrl) parameters
+#undef GM_READ_K3D_REDI
+#undef GM_READ_K3D_GM
+
 C This allows to use Visbeck et al formulation to compute K_GM+Redi
 #undef GM_VISBECK_VARIABLE_K
-C Use old calculation (before 2007/05/24) of Visbeck etal K_GM+Redi
-C (which depends on tapering scheme)
-#undef OLD_VISBECK_CALC
+
+C This allows to use the GEOMETRIC formulation to compute K_GM
+#undef GM_GEOM_VARIABLE_K
 
 C This allows the Bates et al formulation to calculate the
 C bolus transport and K for Redi
@@ -47,9 +61,9 @@ C Allows to use the Boundary-Value-Problem method to evaluate GM Bolus transport
 C Allow QG Leith variable viscosity to be added to GMRedi coefficient
 #undef ALLOW_GM_LEITH_QG
 
+C Related to Adjoint-code:
+#undef GM_AUTODIFF_EXCESSIVE_STORE
+#undef GMREDI_MASK_SLOPES
+
 #endif /* ALLOW_GMREDI */
 #endif /* GMREDI_OPTIONS_H */
-
-CEH3 ;;; Local Variables: ***
-CEH3 ;;; mode:fortran ***
-CEH3 ;;; End: ***

--- a/offline_cheapaml/code/SEAICE_OPTIONS.h
+++ b/offline_cheapaml/code/SEAICE_OPTIONS.h
@@ -85,7 +85,7 @@ C     the thermodynamics component of the code. Note that, if needed,
 C     sea-ice dynamics can be turned off at runtime (SEAICEuseDYNAMICS=F).
 
 C--   Historically, the seaice model was discretized on a B-Grid. This
-C     discretization should still work but it is not longer actively
+C     discretization should still work but it is no longer actively
 C     tested and supported. Define this flag to compile it. It cannot be
 C     defined together with SEAICE_CGRID
 #undef SEAICE_BGRID_DYNAMICS
@@ -99,6 +99,14 @@ C--   Options for the C-grid version only:
 
 C     enable advection of sea ice momentum
 # undef SEAICE_ALLOW_MOM_ADVECTION
+
+C     Use parameterisation of grounding ice for a better representation
+C     of fastice in shallow seas
+# undef SEAICE_ALLOW_BOTTOMDRAG
+
+C     Use parameterisation of explicit lateral drag for a better
+C     representation of fastice along coast lines and islands
+# undef SEAICE_ALLOW_SIDEDRAG
 
 C     enable JFNK code by defining the following flag
 # define SEAICE_ALLOW_JFNK
@@ -179,9 +187,10 @@ C     This flag is also required for an actual adjoint of seaice_lsr;
 C     increases memory requirements a lot.
 # undef SEAICE_LSR_ADJOINT_ITER
 
-C     Use parameterisation of grounding ice for a better representation
-C     of fastice in shallow seas
-# undef SEAICE_ALLOW_BOTTOMDRAG
+C     Allow using the flexible LSR solver, where the number of non-linear
+C     iteration depends on the residual. Good for when a non-linear
+C     convergence criterion must be satified
+# undef SEAICE_ALLOW_LSR_FLEX
 
 #endif /* SEAICE_CGRID */
 

--- a/shelfice_remeshing/results/output_vrm.txt
+++ b/shelfice_remeshing/results/output_vrm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint67x
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Thu Apr 15 12:19:34 EDT 2021
+(PID.TID 0000.0001) // Build date:        Wed Apr  8 18:33:55 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -368,7 +368,6 @@
 (PID.TID 0000.0001) > /
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) STREAMICE_READPARMS: read first param block
-(PID.TID 0000.0001) STREAMICE_READPARMS: read third param block
 (PID.TID 0000.0001)  SHELFICE_READPARMS: opening data.shelfice
 (PID.TID 0000.0001)  OPEN_COPY_DATA_FILE: opening file data.shelfice
 (PID.TID 0000.0001) // =======================================================
@@ -474,7 +473,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -646,29 +649,29 @@
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: shelficemassinit.bin
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   219
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   228
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   209 SHIfwFlx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   210 SHIhtFlx
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   215 SHIgammT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   216 SHIgammS
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   218 SHI_mass
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   219 SHIRshel
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   194 SI_Uvel
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   195 SI_Vvel
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   196 SI_Thick
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   199 SI_hmask
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   198 SI_float
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   217 SHIuStar
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   217 SHIfwFlx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   218 SHIhtFlx
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   223 SHIgammT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   224 SHIgammS
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   225 SHI_mass
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   228 SHIRshel
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   202 SI_Uvel
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   203 SI_Vvel
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   204 SI_Thick
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   207 SI_hmask
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   206 SI_float
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #   226 SHIuStar
 (PID.TID 0000.0001)   space allocated for all diagnostics:      12 levels
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use      12 levels (numDiags =     904 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001)   space allocated for all stats-diags:       0 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use       0 levels (diagSt_size=     900 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) %MON fCori_max                    =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON fCori_min                    =   0.0000000000000E+00
@@ -710,6 +713,101 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) sRef =   /* Reference salinity profile ( g/kg ) */
 (PID.TID 0000.0001)    90 @  3.440000000000000E+01              /* K =  1: 90 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rhoRef =   /* Density vertical profile from (Ref,sRef)( kg/m^3 ) */
+(PID.TID 0000.0001)                 1.027719514974038E+03,      /* K =  1 */
+(PID.TID 0000.0001)                 1.027766853378996E+03,      /* K =  2 */
+(PID.TID 0000.0001)                 1.027814181245172E+03,      /* K =  3 */
+(PID.TID 0000.0001)                 1.027861498574038E+03,      /* K =  4 */
+(PID.TID 0000.0001)                 1.027908805367066E+03,      /* K =  5 */
+(PID.TID 0000.0001)                 1.027956101625729E+03,      /* K =  6 */
+(PID.TID 0000.0001)                 1.028003387351500E+03,      /* K =  7 */
+(PID.TID 0000.0001)                 1.028050662545853E+03,      /* K =  8 */
+(PID.TID 0000.0001)                 1.028097927210260E+03,      /* K =  9 */
+(PID.TID 0000.0001)                 1.028145181346197E+03,      /* K = 10 */
+(PID.TID 0000.0001)                 1.028192424955136E+03,      /* K = 11 */
+(PID.TID 0000.0001)                 1.028239658038552E+03,      /* K = 12 */
+(PID.TID 0000.0001)                 1.028286880597919E+03,      /* K = 13 */
+(PID.TID 0000.0001)                 1.028334092634713E+03,      /* K = 14 */
+(PID.TID 0000.0001)                 1.028381294150408E+03,      /* K = 15 */
+(PID.TID 0000.0001)                 1.028428485146480E+03,      /* K = 16 */
+(PID.TID 0000.0001)                 1.028475665624404E+03,      /* K = 17 */
+(PID.TID 0000.0001)                 1.028522835585657E+03,      /* K = 18 */
+(PID.TID 0000.0001)                 1.028569995031713E+03,      /* K = 19 */
+(PID.TID 0000.0001)                 1.028617143964050E+03,      /* K = 20 */
+(PID.TID 0000.0001)                 1.028664282384143E+03,      /* K = 21 */
+(PID.TID 0000.0001)                 1.028711410293470E+03,      /* K = 22 */
+(PID.TID 0000.0001)                 1.028758527693508E+03,      /* K = 23 */
+(PID.TID 0000.0001)                 1.028805634585734E+03,      /* K = 24 */
+(PID.TID 0000.0001)                 1.028852730971626E+03,      /* K = 25 */
+(PID.TID 0000.0001)                 1.028899816852661E+03,      /* K = 26 */
+(PID.TID 0000.0001)                 1.028946892230317E+03,      /* K = 27 */
+(PID.TID 0000.0001)                 1.028993957106074E+03,      /* K = 28 */
+(PID.TID 0000.0001)                 1.029041011481408E+03,      /* K = 29 */
+(PID.TID 0000.0001)                 1.029088055357800E+03,      /* K = 30 */
+(PID.TID 0000.0001)                 1.029135088736727E+03,      /* K = 31 */
+(PID.TID 0000.0001)                 1.029182111619670E+03,      /* K = 32 */
+(PID.TID 0000.0001)                 1.029229124008108E+03,      /* K = 33 */
+(PID.TID 0000.0001)                 1.029276125903521E+03,      /* K = 34 */
+(PID.TID 0000.0001)                 1.029323117307388E+03,      /* K = 35 */
+(PID.TID 0000.0001)                 1.029370098221190E+03,      /* K = 36 */
+(PID.TID 0000.0001)                 1.029417068646407E+03,      /* K = 37 */
+(PID.TID 0000.0001)                 1.029464028584521E+03,      /* K = 38 */
+(PID.TID 0000.0001)                 1.029510978037012E+03,      /* K = 39 */
+(PID.TID 0000.0001)                 1.029557917005361E+03,      /* K = 40 */
+(PID.TID 0000.0001)                 1.029604845491050E+03,      /* K = 41 */
+(PID.TID 0000.0001)                 1.029651763495561E+03,      /* K = 42 */
+(PID.TID 0000.0001)                 1.029698671020375E+03,      /* K = 43 */
+(PID.TID 0000.0001)                 1.029745568066975E+03,      /* K = 44 */
+(PID.TID 0000.0001)                 1.029792454636844E+03,      /* K = 45 */
+(PID.TID 0000.0001)                 1.029839330731463E+03,      /* K = 46 */
+(PID.TID 0000.0001)                 1.029886196352316E+03,      /* K = 47 */
+(PID.TID 0000.0001)                 1.029933051500886E+03,      /* K = 48 */
+(PID.TID 0000.0001)                 1.029979896178656E+03,      /* K = 49 */
+(PID.TID 0000.0001)                 1.030026730387111E+03,      /* K = 50 */
+(PID.TID 0000.0001)                 1.030073554127733E+03,      /* K = 51 */
+(PID.TID 0000.0001)                 1.030120367402008E+03,      /* K = 52 */
+(PID.TID 0000.0001)                 1.030167170211419E+03,      /* K = 53 */
+(PID.TID 0000.0001)                 1.030213962557451E+03,      /* K = 54 */
+(PID.TID 0000.0001)                 1.030260744441589E+03,      /* K = 55 */
+(PID.TID 0000.0001)                 1.030307515865318E+03,      /* K = 56 */
+(PID.TID 0000.0001)                 1.030354276830124E+03,      /* K = 57 */
+(PID.TID 0000.0001)                 1.030401027337491E+03,      /* K = 58 */
+(PID.TID 0000.0001)                 1.030447767388906E+03,      /* K = 59 */
+(PID.TID 0000.0001)                 1.030494496985854E+03,      /* K = 60 */
+(PID.TID 0000.0001)                 1.030541216129823E+03,      /* K = 61 */
+(PID.TID 0000.0001)                 1.030587924822298E+03,      /* K = 62 */
+(PID.TID 0000.0001)                 1.030634623064766E+03,      /* K = 63 */
+(PID.TID 0000.0001)                 1.030681310858714E+03,      /* K = 64 */
+(PID.TID 0000.0001)                 1.030727988205630E+03,      /* K = 65 */
+(PID.TID 0000.0001)                 1.030774655107001E+03,      /* K = 66 */
+(PID.TID 0000.0001)                 1.030821311564314E+03,      /* K = 67 */
+(PID.TID 0000.0001)                 1.030867957579058E+03,      /* K = 68 */
+(PID.TID 0000.0001)                 1.030914593152720E+03,      /* K = 69 */
+(PID.TID 0000.0001)                 1.030961218286790E+03,      /* K = 70 */
+(PID.TID 0000.0001)                 1.031007832982755E+03,      /* K = 71 */
+(PID.TID 0000.0001)                 1.031054437242104E+03,      /* K = 72 */
+(PID.TID 0000.0001)                 1.031101031066326E+03,      /* K = 73 */
+(PID.TID 0000.0001)                 1.031147614456912E+03,      /* K = 74 */
+(PID.TID 0000.0001)                 1.031194187415350E+03,      /* K = 75 */
+(PID.TID 0000.0001)                 1.031240749943130E+03,      /* K = 76 */
+(PID.TID 0000.0001)                 1.031287302041742E+03,      /* K = 77 */
+(PID.TID 0000.0001)                 1.031333843712677E+03,      /* K = 78 */
+(PID.TID 0000.0001)                 1.031380374957424E+03,      /* K = 79 */
+(PID.TID 0000.0001)                 1.031426895777475E+03,      /* K = 80 */
+(PID.TID 0000.0001)                 1.031473406174320E+03,      /* K = 81 */
+(PID.TID 0000.0001)                 1.031519906149451E+03,      /* K = 82 */
+(PID.TID 0000.0001)                 1.031566395704359E+03,      /* K = 83 */
+(PID.TID 0000.0001)                 1.031612874840535E+03,      /* K = 84 */
+(PID.TID 0000.0001)                 1.031659343559472E+03,      /* K = 85 */
+(PID.TID 0000.0001)                 1.031705801862661E+03,      /* K = 86 */
+(PID.TID 0000.0001)                 1.031752249751596E+03,      /* K = 87 */
+(PID.TID 0000.0001)                 1.031798687227767E+03,      /* K = 88 */
+(PID.TID 0000.0001)                 1.031845114292668E+03,      /* K = 89 */
+(PID.TID 0000.0001)                 1.031891530947793E+03       /* K = 90 */
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
+(PID.TID 0000.0001)    90 @  0.000000000000000E+00              /* K =  1: 90 */
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useStrainTensionVisc= /* Use StrainTension Form of Viscous Operator */
 (PID.TID 0000.0001)                   F
@@ -904,17 +1002,20 @@
 (PID.TID 0000.0001) freeSurfFac =   /* Implicit free surface factor */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1)*/
+(PID.TID 0000.0001) implicSurfPress =  /* Surface Pressure implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1)*/
+(PID.TID 0000.0001) implicDiv2DFlow =  /* Barot. Flow Div. implicit factor (0-1) */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag*/
+(PID.TID 0000.0001) uniformLin_PhiSurf = /* use uniform Bo_surf on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) uniformFreeSurfLev = /* free-surface level-index is uniform */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) sIceLoadFac =  /* scale factor for sIceLoad (0-1) */
+(PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) hFacMin =   /* minimum partial cell factor (hFac) */
 (PID.TID 0000.0001)                 2.000000000000000E-01
@@ -922,10 +1023,10 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag*/
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag*/
+(PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) nonlinFreeSurf = /* Non-linear Free Surf. options (-1,0,1,2,3)*/
@@ -1002,17 +1103,7 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       0
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -1020,6 +1111,16 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
@@ -1038,6 +1139,7 @@
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (used by Sadourny in JAS 75 paper)
 (PID.TID 0000.0001)    = 3 : energy (general) and enstrophy (2D, nonDiv.) conserving scheme
 (PID.TID 0000.0001)          from Sadourny (Burridge & Haseler, ECMWF Rep.4, 1977)
+(PID.TID 0000.0001)    = 4 : shift 1/hFac from Vorticity to gU,gV tend. (Ang.Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useJamartMomAdv= /* V.I Non-linear terms Jamart flag */
 (PID.TID 0000.0001)                   F
@@ -1092,6 +1194,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doThetaClimRelax = /* apply SST relaxation on/off flag */
 (PID.TID 0000.0001)                   F
@@ -1157,8 +1262,8 @@
 (PID.TID 0000.0001) cg2dMaxIters =   /* Upper limit on 2d con. grad iterations  */
 (PID.TID 0000.0001)                     300
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) cg2dChkResFreq =   /* 2d con. grad convergence test frequency */
-(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001) cg2dMinItersNSA =   /* Minimum number of iterations of 2d con. grad solver  */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) cg2dUseMinResSol= /* use cg2d last-iter(=0) / min-resid.(=1) solution */
 (PID.TID 0000.0001)                       0
@@ -1175,8 +1280,11 @@
 (PID.TID 0000.0001) useSRCGSolver =  /* use single reduction CG solver(s) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useNSACGSolver =  /* use not-self-adjoint CG solver */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -1586,15 +1694,6 @@
 (PID.TID 0000.0001) deepFacF = /* deep-model grid factor @ W-Interface (-) */
 (PID.TID 0000.0001)    91 @  1.000000000000000E+00              /* K =  1: 91 */
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) rVel2wUnit = /* convert units: rVel -> wSpeed (=1 if z-coord)*/
-(PID.TID 0000.0001)    91 @  1.000000000000000E+00              /* K =  1: 91 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) wUnit2rVel = /* convert units: wSpeed -> rVel (=1 if z-coord)*/
-(PID.TID 0000.0001)    91 @  1.000000000000000E+00              /* K =  1: 91 */
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) dBdrRef = /* Vertical grad. of reference buoyancy [(m/s/r)^2] */
-(PID.TID 0000.0001)    90 @  0.000000000000000E+00              /* K =  1: 90 */
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) rotateGrid = /* use rotated grid ( True/False ) */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -1865,6 +1964,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 1.896206941558748E+09
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 3.217922592105728E+06
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 5.940000000000000E+02
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 4.101600000000000E+04
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of Model config. summary
 (PID.TID 0000.0001) // =======================================================
@@ -1872,7 +1980,10 @@
 (PID.TID 0000.0001) == Packages configuration : Check & print summary ==
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) OBCS_CHECK: #define ALLOW_OBCS
-(PID.TID 0000.0001) OBCS_CHECK: start summary:
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // OBCS_CHECK: OBCS configuration summary
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) useOBCSprescribe = /* prescribe OB values */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -1894,6 +2005,9 @@
 (PID.TID 0000.0001) OBCS_balanceFacW = /* Western  OB Factor for balancing OB flow [-] */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCSfixTopo =  /* mod. topo to have zero gradient across boundaries. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) OBCS_uvApplyFac = /* Factor to apply to U,V 2nd column/row */
 (PID.TID 0000.0001)                 1.000000000000000E+00
 (PID.TID 0000.0001)     ;
@@ -1909,11 +2023,56 @@
 (PID.TID 0000.0001) OBCS_monSelect = /* select group of variables to monitor */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) OBCSprintDiags =  /* print some OBCS diagnostics. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useOBCStides = /* apply tidal forcing through OB */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) tidalPeriod = /* (s) */
-(PID.TID 0000.0001)    10 @  0.000000000000000E+00              /* I =  1: 10 */
+(PID.TID 0000.0001) useOrlanskiNorth =  /* use Orlanski for northern bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOrlanskiSouth =  /* use Orlanski for southern bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOrlanskiEast  =  /* use Orlanski for eastern bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOrlanskiWest  =  /* use Orlanski for western bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStevensNorth =  /* use Stevens for northern bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStevensSouth =  /* use Stevens for southern bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStevensEast  =  /* use Stevens for eastern bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStevensWest  =  /* use Stevens for western bound. */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStevensPhaseVel  =  /* include phase vel. term. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useStevensAdvection  =  /* include advection term. */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) TrelaxStevens = /* relaxation time scale for theta ( s ). */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SrelaxStevens = /* relaxation time scale for salinity ( s ). */
+(PID.TID 0000.0001)                 0.000000000000000E+00
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useOBCSSponge =  /* use sponge along boundaries */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSeaiceSponge =  /* use sponge for sea ice variables */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) useSeaiceNeumann =  /* use Neumann conditions for sea ice variables */
+(PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) OB_indexNone = /* null value for OB index (i.e. no OB) */
 (PID.TID 0000.0001)                     -99
@@ -1927,10 +2086,14 @@
 (PID.TID 0000.0001)   206 @      -99                            /* J = -2:203 */
 (PID.TID 0000.0001)  OB_Iw = /* Western OB local indices */
 (PID.TID 0000.0001)   206 @      -99                            /* J = -2:203 */
-(PID.TID 0000.0001) OBCS_CHECK: end summary.
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) // End of OBCS config. summary
+(PID.TID 0000.0001) // =======================================================
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) OBCS_CHECK: #define ALLOW_ORLANSKI
 (PID.TID 0000.0001) OBCS_CHECK: set-up OK
 (PID.TID 0000.0001) OBCS_CHECK: check Inside Mask and OB locations: OK
+(PID.TID 0000.0001) 
 (PID.TID 0000.0001) SHELFICE_CHECK: #define ALLOW_SHELFICE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) SHELFICE_CHECK: start of SHELFICE config. summary
@@ -1953,6 +2116,9 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SHELFICEMassStepping = /* step forward ice shelf mass/thickness */
+(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) SHI_update_kTopC = /* update "kTopC" as ice shelf expand or retreat */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) no_slip_shelfice = /* use no slip boundary conditions */
@@ -2039,20 +2205,11 @@
 (PID.TID 0000.0001) SHELFICE_dump_mdsio = /* use mdsio for snapshots */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SHELFICE_tave_mdsio = /* use mdsio for time averages */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SHELFICE_dump_mnc   = /* use netcdf for snapshots */
-(PID.TID 0000.0001)                   F
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SHELFICE_tave_mnc   = /* use netcdf for time averages */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SHELFICE_dumpFreq = /* analoguous to dumpFreq */
 (PID.TID 0000.0001)                 3.000000000000000E+03
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) SHELFICE_taveFreq = /* analoguous to taveFreq */
-(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) SHELFICE_CHECK: end of SHELFICE config. summary
 (PID.TID 0000.0001) STREAMICE_CHECK: #define STREAMICE
@@ -2114,19 +2271,19 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on no bd for no-slip (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -2.000000000000000E+02
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on no bd for no-slip (km) = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on so bd for no-slip (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -2.000000000000000E+02
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on so bd for no-slip (km) = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on east bd for no-slip (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.800000000000000E+02
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on east bd for no-slip (km) = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2150,31 +2307,31 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on east bd for no-stress (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on east bd for no-stress (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on west bd for no-stress (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on west bd for no-stress (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on no bd for FluxBdry (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on no bd for FluxBdry (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on so bd for FluxBdry (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on so bd for FluxBdry (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on east bd for FluxBdry (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.800000000000000E+02
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on east bd for FluxBdry (km) = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2186,40 +2343,40 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on no bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on no bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on so bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on so bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on east bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on east bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on west bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on west bd for Dirich (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on no bd for CFBC (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on no bd for CFBC (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on so bd for CFBC (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on so bd for CFBC (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.000000000000000E+00
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on east bd for CFBC (km) = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2228,7 +2385,7 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  min range on west bd for CFBC (km) = /* user defined parameter */
-(PID.TID 0000.0001)                -1.800000000000000E+02
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  max range on west bd for CFBC (km) = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2240,7 +2397,7 @@
 (PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  val (m^2/a) for east flux bdry = /* user defined parameter */
-(PID.TID 0000.0001)                 1.500000000000000E+06
+(PID.TID 0000.0001)                 0.000000000000000E+00
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  val (m^2/a) for west flux bdry = /* user defined parameter */
 (PID.TID 0000.0001)                 0.000000000000000E+00
@@ -2316,18 +2473,18 @@ listId=    1 ; file name: surfDiag
    12  |   12  |       300.000000         0.000000 |   1
  levels:   1
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-   209 |SHIfwFlx|      1 |      0 |   1 |       0 |
-   210 |SHIhtFlx|      2 |      0 |   1 |       0 |
-   215 |SHIgammT|      3 |      0 |   1 |       0 |
-   216 |SHIgammS|      4 |      0 |   1 |       0 |
-   218 |SHI_mass|      5 |      0 |   1 |       0 |
-   219 |SHIRshel|      6 |      0 |   1 |       0 |
-   194 |SI_Uvel |      7 |      0 |   1 |       0 |
-   195 |SI_Vvel |      8 |      0 |   1 |       0 |
-   196 |SI_Thick|      9 |      0 |   1 |       0 |
-   199 |SI_hmask|     10 |      0 |   1 |       0 |
-   198 |SI_float|     11 |      0 |   1 |       0 |
-   217 |SHIuStar|     12 |      0 |   1 |       0 |
+   217 |SHIfwFlx|      1 |      0 |   1 |       0 |
+   218 |SHIhtFlx|      2 |      0 |   1 |       0 |
+   223 |SHIgammT|      3 |      0 |   1 |       0 |
+   224 |SHIgammS|      4 |      0 |   1 |       0 |
+   225 |SHI_mass|      5 |      0 |   1 |       0 |
+   228 |SHIRshel|      6 |      0 |   1 |       0 |
+   202 |SI_Uvel |      7 |      0 |   1 |       0 |
+   203 |SI_Vvel |      8 |      0 |   1 |       0 |
+   204 |SI_Thick|      9 |      0 |   1 |       0 |
+   207 |SI_hmask|     10 |      0 |   1 |       0 |
+   206 |SI_float|     11 |      0 |   1 |       0 |
+   226 |SHIuStar|     12 |      0 |   1 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     0
 ------------------------------------------------------------------------
@@ -2507,18 +2664,18 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011396 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
@@ -2539,9 +2696,9 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293493000521E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2792794259427E-12
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.2915768242204E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9643500789049E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.2930056107756E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2666398646199E-14
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9643541937629E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.2930056093303E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2666398646495E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9868987972862E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1045569078569E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.9515628115462E-07
@@ -2584,67 +2741,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011397 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
  cg2d: Sum(rhs),rhsMax =   1.18792338242571E-01  5.71292358056374E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78576695426766E-05
+(PID.TID 0000.0001)      cg2d_init_res =   6.78576695426763E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.46505873835744E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.46505873835073E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11398
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4194000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5005395338716E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4554929537072E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5005395338713E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4554929537073E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2863815094359E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4093111935650E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293491001435E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9130569491781E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.9267340820035E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8613328988883E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.3926475395160E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2908901790143E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4093111935649E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293491001433E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9130371924266E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.9266858109207E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8648089247374E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.3926410908058E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2908869674441E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9869239386643E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1045327787887E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.0053500796641E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.0053500795175E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1888702482634E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5358773222219E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2388040479803E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2388040479805E-02
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7749791231890E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0022241253140E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8033728325815E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9286023870599E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0022241253141E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8033728325817E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9286023870607E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439539593676E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515503963836E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2453148003593E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764616322065E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7681541745665E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7681541745668E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692814610175E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812094788390E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431623903180E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349508973597E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5925962496350E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.4805797729437E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8627103085097E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7164121439409E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7164121439409E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.4806093164674E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8627103085096E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7164121439415E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7164121439415E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.7184011974070E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9725385921631E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9725385921630E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3461846973443E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174237260812E+12
 (PID.TID 0000.0001) // =======================================================
@@ -2661,67 +2818,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011398 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.18784869429308E-01  5.71291098680163E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78570211455333E-05
+ cg2d: Sum(rhs),rhsMax =   1.18784869429310E-01  5.71291098680156E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78570216148887E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.46524609003199E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.46523907277764E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11399
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4197000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5007204558931E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4553483656347E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5007204558924E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4553483656297E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2862977953953E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4092614380951E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293489014812E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5032477734803E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5191597775960E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9510695964457E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.3320369503028E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2761735237959E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9869501722072E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1045086099982E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.9910223667986E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4092614380947E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293489014804E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5055272706813E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5175580461184E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9868113084311E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.3319828479356E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2761330161328E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9869501722073E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1045086099983E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.9910223611943E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1890804772660E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5358965711772E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2387752967608E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7762237276484E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0022224422183E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8035828654879E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9288446667989E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5358965711768E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2387752967603E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7762237276456E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0022224422168E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8035828654856E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9288446667960E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439546811184E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515429050015E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2464726300210E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764585994724E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7684665441528E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7684665441530E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692814702708E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812087951368E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431624607466E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349575387915E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5926083542006E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.1560178903057E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8628009175167E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7163258902824E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7163258902824E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.7182305593239E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9725971109798E-02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5926083542008E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.1547510773366E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8628009175172E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7163258902809E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7163258902809E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.7182305593238E-01
+(PID.TID 0000.0001) %MON ke_max                       =   1.9725971109799E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3462938115387E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174238848304E+12
 (PID.TID 0000.0001) // =======================================================
@@ -2738,67 +2895,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011399 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.18777400967778E-01  5.71289839804992E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78561674602470E-05
+ cg2d: Sum(rhs),rhsMax =   1.18777400967771E-01  5.71289839805033E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78561668429988E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.46532221187733E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.46533005189761E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11400
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4200000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5009014569708E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4552038485320E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.5009014569631E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4552038485375E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2862140866481E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4092116738048E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293487040972E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7997174405682E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8127939274993E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0232372497583E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.3749293564709E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2865962635393E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9869775354136E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4092116738050E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8293487040976E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8012591839019E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8102055479912E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0701200599458E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.3749343358167E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2865879292669E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9869775354138E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1044843844685E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.9288923307025E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.9288923367249E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1892901862941E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5359161183047E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2387469535815E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7774695284440E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0022202362362E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8037944244800E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9290899616646E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7774695284455E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0022202362368E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8037944244819E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9290899616687E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439554029174E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515354022138E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2476297638350E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2476297638349E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764555686921E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7687803448530E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7687803448531E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692814795246E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812081195867E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431625311491E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349641721303E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5926209206609E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3856654840548E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8628954283105E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7162408607446E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7162408607446E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5926209206607E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3836193123483E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8628954283112E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7162408607445E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7162408607445E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.7180599166810E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9726577261799E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9726577261805E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3464026602543E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174240435695E+12
 (PID.TID 0000.0001) // =======================================================
@@ -2815,18 +2972,18 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) SHI_REMESH at it=     11400
 (PID.TID 0000.0001) --> REMESH in:    1   68   1   1 , x,y=  -1.054E+02  -7.492E+01
 (PID.TID 0000.0001)  before:  ks=  40 Ro_s=  -3.900E+02 eta=   2.501E+00 hFac=   1.250E+00
@@ -2841,52 +2998,52 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011400 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23358635624637E-01  5.71288581361239E+01
-(PID.TID 0000.0001)      cg2d_init_res =   7.87987307899592E-05
+ cg2d: Sum(rhs),rhsMax =   1.23358635624632E-01  5.71288581361234E+01
+(PID.TID 0000.0001)      cg2d_init_res =   7.87987303142872E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.46788903902244E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.46790572287162E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11401
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4203000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4707439423285E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4988216337029E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4707439423291E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4988216337138E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3358203163809E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4335393102799E+00
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4335393102798E+00
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281088783600E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5748420692021E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5671518336697E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9949094297095E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4955340905053E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3159063349460E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9870054862688E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1044602774519E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.0818362815069E-07
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5726860735199E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.5640322367081E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0392137626173E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4958857824388E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3159588629977E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9870054862682E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1044602774518E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.0818362834888E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1894791742894E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5279738162109E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2387184445446E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7787164056348E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020047652253E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8037112261892E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9289616252145E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2387184445431E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7787164056362E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020047652268E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8037112261895E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9289616252148E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439561247529E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515278879263E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2487862138970E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2487862138969E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764525257813E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7999690490837E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7999690490841E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692814887789E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812074519917E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431626015306E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349706354534E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6113968064714E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.1975592351743E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8629919688062E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7161553336337E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7161553336337E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.1958548725217E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8629919688043E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7161553336293E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7161553336293E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8129423069652E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9727193284465E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9727193284467E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3465007575748E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174242022986E+12
 (PID.TID 0000.0001) // =======================================================
@@ -2903,67 +3060,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011401 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23351178087110E-01  5.71287323004486E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79476187870032E-05
+ cg2d: Sum(rhs),rhsMax =   1.23351178087127E-01  5.71287323004432E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79476174770582E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.54184410605902E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.54183515784915E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11402
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4206000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4709283510692E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4986358578118E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4709283510695E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4986358578258E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3357366183564E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4334880789221E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281084617163E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7076206637044E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7114994161841E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0457677026896E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5324489224321E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3249097853395E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9870381388329E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4334880789225E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281084617173E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7064265894972E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7134939268572E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0658887030815E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.5323569077839E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3248515456553E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9870381388334E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1044349939054E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.0446067302275E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.0446067131387E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1897102432644E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5269207837210E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386942422685E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7799640431294E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020446300294E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8039227161317E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9291764659491E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5269207837216E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386942422681E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7799640431234E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020446300281E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8039227161320E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9291764659429E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439568466142E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515203620922E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2499419979259E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2499419979260E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764494876978E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7935189947903E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7935189947895E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692814980335E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812067941233E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431626718889E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349771279505E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6072785968812E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3059542914196E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8631047487090E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7160827268054E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7160827268054E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6072785968810E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3071666197539E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8631047487105E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7160827268044E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7160827268044E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8127707333769E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9727902629492E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9727902629494E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3466207026218E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174243610177E+12
 (PID.TID 0000.0001) // =======================================================
@@ -2980,67 +3137,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011402 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23343719309751E-01  5.71286066683827E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78207744270266E-05
+ cg2d: Sum(rhs),rhsMax =   1.23343719309742E-01  5.71286066683878E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78207747298992E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.48984647095847E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.48985763500860E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11403
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4209000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4711124176803E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4984598521952E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4711124176872E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4984598521983E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3356529120222E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4334371822967E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281081122538E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9113200621810E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.9216730998164E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.8692224885828E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4173890268191E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2967988115900E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4334371822966E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281081122537E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.9085338095090E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.9215635198147E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9118206890643E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4176200861611E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2968368004037E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9870705747072E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1044093908752E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.5258497498956E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1044093908750E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.5258497178826E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1899371806940E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5248664241856E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386700425027E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7812120774519E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020757400696E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8041591204931E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9295014014256E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5248664241853E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386700424996E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7812120774504E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020757400665E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8041591204893E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9295014014173E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439575684925E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515128247230E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2510968893497E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2510968893496E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764464564345E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7885820897482E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7885820897468E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815072884E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812061440826E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431627421440E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349836662373E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6040780510987E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.4743665673219E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8632167801785E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7160101275082E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7160101275082E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6040780510985E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.4742799002562E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8632167801786E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7160101274987E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7160101274987E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8125994115658E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9728605145269E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9728605145263E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3467385081949E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174245197265E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3057,67 +3214,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011403 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23336260144183E-01  5.71284810370348E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78418709420691E-05
+ cg2d: Sum(rhs),rhsMax =   1.23336260144183E-01  5.71284810370346E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78418696741338E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51327403097573E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51324653965726E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11404
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4212000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4712967225924E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4982833263101E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4712967225852E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4982833263106E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3355692018562E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4333863454083E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281077653240E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7117120952803E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7186118596968E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0364365693169E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4288640341378E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2995738472949E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4333863454086E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281077653245E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7160002681924E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7212122577348E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9614637917945E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4286118742760E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.2995320272958E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9871029031489E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043842487854E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.8568279445833E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043842487853E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.8568279351759E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1901683200549E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5244147156218E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386441405286E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7824607164020E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020893703131E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8043788094522E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9297554347796E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386441405266E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7824607163878E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020893703135E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8043788094526E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9297554347803E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439582903806E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8515052758098E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2522509627509E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2522509627508E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764434305363E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7848496176023E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7848496176012E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815165433E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812055015477E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431628123287E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349902345136E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6016108892708E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3157183045636E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8633284405829E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7159324215857E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7159324215857E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.6016108892706E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3173480137552E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8633284405827E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7159324215797E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7159324215797E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8124281940316E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9729302979374E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9729302979379E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3468585003173E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174246784510E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3134,67 +3291,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011404 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23328800503581E-01  5.71283553499792E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78600454098732E-05
+ cg2d: Sum(rhs),rhsMax =   1.23328800503586E-01  5.71283553499777E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78600466465753E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.52055739694975E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.52056391362936E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11405
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4215000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4714814134925E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4981071882924E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4714814134863E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4981071882930E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3354854855992E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4333355068239E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281074128447E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7500686717287E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7765520606545E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0158815919298E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4526734256170E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3054031185732E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9871355371428E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043596614980E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.8196411090887E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1904003748954E-02
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4333355068240E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281074128448E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7504909577649E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7632348063302E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9148063113792E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4533190342992E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3054742086173E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9871355371425E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043596614979E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.8196411257150E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1904003748953E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5244159430988E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386169984427E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7837106889240E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020843881673E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8045970385454E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9300169101686E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2386169984462E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7837106889292E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020843881693E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8045970385458E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9300169101691E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439590122695E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514977152422E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2534041957730E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2534041957728E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764404099231E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7820256755765E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7820256755755E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815257983E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812048667482E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431628824344E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8349968308975E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5996970059087E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3595900164004E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8634411563449E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7158509953281E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7158509953281E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5996970059085E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3490573704938E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8634411563439E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7158509953386E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7158509953386E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8122569216840E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9730005380674E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9730005380667E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3469789730477E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174248371828E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3211,67 +3368,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011405 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23321340313415E-01  5.71282296354219E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78784112222550E-05
+ cg2d: Sum(rhs),rhsMax =   1.23321340313418E-01  5.71282296354202E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78784122845057E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.52219657446480E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.52221217878602E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11406
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4218000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4716664625976E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4979305040972E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4716664626036E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4979305041066E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3354017631038E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4332845748784E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281070535553E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7258527672685E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7495319640938E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2169363626812E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4520734897670E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3052217684331E-14
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281070535552E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7340330602718E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7491418645906E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1060504477234E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4519877379338E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3052010878432E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9871687288109E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043354792579E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.4605958335137E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043354792575E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.4605958681194E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1906330396699E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5245748131690E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385893091866E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7849625657564E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020673872464E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8048109585352E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9302580751073E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5245748131688E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385893091873E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7849625657460E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020673872475E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8048109585338E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9302580751050E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439597341464E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514901428198E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2545565912503E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2545565912506E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764373942984E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7798940909670E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7798940909664E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815350532E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812042398380E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431629524612E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350034519459E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5982046967079E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3375082054141E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8635557982789E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7157679275597E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7157679275597E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5982046967078E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3390984193601E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8635557982791E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7157679275620E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7157679275620E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8120854909132E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9730717236575E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9730717236578E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3470997678166E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174249959261E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3288,67 +3445,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011406 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23313879473930E-01  5.71281039218944E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.78965580300772E-05
+ cg2d: Sum(rhs),rhsMax =   1.23313879473922E-01  5.71281039218971E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.78965566067884E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.52149243277677E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.52149248180220E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11407
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4221000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4718518380330E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4977530588116E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4718518380322E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4977530587930E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3353180339567E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4332335010326E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281066852749E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7516743488376E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7830953320191E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1820229102330E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4583252300308E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3067420394344E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9872026421323E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043115361142E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.8690874198527E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4332335010324E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281066852745E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7600250984494E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7765773740987E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0862104224513E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4582702718493E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3067683783778E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9872026421321E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1043115361141E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.8690874576591E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1908657982047E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5247950159477E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385615781358E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7862163340570E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020430499781E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8050250372645E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9304983560482E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5247950159480E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385615781368E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7862163340580E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020430499801E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8050250372661E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9304983560549E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439604559957E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514825583309E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2557081448086E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2557081448087E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764343834906E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7782895894170E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7782895894175E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815443076E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812036208622E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431630224063E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350100955911E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5970331191474E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3647651041982E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8636729327578E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7156847344073E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7156847344073E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8119138389633E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9731441742432E-02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5970331191476E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3596100368594E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8636729327571E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7156847344103E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7156847344103E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8119138389634E-01
+(PID.TID 0000.0001) %MON ke_max                       =   1.9731441742429E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3472206166690E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174251546813E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3365,67 +3522,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011407 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23306417943783E-01  5.71279782235834E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79114798596640E-05
+ cg2d: Sum(rhs),rhsMax =   1.23306417943781E-01  5.71279782235840E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79114794788051E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51963578986892E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51962039758857E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11408
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4224000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4720375221384E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4975746680083E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4720375221297E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4975746679968E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3352342980420E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4331822647025E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281063091198E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7541088258144E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7637707812899E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2189220650614E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4536385703323E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3056114351419E-14
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4331822647023E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281063091193E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7477884965585E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7618992685544E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0917992259890E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4539129120691E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3056489587882E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9872374762851E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042876621625E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.1860489752635E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042876621626E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   6.1860489990782E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1910983994291E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5250044674315E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385342526752E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7874715602723E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020159673974E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8052403282218E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9307376403018E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385342526761E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7874715602702E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0020159673978E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8052403282228E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9307376403054E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439611778015E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514749616182E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2568588541774E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2568588541778E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764313773404E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7770878600580E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7770878600594E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815535616E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812030098049E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431630922678E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350167600438E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5961063500197E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3469115940547E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8637932477305E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7156027580255E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7156027580255E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5961063500202E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3454321215138E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8637932477306E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7156027580283E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7156027580283E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8117419425035E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9732182795937E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9732182795941E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3473413892570E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174253134491E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3442,67 +3599,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011408 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23298955709506E-01  5.71278525455602E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79239778429335E-05
+ cg2d: Sum(rhs),rhsMax =   1.23298955709507E-01  5.71278525455610E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79239779514470E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51781967981951E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51781551232940E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11409
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4227000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4722234947620E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4973953237988E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4722234947589E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4973953238169E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3351505553323E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4331308766213E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281059261086E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7451015321169E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7930899796507E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0458627512506E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4541754509657E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3057959361875E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9872734326730E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042636931332E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.5452823156257E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4331308766214E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281059261090E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7517153352618E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7882658741839E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.9784648828143E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4545173610944E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3058068693791E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9872734326729E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042636931334E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.5452823001812E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1913306643413E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5251906404063E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385077115235E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7887277786763E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019905788909E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8054586765660E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9309810292042E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5251906404066E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2385077115240E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7887277786764E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019905788899E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8054586765670E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9309810292077E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439618995500E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514673525932E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2580087182638E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2580087182637E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764283757147E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7761961669830E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7761961669846E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815628147E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812024065957E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431631620446E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350234438525E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5953677781066E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3726698931210E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8639174388327E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7155231345706E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7155231345706E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5953677781069E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3688544974351E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8639174388326E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7155231345719E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7155231345719E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8115698163182E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9732944337594E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9732944337593E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3474619926299E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174254722297E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3519,67 +3676,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011409 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23291492783086E-01  5.71277268855133E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79336188206655E-05
+ cg2d: Sum(rhs),rhsMax =   1.23291492783085E-01  5.71277268855133E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79336203814512E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51632722852076E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51633031972905E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11410
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4230000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4724097147338E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4972151104891E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4724097147315E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4972151104983E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3350668059033E+00
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4330793703421E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281055379272E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7567098246969E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7637894887426E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1325307853926E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4513043785682E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3050721221028E-14
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281055379274E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7490975591835E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7596057993160E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0357920405996E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4515950243809E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3051236265917E-14
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9873106758256E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042395023819E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.0473046735401E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.0473046552373E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1915624774146E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5253474061739E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384821914332E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7899847136064E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5253474061743E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384821914330E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7899847136089E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019705879349E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8056810169920E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9312295851937E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8056810169909E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9312295851871E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439626212297E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514597312152E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2591577380702E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2591577380699E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764253784897E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7755449563462E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7755449563468E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815720671E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812018111253E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431632317360E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350301456707E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5947749625758E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3519174563057E-13
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5947749625759E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3474851072589E-13
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8640460743393E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7154465742997E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7154465742997E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7154465742989E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7154465742989E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8113975069827E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9733729566590E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9733729566587E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3475823667771E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174256310232E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3596,67 +3753,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011410 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23284029188745E-01  5.71276012379403E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79407379372710E-05
+ cg2d: Sum(rhs),rhsMax =   1.23284029188748E-01  5.71276012379388E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79407384987544E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51551767119866E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51550213932029E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11411
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4233000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4725961071884E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4970341524681E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4725961071863E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4970341524572E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3349830498888E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4330277912336E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281051461656E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7456751035138E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7748310870102E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1002532431484E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4506249114084E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3049152638533E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9873493024787E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042150235644E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.7460697983121E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4330277912337E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281051461659E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7591971750053E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7668089595358E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0710997165156E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4507772912753E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3049058593295E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9873493024781E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1042150235648E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.7460697746850E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1917937576746E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5254780869097E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384577492755E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7912423005480E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019582534921E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8059077575161E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9314838046334E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5254780869100E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384577492775E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7912423005500E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019582534906E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8059077575150E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9314838046341E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439633428315E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514520974631E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2603059158862E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764223855510E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7750819695765E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7750819695771E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815813184E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812012232715E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431633013428E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350368642046E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350368642045E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5942960842551E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3582288945379E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8641794883697E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7153732478266E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7153732478266E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3518841761712E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8641794883676E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7153732478324E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7153732478324E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8112250804917E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9734540350356E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9734540350346E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3477024696175E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174257898295E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3673,67 +3830,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011411 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23276564954465E-01  5.71274755974149E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79455110609040E-05
+ cg2d: Sum(rhs),rhsMax =   1.23276564954467E-01  5.71274755974130E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79455121673941E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51535772453905E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51536848660671E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11412
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4236000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4727825663386E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4968525696057E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4727825663380E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4968525696192E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3348992874648E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4329761854902E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281047523634E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7638327008075E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7604185081882E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2058039772724E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4518849110691E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3051982154968E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9873893313099E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041902510874E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.6513393327612E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4329761854903E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281047523636E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7587551027817E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7491186602808E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1705522456694E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4518060828564E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3051830168215E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9873893313101E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041902510877E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.6513392996895E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1920244479010E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5255868368938E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384342840226E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7925006022016E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019541775605E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8061386311663E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9317428446419E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5255868368941E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384342840231E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7925006022006E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019541775585E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8061386311662E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9317428446431E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439640643468E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514444513138E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2614532545124E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764193967935E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7747675398495E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7747675398503E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815905686E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812006429193E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431633708660E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350435981993E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5939070795655E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3443934059699E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8643177454346E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7153028520679E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7153028520679E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8110526080777E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9735377026301E-02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5939070795656E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3416326950216E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8643177454354E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7153028520692E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7153028520692E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8110526080776E-01
+(PID.TID 0000.0001) %MON ke_max                       =   1.9735377026303E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3478222713966E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174259486482E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3750,67 +3907,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011412 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23269100103862E-01  5.71273499617798E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79482415657103E-05
+ cg2d: Sum(rhs),rhsMax =   1.23269100103869E-01  5.71273499617780E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79482418307595E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51578297563932E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51577445354246E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11413
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4239000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4729689743651E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4966704565485E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4729689743657E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4966704565324E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3348155188368E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4329245922968E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281043578543E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7482828305670E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7557121393939E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0868069337689E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4522935663710E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3053138802778E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9874307093690E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041652250660E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.7380058890631E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4329245922966E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281043578535E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7565857656433E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7454855110853E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1219455027460E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4523041799036E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3052867794023E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9874307093686E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041652250663E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.7380058657785E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1922545064163E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5256782321222E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384115910300E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7937597314450E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019575076019E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8063729347633E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9320054284030E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5256782321220E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2384115910315E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7937597314410E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019575076022E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8063729347623E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9320054283988E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439647857668E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514367927325E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2625997565799E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2625997565800E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764164121235E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7745712756862E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7745712756868E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692815998175E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3812000699669E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431634403072E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350503464652E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5935896147335E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3431076765717E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8644606626482E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7152347730900E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7152347730900E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8108801537485E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9736238522631E-02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5935896147336E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3419265935432E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8644606626470E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7152347730946E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7152347730946E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8108801537484E-01
+(PID.TID 0000.0001) %MON ke_max                       =   1.9736238522625E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3479417504265E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174261074791E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3827,67 +3984,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011413 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23261634657062E-01  5.71272243315697E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79492174348470E-05
+ cg2d: Sum(rhs),rhsMax =   1.23261634657065E-01  5.71272243315686E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79492158161172E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51670025887402E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51670865022204E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11414
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4242000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4731552273923E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4964878807131E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4731552273952E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4964878806880E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3347317442352E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4328730395648E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281039637644E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7459187424075E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7595119677333E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.0849903536939E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4545911520285E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3058760262794E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9874733300486E-01
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4328730395643E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281039637631E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7532078464833E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7538688699447E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1861973283728E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4546415800183E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3058657442147E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9874733300481E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041400123646E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.9580742451092E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   4.9580742286870E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1924839025369E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5257561232579E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2383894212768E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7950197976153E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019663682174E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8066097172704E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9322701039803E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5257561232575E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2383894212776E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7950197976164E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019663682175E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8066097172730E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9322701039936E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439655070825E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514291216695E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2637454242925E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764134314566E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7744696250033E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7744696250061E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692816090652E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3811995043193E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431635096676E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350571078933E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5933295794106E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3435449069923E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8646078717947E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7151682638303E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7151682638303E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5933295794113E-05
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3411270257685E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8646078717929E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7151682638328E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7151682638328E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8107077655162E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9737122703035E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9737122703038E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3480608907252E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174262663218E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3904,67 +4061,67 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) streamice solo_time_step: nIter0000011414 0.11E+00seconds
  time_step_loc    9.5129375951293768E-006
 (PID.TID 0000.0001) END STREAMICE_ADVECT_THICKNESS
- cg2d: Sum(rhs),rhsMax =   1.23254168632122E-01  5.71270987092403E+01
-(PID.TID 0000.0001)      cg2d_init_res =   6.79487307941592E-05
+ cg2d: Sum(rhs),rhsMax =   1.23254168632124E-01  5.71270987092373E+01
+(PID.TID 0000.0001)      cg2d_init_res =   6.79487323518644E-05
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     115
-(PID.TID 0000.0001)      cg2d_last_res =   5.51799651550435E-12
+(PID.TID 0000.0001)      cg2d_last_res =   5.51797103105267E-12
 (PID.TID 0000.0001) CALLING FILL DIAGNOSTICS
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                 11415
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4245000000000E+06
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4733412572563E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4963048886616E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   2.4733412572590E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -7.4963048886594E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3346479639129E+00
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4328215425462E+00
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281035709974E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7358781770720E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7524032930427E-12
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.1323161944816E-26
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4563005956230E-13
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3062837499241E-14
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9875170565368E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041146903646E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.2524209814408E-07
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.4328215425463E+00
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8281035709976E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7453732184185E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.7543685895050E-12
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2463257382144E-26
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.4567578656971E-13
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.3063545287807E-14
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.9875170565371E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1041146903648E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.2524209814395E-07
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.1927126134996E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5258236274452E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2383675283764E-02
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7962808915143E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019783529063E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8068479787813E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9325355758569E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.5258236274450E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.2383675283773E-02
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.7962808915146E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   3.0019783529055E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8068479787810E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.9325355758558E-06
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   1.9439662282839E+00
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.8514214380612E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2648902595110E-02
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   2.2648902595111E-02
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   1.2764104547193E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7744441526024E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.7744441526039E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   3.4692816183113E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   3.3811989458803E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4431635789490E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   1.8350638814578E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.5931160076639E-05
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3404907026724E-13
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8647589003346E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7151025851292E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7151025851292E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.3369154069898E-13
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.8647589003358E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.7151025851318E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.7151025851318E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =  -2.8105354708345E-01
-(PID.TID 0000.0001) %MON ke_max                       =   1.9738026825090E-02
+(PID.TID 0000.0001) %MON ke_max                       =   1.9738026825094E-02
 (PID.TID 0000.0001) %MON ke_mean                      =   1.3481796804212E-03
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3174264251757E+12
 (PID.TID 0000.0001) // =======================================================
@@ -3981,191 +4138,191 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End OBCS MONITOR field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #    209  SHIfwFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    210  SHIhtFlx     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    215  SHIgammT     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    216  SHIgammS     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    218  SHI_mass     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    219  SHIRshel     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    194  SI_Uvel      Counter:       1   Parms: UZ      L1      
- Computing Diagnostic #    195  SI_Vvel      Counter:       1   Parms: VZ      L1      
- Computing Diagnostic #    196  SI_Thick     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    199  SI_hmask     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    198  SI_float     Counter:       1   Parms: SM      L1      
- Computing Diagnostic #    217  SHIuStar     Counter:       1   Parms: SM      L1      
+ Computing Diagnostic #   217 "SHIfwFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   218 "SHIhtFlx" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   223 "SHIgammT" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   224 "SHIgammS" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   225 "SHI_mass" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   228 "SHIRshel" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   202 "SI_Uvel " (list#  1) Parms "UZ      L1      ", Count=       1
+ Computing Diagnostic #   203 "SI_Vvel " (list#  1) Parms "VZ      L1      ", Count=       1
+ Computing Diagnostic #   204 "SI_Thick" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   207 "SI_hmask" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   206 "SI_float" (list#  1) Parms "SM      L1      ", Count=       1
+ Computing Diagnostic #   226 "SHIuStar" (list#  1) Parms "SM      L1      ", Count=       1
 (PID.TID 0000.0001) %CHECKPOINT     11415 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   18.844573974609375
-(PID.TID 0000.0001)         System time:  0.12943300348706543
-(PID.TID 0000.0001)     Wall clock time:   19.017664909362793
+(PID.TID 0000.0001)           User time:   13.157106974860653
+(PID.TID 0000.0001)         System time:   6.7970000207424164E-002
+(PID.TID 0000.0001)     Wall clock time:   13.430649042129517
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.12346599996089935
-(PID.TID 0000.0001)         System time:   3.3278999151661992E-002
-(PID.TID 0000.0001)     Wall clock time:  0.17258787155151367
+(PID.TID 0000.0001)           User time:   5.9072000323794782E-002
+(PID.TID 0000.0001)         System time:   1.1296000331640244E-002
+(PID.TID 0000.0001)     Wall clock time:   7.1639060974121094E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   18.721087440848351
-(PID.TID 0000.0001)         System time:   9.6127003431320190E-002
-(PID.TID 0000.0001)     Wall clock time:   18.845041990280151
+(PID.TID 0000.0001)           User time:   13.098014112561941
+(PID.TID 0000.0001)         System time:   5.6673000566661358E-002
+(PID.TID 0000.0001)     Wall clock time:   13.358993053436279
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.23218201100826263
-(PID.TID 0000.0001)         System time:   2.7376998215913773E-002
-(PID.TID 0000.0001)     Wall clock time:  0.28673911094665527
+(PID.TID 0000.0001)           User time:  0.12339400500059128
+(PID.TID 0000.0001)         System time:   1.2147000990808010E-002
+(PID.TID 0000.0001)     Wall clock time:  0.33784890174865723
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   18.488877803087234
-(PID.TID 0000.0001)         System time:   6.8745002150535583E-002
-(PID.TID 0000.0001)     Wall clock time:   18.558274984359741
+(PID.TID 0000.0001)           User time:   12.974608257412910
+(PID.TID 0000.0001)         System time:   4.4524999335408211E-002
+(PID.TID 0000.0001)     Wall clock time:   13.021131992340088
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   18.488706856966019
-(PID.TID 0000.0001)         System time:   6.8736009299755096E-002
-(PID.TID 0000.0001)     Wall clock time:   18.558092355728149
+(PID.TID 0000.0001)           User time:   12.974529191851616
+(PID.TID 0000.0001)         System time:   4.4513000175356865E-002
+(PID.TID 0000.0001)     Wall clock time:   13.021047353744507
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   18.488415241241455
-(PID.TID 0000.0001)         System time:   6.8721011281013489E-002
-(PID.TID 0000.0001)     Wall clock time:   18.557783842086792
+(PID.TID 0000.0001)           User time:   12.974386721849442
+(PID.TID 0000.0001)         System time:   4.4487005099654198E-002
+(PID.TID 0000.0001)     Wall clock time:   13.020865440368652
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "SHELFICE_REMESHING     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.11821269989013672
-(PID.TID 0000.0001)         System time:   6.7003071308135986E-005
-(PID.TID 0000.0001)     Wall clock time:  0.11829328536987305
+(PID.TID 0000.0001)           User time:   6.0995608568191528E-002
+(PID.TID 0000.0001)         System time:   4.2002648115158081E-005
+(PID.TID 0000.0001)     Wall clock time:   6.1042070388793945E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3283829689025879E-003
-(PID.TID 0000.0001)         System time:   4.5008957386016846E-005
-(PID.TID 0000.0001)     Wall clock time:   3.3769607543945312E-003
+(PID.TID 0000.0001)           User time:   2.3525804281234741E-003
+(PID.TID 0000.0001)         System time:   6.5004453063011169E-005
+(PID.TID 0000.0001)     Wall clock time:   2.4316310882568359E-003
 (PID.TID 0000.0001)          No. starts:          60
 (PID.TID 0000.0001)           No. stops:          60
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.5362114906311035E-004
-(PID.TID 0000.0001)         System time:   2.7000904083251953E-005
-(PID.TID 0000.0001)     Wall clock time:   4.8089027404785156E-004
+(PID.TID 0000.0001)           User time:   4.7521293163299561E-004
+(PID.TID 0000.0001)         System time:   7.9996883869171143E-005
+(PID.TID 0000.0001)     Wall clock time:   5.5909156799316406E-004
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.5258789062500000E-004
-(PID.TID 0000.0001)         System time:   7.9944729804992676E-006
-(PID.TID 0000.0001)     Wall clock time:   1.6379356384277344E-004
+(PID.TID 0000.0001)           User time:   7.8961253166198730E-005
+(PID.TID 0000.0001)         System time:   1.1997297406196594E-005
+(PID.TID 0000.0001)     Wall clock time:   9.0360641479492188E-005
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0784139633178711E-004
-(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
-(PID.TID 0000.0001)     Wall clock time:   2.2268295288085938E-004
+(PID.TID 0000.0001)           User time:   7.4908137321472168E-005
+(PID.TID 0000.0001)         System time:   1.4005228877067566E-005
+(PID.TID 0000.0001)     Wall clock time:   8.9168548583984375E-005
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.32163330912590027
-(PID.TID 0000.0001)         System time:   1.0370999574661255E-002
-(PID.TID 0000.0001)     Wall clock time:  0.33202385902404785
+(PID.TID 0000.0001)           User time:  0.17597556114196777
+(PID.TID 0000.0001)         System time:   1.2759001925587654E-002
+(PID.TID 0000.0001)     Wall clock time:  0.18876028060913086
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "SHELFICE_THERMODYNAMICS [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   1.4152139425277710E-002
-(PID.TID 0000.0001)         System time:   8.1401318311691284E-004
-(PID.TID 0000.0001)     Wall clock time:   1.4967203140258789E-002
+(PID.TID 0000.0001)           User time:   8.9789479970932007E-003
+(PID.TID 0000.0001)         System time:   1.6299989074468613E-003
+(PID.TID 0000.0001)     Wall clock time:   1.0609149932861328E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "STREAMICE_TIMESTEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6205152273178101E-002
-(PID.TID 0000.0001)         System time:   3.0299276113510132E-004
-(PID.TID 0000.0001)     Wall clock time:   2.6512622833251953E-002
+(PID.TID 0000.0001)           User time:   2.1596118807792664E-002
+(PID.TID 0000.0001)         System time:   2.5899894535541534E-004
+(PID.TID 0000.0001)     Wall clock time:   2.1901607513427734E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "STREAMICE_ADVECT_THICKNESS":
-(PID.TID 0000.0001)           User time:   1.4318346977233887E-002
-(PID.TID 0000.0001)         System time:   1.6699731349945068E-004
-(PID.TID 0000.0001)     Wall clock time:   1.4475584030151367E-002
+(PID.TID 0000.0001)           User time:   1.1899724602699280E-002
+(PID.TID 0000.0001)         System time:   1.3900734484195709E-004
+(PID.TID 0000.0001)     Wall clock time:   1.2040853500366211E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0378443300724030
-(PID.TID 0000.0001)         System time:   1.6086995601654053E-002
-(PID.TID 0000.0001)     Wall clock time:   8.0542428493499756
+(PID.TID 0000.0001)           User time:   5.7312714159488678
+(PID.TID 0000.0001)         System time:   8.2380026578903198E-003
+(PID.TID 0000.0001)     Wall clock time:   5.7401163578033447
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "UPDATE_SURF_DR      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7860274314880371E-003
-(PID.TID 0000.0001)         System time:   3.2000243663787842E-005
-(PID.TID 0000.0001)     Wall clock time:   3.8113594055175781E-003
+(PID.TID 0000.0001)           User time:   2.5413334369659424E-003
+(PID.TID 0000.0001)         System time:   2.2001564502716064E-005
+(PID.TID 0000.0001)     Wall clock time:   2.5663375854492188E-003
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.9051654338836670E-002
-(PID.TID 0000.0001)         System time:   1.8800795078277588E-004
-(PID.TID 0000.0001)     Wall clock time:   9.9277973175048828E-002
+(PID.TID 0000.0001)           User time:   6.3643425703048706E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   6.3657283782958984E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.53170120716094971
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.53174471855163574
+(PID.TID 0000.0001)           User time:  0.41441717743873596
+(PID.TID 0000.0001)         System time:   4.4997781515121460E-005
+(PID.TID 0000.0001)     Wall clock time:  0.41449332237243652
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25104129314422607
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:  0.25108480453491211
+(PID.TID 0000.0001)           User time:  0.15969642996788025
+(PID.TID 0000.0001)         System time:   1.8000602722167969E-005
+(PID.TID 0000.0001)     Wall clock time:  0.15973162651062012
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.27315926551818848
-(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
-(PID.TID 0000.0001)     Wall clock time:  0.27324271202087402
+(PID.TID 0000.0001)           User time:  0.19661122560501099
+(PID.TID 0000.0001)         System time:   4.0046870708465576E-006
+(PID.TID 0000.0001)     Wall clock time:  0.19663357734680176
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "CALC_SURF_DR      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.4560174942016602E-003
-(PID.TID 0000.0001)         System time:   9.9986791610717773E-006
-(PID.TID 0000.0001)     Wall clock time:   6.4740180969238281E-003
+(PID.TID 0000.0001)           User time:   4.6211481094360352E-003
+(PID.TID 0000.0001)         System time:   1.1995434761047363E-005
+(PID.TID 0000.0001)     Wall clock time:   4.6381950378417969E-003
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25074988603591919
-(PID.TID 0000.0001)         System time:   7.3000788688659668E-005
-(PID.TID 0000.0001)     Wall clock time:  0.25089073181152344
+(PID.TID 0000.0001)           User time:  0.18141442537307739
+(PID.TID 0000.0001)         System time:   8.5998326539993286E-005
+(PID.TID 0000.0001)     Wall clock time:  0.18159508705139160
 (PID.TID 0000.0001)          No. starts:          40
 (PID.TID 0000.0001)           No. stops:          40
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.6503138542175293
-(PID.TID 0000.0001)         System time:   1.6218997538089752E-002
-(PID.TID 0000.0001)     Wall clock time:   6.6668853759765625
+(PID.TID 0000.0001)           User time:   4.6689057946205139
+(PID.TID 0000.0001)         System time:   1.5915002673864365E-002
+(PID.TID 0000.0001)     Wall clock time:   4.6859824657440186
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.82087671756744385
-(PID.TID 0000.0001)         System time:   3.9250031113624573E-003
-(PID.TID 0000.0001)     Wall clock time:  0.82485437393188477
+(PID.TID 0000.0001)           User time:  0.54341465234756470
+(PID.TID 0000.0001)         System time:   4.9993395805358887E-006
+(PID.TID 0000.0001)     Wall clock time:  0.54357409477233887
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99230206012725830
-(PID.TID 0000.0001)         System time:   4.0149986743927002E-003
-(PID.TID 0000.0001)     Wall clock time:  0.99638056755065918
+(PID.TID 0000.0001)           User time:  0.67532759904861450
+(PID.TID 0000.0001)         System time:   2.4999678134918213E-004
+(PID.TID 0000.0001)     Wall clock time:  0.67571496963500977
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.6107978820800781E-002
-(PID.TID 0000.0001)         System time:   1.3239003717899323E-002
-(PID.TID 0000.0001)     Wall clock time:   8.9395761489868164E-002
+(PID.TID 0000.0001)           User time:   5.4892063140869141E-002
+(PID.TID 0000.0001)         System time:   2.5559961795806885E-003
+(PID.TID 0000.0001)     Wall clock time:   5.7457685470581055E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.0587563514709473E-002
-(PID.TID 0000.0001)         System time:   4.0090084075927734E-003
-(PID.TID 0000.0001)     Wall clock time:   2.4596452713012695E-002
+(PID.TID 0000.0001)           User time:   1.3619422912597656E-002
+(PID.TID 0000.0001)         System time:   4.0119960904121399E-003
+(PID.TID 0000.0001)     Wall clock time:   1.7628431320190430E-002
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001) // ======================================================
@@ -4183,9 +4340,9 @@ Global & Regional Statistics diagnostics: Number of lists:     0
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          25340
+(PID.TID 0000.0001) //            No. barriers =          25346
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          25340
+(PID.TID 0000.0001) //     Total barrier spins =          25346
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/small_toy/code/CTRL_OPTIONS.h
+++ b/small_toy/code/CTRL_OPTIONS.h
@@ -67,20 +67,27 @@ C       >>> Generic Control.
 C       >>> Open boundaries
 #ifdef ALLOW_OBCS
 C    Control of Open-Boundaries is meaningless without compiling pkg/obcs
-C    Note: Make sure that corresponding OBCS N/S/W/E Option is defined
+C    Note: Make sure that corresponding OBCS N/S/E/W Option is defined
 # define ALLOW_OBCSN_CONTROL
 # define ALLOW_OBCSS_CONTROL
-# define ALLOW_OBCSW_CONTROL
 # define ALLOW_OBCSE_CONTROL
-# undef ALLOW_OBCS_CONTROL_MODES
+# define ALLOW_OBCSW_CONTROL
 #endif /* ALLOW_OBCS */
 
 C  o Set ALLOW_OBCS_CONTROL (Do not edit/modify):
 #if (defined (ALLOW_OBCSN_CONTROL) || \
      defined (ALLOW_OBCSS_CONTROL) || \
-     defined (ALLOW_OBCSW_CONTROL) || \
-     defined (ALLOW_OBCSE_CONTROL))
+     defined (ALLOW_OBCSE_CONTROL) || \
+     defined (ALLOW_OBCSW_CONTROL))
 # define ALLOW_OBCS_CONTROL
+#endif
+
+#ifdef ALLOW_OBCS_CONTROL
+C     Untested code:
+# undef ALLOW_OBCS_CONTROL_MODES
+C     Enable code for 2D (horizontal,vertical) weights for obcs;
+C     this code is incomplete (fields are defined but not used anywhere)
+# undef ALLOW_OBCS_WEIGHTS2D
 #endif
 
 C  o Impose bounds on controls

--- a/update_history
+++ b/update_history
@@ -1,6 +1,10 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #976 (seaice metric-terms): set SEAICEselectMetricTerms=1 in
+    llc90 ecco_v4 secondary test to keep results unchanged and update other
+    affected reference output (3 cs32 + 3 forward llc90).
+
 checkpoint69m (2026/03/30) synchronised with main MITgcm code.
 checkpoint69l (2026/03/01) synchronised with main MITgcm code.
   - update few "prepare_run" in exp. global_oce _cs32 and _llc90 to follow


### PR DESCRIPTION
## Main purpose:
following the addition/fix of seaice metric terms in main MITgcm code (https://github.com/MITgcm/MITgcm/pull/976),
1. set new run-time parameter `SEAICEselectMetricTerms` to 1 in exp. `global_oce_llc90` secondary test "ecco_v4" (used both by forward and adjoint test) to keep results unchanged.
2. update other reference output that are affected by this seaice metric-term addition, namely all 3 other `global_oce_llc90`  forward tests and all `global_oce_cs32` output.

### Other updates:
1. update reference output of untested `shelfice_remesh_vrm` test (i.e., `shelfice_remeshing/results/output_vrm.txt`), left from https://github.com/MITgcm/MITgcm/pull/968 was merged in.
2. bring few "*_OPTIONS.h" files up-to-date with reference version (from corresponding pkg), namely `CTRL_OPTIONS.h`, `EXF_OPTIONS.h`, `GMREDI_OPTIONS.h` and `SEAICE_OPTIONS.h`.
