### PR TITLE
Update reference output affected by MITgcm PR 1014

### DIFF
--- a/global_oce_cs32/results/output.txt
+++ b/global_oce_cs32/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:43:56 EDT 2026
+(PID.TID 0000.0001) // Build date:        Wed Aug 12 18:10:50 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -5043,7 +5043,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   2.29726808616952E+00  4.04176142668240E+00
+ cg2d: Sum(rhs),rhsMax =   2.29726808616958E+00  4.04176142668240E+00
 (PID.TID 0000.0001)      cg2d_init_res =   8.99965395716137E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
 (PID.TID 0000.0001)      cg2d_last_res =   1.36249989550521E-05
@@ -5054,7 +5054,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   9.6887384398168E-01
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.0100088188579E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.9115061540482E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.9115061540481E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.5768847477280E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1966748006528E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.9566459823624E-01
@@ -5125,7 +5125,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385742338320E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229760090533E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1667189197556E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1949448073601E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1949448073595E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5250,7 +5250,7 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.05425779352041E+00  3.85943572236571E+00
+ cg2d: Sum(rhs),rhsMax =   3.05425779352018E+00  3.85943572236571E+00
 (PID.TID 0000.0001)      cg2d_init_res =   6.85364692571299E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      31
 (PID.TID 0000.0001)      cg2d_last_res =   1.20046364383687E-05
@@ -5261,7 +5261,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0890141177600E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.6303215008824E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5299326792706E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.5299326792709E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.1484885079155E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1609505095972E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532847319196E-01
@@ -5332,7 +5332,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737849075E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623696127E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7362235527993E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0933593027802E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0933593027831E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5457,10 +5457,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   3.79205605273486E+00  3.61217726753160E+00
+ cg2d: Sum(rhs),rhsMax =   3.79205605273495E+00  3.61217726753161E+00
 (PID.TID 0000.0001)      cg2d_init_res =   5.57930382167635E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.42219155120610E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.42219155120611E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5468,7 +5468,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1404016647630E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.0741590726092E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1073283312613E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -8.1073283312612E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.5178792679493E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1507794768372E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2868838254637E-01
@@ -5480,10 +5480,10 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4524984031454E-01
 (PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.8149383435249E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0808806205211E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6774436857260E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6774436857259E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.9979697065429E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.0982429405399E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.1874190720087E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.1874190720088E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.3150704094188E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6000666245471E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153625517001E+01
@@ -5495,7 +5495,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   1.7955690137084E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722425129955E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8377146041077E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2541867143792E-04
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2541867143791E-04
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   8.5192196398706E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0470511721041E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.5782874237971E+01
@@ -5539,7 +5539,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734926271E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229530526531E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1072181554297E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.9851622508142E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   7.9851622508117E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5664,10 +5664,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.51388023593563E+00  3.33482048706551E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.96839324707076E+00
+ cg2d: Sum(rhs),rhsMax =   4.51388023593577E+00  3.33482048706551E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.96839324707074E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.34356910327841E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.34356910327848E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5675,7 +5675,7 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1390913767014E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.1266642171440E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6505717773671E-04
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6505717773677E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7120981713726E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1446751212566E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7250482909508E-01
@@ -5690,7 +5690,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8143049637635E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5245371770836E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.4966678399809E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3594420526953E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3594420526954E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8838556287460E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9215122660405E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152883307839E+01
@@ -5745,8 +5745,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771603816E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734543749E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484402108E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4609499696438E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2467121219896E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4609499696437E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2467121218867E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5759,7 +5759,7 @@
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.8903652861827E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8856185441551E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2808998488469E-03
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   2.2808998488468E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_mean             =  -5.4646692511829E-02
@@ -5836,10 +5836,10 @@
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3817508881300E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1151716150208E+01
 (PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7443198409197E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7577814582196E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7577814582197E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431695554325E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.0916345812712E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7177657060957E-08
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7177657060958E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7085440485613E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5822245611208E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   5.0408473972077E-10
@@ -5871,10 +5871,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.22378551439951E+00  3.10565393023255E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.59442350333151E+00
+ cg2d: Sum(rhs),rhsMax =   5.22378551439962E+00  3.10565393023255E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.59442350333146E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      30
-(PID.TID 0000.0001)      cg2d_last_res =   1.24155965095491E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.24155965095470E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5914,7 +5914,7 @@
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8488656388529E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6678133577939E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3313529647758E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2702238262292E+00
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   1.2702238262293E+00
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.0868927255252E+02
 (PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8595543006364E+02
@@ -5952,8 +5952,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192859817795E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385736586875E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229489807718E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.6257538645406E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.1830839044983E-08
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   9.6257538645414E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.1830839056141E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5982,7 +5982,7 @@
 (PID.TID 0000.0001) %MON seaice_heff_mean             =   1.2626412468061E-03
 (PID.TID 0000.0001) %MON seaice_heff_sd               =   6.9431121170489E-03
 (PID.TID 0000.0001) %MON seaice_heff_del2             =   6.2547439716130E-05
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7693352123004E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7693352123003E-05
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.6035993617453E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   4.1995485944651E-06
@@ -6012,7 +6012,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9136183197248E+00
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.6825327701776E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2583722231700E-07
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.5438453546541E-09
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   1.5438453546542E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4406076848912E-08
 (PID.TID 0000.0001) %MON exf_sflux_del2               =   4.8545458423057E-10
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.1417681338615E+01
@@ -6046,7 +6046,7 @@
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7555637398794E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3431385024112E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.1790880052827E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5605511829965E-08
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5605511829966E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7225368083906E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5887078830194E-08
 (PID.TID 0000.0001) %MON exf_evap_del2                =   5.0616985024984E-10
@@ -6078,10 +6078,10 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   5.92587470002084E+00  2.96119649638921E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.22912098901423E+00
+ cg2d: Sum(rhs),rhsMax =   5.92587470002081E+00  2.96119649638920E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.22912098901427E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      29
-(PID.TID 0000.0001)      cg2d_last_res =   1.67541046565464E-05
+(PID.TID 0000.0001)      cg2d_last_res =   1.67541046565508E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6089,10 +6089,10 @@
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2517253173759E+00
 (PID.TID 0000.0001) %MON dynstat_eta_min              =  -9.5713512815971E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2669383356907E-03
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2669383356908E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7979374130950E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1340252834053E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3041032731175E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3041032731174E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7962180591953E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1084776836385E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2498105851853E-02
@@ -6117,7 +6117,7 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4722429830554E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.8373591711667E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.2446338350359E-04
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9492876201839E+02
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   8.9492876201836E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8005205413571E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.6254021761749E+01
 (PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3334247682812E+02
@@ -6128,12 +6128,12 @@
 (PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1304269927980E+01
 (PID.TID 0000.0001) %MON forcing_qsw_del2             =   1.5794372463368E-01
 (PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3219048372661E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2725834611742E-04
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -1.2725834611743E-04
 (PID.TID 0000.0001) %MON forcing_empmr_mean           =   4.2905026125905E-05
 (PID.TID 0000.0001) %MON forcing_empmr_sd             =   2.4411660007973E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.1865506247634E-06
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   2.1865506247635E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.0826407904782E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.0252593856888E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.0252593856887E-01
 (PID.TID 0000.0001) %MON forcing_fu_mean              =  -8.2778201501586E-03
 (PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1863113757761E-01
 (PID.TID 0000.0001) %MON forcing_fu_del2              =   1.5808055836984E-03
@@ -6145,7 +6145,7 @@
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4792132558596E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5471530443595E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1055333375727E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8811151026851E-03
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8811151026849E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7112174285834E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1974778395630E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.2984174394513E-01
@@ -6159,8 +6159,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193060004194E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740359616E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538945466E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8351287290440E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.5959338903847E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8351287290442E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.5959338904207E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6193,7 +6193,7 @@
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8381828158227E-07
 (PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6018675632909E-06
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2325513813529E-08
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2325513813528E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6228,237 +6228,237 @@
 (PID.TID 0000.0001) // End of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   7.4494682215154171
-(PID.TID 0000.0001)         System time:  0.11250899732112885
-(PID.TID 0000.0001)     Wall clock time:   7.5693979263305664
+(PID.TID 0000.0001)           User time:   7.6284792143851519
+(PID.TID 0000.0001)         System time:  0.16820900584571064
+(PID.TID 0000.0001)     Wall clock time:   7.8194029331207275
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.24918000493198633
-(PID.TID 0000.0001)         System time:   3.6627998575568199E-002
-(PID.TID 0000.0001)     Wall clock time:  0.28931307792663574
+(PID.TID 0000.0001)           User time:  0.22968000546097755
+(PID.TID 0000.0001)         System time:   4.8340001609176397E-002
+(PID.TID 0000.0001)     Wall clock time:  0.29680299758911133
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   7.2002648711204529
-(PID.TID 0000.0001)         System time:   7.5869996100664139E-002
-(PID.TID 0000.0001)     Wall clock time:   7.2800538539886475
+(PID.TID 0000.0001)           User time:   7.3987739235162735
+(PID.TID 0000.0001)         System time:  0.11986400559544563
+(PID.TID 0000.0001)     Wall clock time:   7.5225720405578613
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.44619199633598328
-(PID.TID 0000.0001)         System time:   2.3724999278783798E-002
-(PID.TID 0000.0001)     Wall clock time:  0.47027611732482910
+(PID.TID 0000.0001)           User time:  0.43838700652122498
+(PID.TID 0000.0001)         System time:   4.3744999915361404E-002
+(PID.TID 0000.0001)     Wall clock time:  0.48239588737487793
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.7540570497512817
-(PID.TID 0000.0001)         System time:   5.2143000066280365E-002
-(PID.TID 0000.0001)     Wall clock time:   6.8097608089447021
+(PID.TID 0000.0001)           User time:   6.9603701233863831
+(PID.TID 0000.0001)         System time:   7.6117008924484253E-002
+(PID.TID 0000.0001)     Wall clock time:   7.0401599407196045
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   4.5317530632019043E-002
-(PID.TID 0000.0001)         System time:   1.6299635171890259E-004
-(PID.TID 0000.0001)     Wall clock time:   4.5503377914428711E-002
+(PID.TID 0000.0001)           User time:   4.2250812053680420E-002
+(PID.TID 0000.0001)         System time:   3.9879977703094482E-003
+(PID.TID 0000.0001)     Wall clock time:   4.6250820159912109E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   4.7047138214111328E-002
-(PID.TID 0000.0001)         System time:   1.2002885341644287E-005
-(PID.TID 0000.0001)     Wall clock time:   4.7071695327758789E-002
+(PID.TID 0000.0001)           User time:   4.4227302074432373E-002
+(PID.TID 0000.0001)         System time:   6.7993998527526855E-005
+(PID.TID 0000.0001)     Wall clock time:   4.4314622879028320E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.5361770987510681
-(PID.TID 0000.0001)         System time:   4.7924995422363281E-002
-(PID.TID 0000.0001)     Wall clock time:   6.5876019001007080
+(PID.TID 0000.0001)           User time:   6.7559813261032104
+(PID.TID 0000.0001)         System time:   6.4048007130622864E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8234710693359375
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   6.5361087918281555
-(PID.TID 0000.0001)         System time:   4.7923997044563293E-002
-(PID.TID 0000.0001)     Wall clock time:   6.5875301361083984
+(PID.TID 0000.0001)           User time:   6.7559126019477844
+(PID.TID 0000.0001)         System time:   6.4048007130622864E-002
+(PID.TID 0000.0001)     Wall clock time:   6.8234059810638428
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10011142492294312
-(PID.TID 0000.0001)         System time:   8.7000429630279541E-005
-(PID.TID 0000.0001)     Wall clock time:  0.10027313232421875
+(PID.TID 0000.0001)           User time:  0.10412013530731201
+(PID.TID 0000.0001)         System time:   1.8998980522155762E-005
+(PID.TID 0000.0001)     Wall clock time:  0.10417437553405762
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.1853327751159668E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.2168159484863281E-002
+(PID.TID 0000.0001)           User time:   2.2666871547698975E-002
+(PID.TID 0000.0001)         System time:   2.7999281883239746E-005
+(PID.TID 0000.0001)     Wall clock time:   2.2751569747924805E-002
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.5790424346923828E-002
-(PID.TID 0000.0001)         System time:   3.9599984884262085E-003
-(PID.TID 0000.0001)     Wall clock time:   5.9766530990600586E-002
+(PID.TID 0000.0001)           User time:   5.7124018669128418E-002
+(PID.TID 0000.0001)         System time:   4.0760040283203125E-003
+(PID.TID 0000.0001)     Wall clock time:   6.1204671859741211E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   5.5453181266784668E-002
-(PID.TID 0000.0001)         System time:   3.9590001106262207E-003
-(PID.TID 0000.0001)     Wall clock time:   5.9429407119750977E-002
+(PID.TID 0000.0001)           User time:   5.6783735752105713E-002
+(PID.TID 0000.0001)         System time:   4.0679946541786194E-003
+(PID.TID 0000.0001)     Wall clock time:   6.0866355895996094E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.1902065277099609E-005
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   4.3153762817382812E-005
+(PID.TID 0000.0001)           User time:   5.0067901611328125E-005
+(PID.TID 0000.0001)         System time:   3.0025839805603027E-006
+(PID.TID 0000.0001)     Wall clock time:   5.1259994506835938E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1033117771148682E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.1037111282348633E-002
+(PID.TID 0000.0001)           User time:   1.1338651180267334E-002
+(PID.TID 0000.0001)         System time:   8.8997185230255127E-005
+(PID.TID 0000.0001)     Wall clock time:   1.1507987976074219E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1634569168090820E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.1640529632568359E-003
+(PID.TID 0000.0001)           User time:   3.1555294990539551E-003
+(PID.TID 0000.0001)         System time:   2.8997659683227539E-005
+(PID.TID 0000.0001)     Wall clock time:   3.1840801239013672E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.1160311102867126
-(PID.TID 0000.0001)         System time:   7.8229978680610657E-003
-(PID.TID 0000.0001)     Wall clock time:   1.1248950958251953
+(PID.TID 0000.0001)           User time:   1.1549160480499268
+(PID.TID 0000.0001)         System time:   4.0039941668510437E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1594767570495605
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  0.11883211135864258
-(PID.TID 0000.0001)         System time:   1.9997358322143555E-005
-(PID.TID 0000.0001)     Wall clock time:  0.11886310577392578
+(PID.TID 0000.0001)           User time:  0.11604702472686768
+(PID.TID 0000.0001)         System time:   1.0997056961059570E-005
+(PID.TID 0000.0001)     Wall clock time:  0.11607313156127930
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   8.7288141250610352E-002
+(PID.TID 0000.0001)           User time:   8.4507346153259277E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.7298870086669922E-002
+(PID.TID 0000.0001)     Wall clock time:   8.4523916244506836E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:  0.27754569053649902
-(PID.TID 0000.0001)         System time:   3.9639994502067566E-003
-(PID.TID 0000.0001)     Wall clock time:  0.28174519538879395
+(PID.TID 0000.0001)           User time:  0.28942698240280151
+(PID.TID 0000.0001)         System time:   5.9977173805236816E-006
+(PID.TID 0000.0001)     Wall clock time:  0.28951883316040039
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4705587029457092
-(PID.TID 0000.0001)         System time:   1.2002885341644287E-005
-(PID.TID 0000.0001)     Wall clock time:   1.4709758758544922
+(PID.TID 0000.0001)           User time:   1.4742652177810669
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.4746100902557373
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2974362373352051E-002
-(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
-(PID.TID 0000.0001)     Wall clock time:   3.2985210418701172E-002
+(PID.TID 0000.0001)           User time:   4.7393321990966797E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.7398090362548828E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.9574117660522461E-002
-(PID.TID 0000.0001)         System time:   7.5995922088623047E-005
-(PID.TID 0000.0001)     Wall clock time:   6.9654226303100586E-002
+(PID.TID 0000.0001)           User time:   7.5820088386535645E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   7.5828790664672852E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1373143196105957E-002
+(PID.TID 0000.0001)           User time:   3.1382560729980469E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.1384468078613281E-002
+(PID.TID 0000.0001)     Wall clock time:   3.1387329101562500E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.5214772224426270E-002
+(PID.TID 0000.0001)           User time:   5.3227186203002930E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.5218467712402344E-002
+(PID.TID 0000.0001)     Wall clock time:   5.3311109542846680E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.4467449188232422E-003
+(PID.TID 0000.0001)           User time:   4.3939352035522461E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.4479370117187500E-003
+(PID.TID 0000.0001)     Wall clock time:   4.3952465057373047E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.0601830482482910E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   6.0624599456787109E-002
+(PID.TID 0000.0001)           User time:   6.0115694999694824E-002
+(PID.TID 0000.0001)         System time:   2.8560012578964233E-003
+(PID.TID 0000.0001)     Wall clock time:   6.3022375106811523E-002
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.6995612382888794
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.7003536224365234
+(PID.TID 0000.0001)           User time:   1.8088132143020630
+(PID.TID 0000.0001)         System time:   3.9170011878013611E-003
+(PID.TID 0000.0001)     Wall clock time:   1.8143033981323242
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7550926208496094E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.1007995605468750E-005
+(PID.TID 0000.0001)           User time:   3.9815902709960938E-005
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:   3.8862228393554688E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25543105602264404
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.25556397438049316
+(PID.TID 0000.0001)           User time:  0.25097370147705078
+(PID.TID 0000.0001)         System time:   1.0429993271827698E-003
+(PID.TID 0000.0001)     Wall clock time:  0.25218725204467773
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7431716918945312E-005
+(PID.TID 0000.0001)           User time:   4.0650367736816406E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6954879760742188E-005
+(PID.TID 0000.0001)     Wall clock time:   3.9815902709960938E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.29331147670745850
-(PID.TID 0000.0001)         System time:   1.1946998536586761E-002
-(PID.TID 0000.0001)     Wall clock time:  0.30538487434387207
+(PID.TID 0000.0001)           User time:  0.27246618270874023
+(PID.TID 0000.0001)         System time:   2.3935995995998383E-002
+(PID.TID 0000.0001)     Wall clock time:  0.29665780067443848
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.1879138946533203E-002
-(PID.TID 0000.0001)         System time:   2.3970998823642731E-002
-(PID.TID 0000.0001)     Wall clock time:  0.10612320899963379
+(PID.TID 0000.0001)           User time:   8.1784963607788086E-002
+(PID.TID 0000.0001)         System time:   2.4026006460189819E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10599231719970703
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.5088996887207031E-003
-(PID.TID 0000.0001)         System time:   2.5004148483276367E-005
-(PID.TID 0000.0001)     Wall clock time:   5.5339336395263672E-003
+(PID.TID 0000.0001)           User time:   5.7849884033203125E-003
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   5.7840347290039062E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.0776519775390625E-004
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:   1.1086463928222656E-004
+(PID.TID 0000.0001)           User time:   1.0204315185546875E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.0204315185546875E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   9.4486236572265625E-002
-(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
-(PID.TID 0000.0001)     Wall clock time:   9.4528913497924805E-002
+(PID.TID 0000.0001)           User time:   8.5443019866943359E-002
+(PID.TID 0000.0001)         System time:   4.0310025215148926E-003
+(PID.TID 0000.0001)     Wall clock time:   8.9681863784790039E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   6.4402103424072266E-002
-(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
-(PID.TID 0000.0001)     Wall clock time:   6.4448118209838867E-002
+(PID.TID 0000.0001)           User time:   5.5282115936279297E-002
+(PID.TID 0000.0001)         System time:   3.9829909801483154E-003
+(PID.TID 0000.0001)     Wall clock time:   5.9474945068359375E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.0063152313232422E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.0062913894653320E-002
+(PID.TID 0000.0001)           User time:   3.0140876770019531E-002
+(PID.TID 0000.0001)         System time:   4.8011541366577148E-005
+(PID.TID 0000.0001)     Wall clock time:   3.0189990997314453E-002
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   8.9693069458007812E-004
+(PID.TID 0000.0001)           User time:   1.2879371643066406E-003
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9812278747558594E-004
+(PID.TID 0000.0001)     Wall clock time:   1.2891292572021484E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================

--- a/global_oce_cs32/results/output_adm.txt
+++ b/global_oce_cs32/results/output_adm.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Apr 21 10:54:07 EDT 2026
+(PID.TID 0000.0001) // Build date:        Wed Aug 12 17:35:41 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -4511,7 +4511,7 @@
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385746079982E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229941854223E-04
 (PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.0823556648655E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328655665452E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.0328655665451E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4637,10 +4637,10 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
  cg2d: Sum(rhs),rhsMax =   2.87992650799731E-01  7.97821468767044E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300431E-01  7.74858747615990E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.84404459441544E-01
+ cg2d: Sum(rhs),rhsMax =   3.94276103300442E-01  7.74858747615990E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.84404459441547E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      47
-(PID.TID 0000.0001)      cg2d_last_res =   9.19496287074642E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.19496287074650E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4693,8 +4693,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193096777662E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385737833612E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229623570993E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959017430E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276265061567E-06
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.7366959017431E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1276265061636E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4819,11 +4819,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   4.95270753311019E-01  7.65934820675236E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207482520E-01  7.61970515877186E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.51870870684693E-01
+ cg2d: Sum(rhs),rhsMax =   4.95270753311036E-01  7.65934820675235E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207482531E-01  7.61970515877197E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.51870870684681E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      46
-(PID.TID 0000.0001)      cg2d_last_res =   9.43883227760983E-10
+(PID.TID 0000.0001)      cg2d_last_res =   9.43883227760978E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4834,8 +4834,8 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -9.6548815206935E-04
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7119527919085E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1463461580090E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901465211E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680926573E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7251901465213E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7731680926574E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.3510302348038E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0436491859088E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.2992874169774E-05
@@ -4846,7 +4846,7 @@
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8188719804444E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   3.5338487115575E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.5103840646586E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673510500982E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.3673510500976E-08
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.8943369582164E-05
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9264808108150E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0153490706944E+01
@@ -4859,15 +4859,15 @@
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726333694657E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0067567206882E-01
 (PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3721088836775E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576152248E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5466576152253E-03
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1727681575436E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6550012920689E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686365117E-03
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.0353686365119E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3905534733322E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209520170E-01
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.7318209520171E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.8098925323475E-01
 (PID.TID 0000.0001) %MON pe_b_mean                    =   1.8146742658676E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5061127701031E-01
+(PID.TID 0000.0001) %MON ke_max                       =   3.5061127701032E-01
 (PID.TID 0000.0001) %MON ke_mean                      =   4.3301720510353E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3542977276382E+18
 (PID.TID 0000.0001) %MON vort_r_min                   =  -3.7495794247739E-06
@@ -4876,8 +4876,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5192771506334E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385734511739E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229484263698E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614782964014E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210451893047E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.4614782964013E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.6210451891612E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4934,7 +4934,7 @@
 (PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1271891369987E+01
 (PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.6836909459000E+02
 (PID.TID 0000.0001) %MON exf_hflux_del2               =   1.9183387149987E+00
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539017090E-07
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7452539017089E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.2342284317846E-07
 (PID.TID 0000.0001) %MON exf_sflux_mean               =   1.4077497796477E-09
 (PID.TID 0000.0001) %MON exf_sflux_sd                 =   3.4416292781655E-08
@@ -4966,10 +4966,10 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   9.2570459671690E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   1.3816578923417E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.1104555774393E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046679E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7446812046680E+01
 (PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7576653104752E+01
 (PID.TID 0000.0001) %MON exf_lwflux_del2              =   4.3433120172419E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594356E-07
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.0912895594355E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -2.7173197745550E-08
 (PID.TID 0000.0001) %MON exf_evap_mean                =   3.7089471371846E-08
 (PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5811478764647E-08
@@ -5002,11 +5002,11 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =   6.88070042799573E-01  7.59584828994177E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243680671E-01  7.57582533116067E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.57970833906427E-01
+ cg2d: Sum(rhs),rhsMax =   6.88070042799566E-01  7.59584828994174E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243680714E-01  7.57582533116066E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.57970833906402E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1      46
-(PID.TID 0000.0001)      cg2d_last_res =   8.72165674873427E-10
+(PID.TID 0000.0001)      cg2d_last_res =   8.72165674873776E-10
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5017,21 +5017,21 @@
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.2676716993124E-03
 (PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7977403021025E-01
 (PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.1361004056978E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754371170E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2994754371171E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8152033571924E-01
 (PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.1089658606654E-03
 (PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2499029751211E-02
 (PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0094320151325E-04
 (PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.4625188164490E+00
 (PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.5209188510815E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1681982913951E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1681982913950E-03
 (PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5165811812228E-02
 (PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0848780971386E-04
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.5278920870025E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.2890786384335E-03
 (PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.9072405465265E-07
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   7.8644189430346E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246311412E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.4783246311413E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.0152078185599E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9023458180603E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5950801892053E+00
@@ -5041,11 +5041,11 @@
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.8976439292116E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4726336750298E+01
 (PID.TID 0000.0001) %MON dynstat_salt_sd              =   4.0065222985484E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976413610E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502778593E-02
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   3.3660976413609E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.1675502778592E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.5035601919657E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633162381E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753295838545E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1089633162380E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.8753295838547E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7227356029118E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2079446514695E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3093745471558E-01
@@ -5059,8 +5059,8 @@
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.5193059943442E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.3385740316408E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.1229538645657E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826895125E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326267299667E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   6.8441826895116E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -1.1326267300259E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5071,7 +5071,7 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015706084E-02
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.0125015706085E-02
 (PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9401425196443E-01
 (PID.TID 0000.0001) %MON seaice_uice_del2             =   2.4059935392124E-03
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
@@ -5092,7 +5092,7 @@
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   1.0295657520899E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_hsnow_mean            =   8.8502147587133E-07
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146827E-06
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   5.6086171146826E-06
 (PID.TID 0000.0001) %MON seaice_hsnow_del2            =   9.2814095039265E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
@@ -5134,25 +5134,25 @@
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689202E-01  6.80494402321960E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537588E-01  8.23075697484955E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799723E-01  7.97821468767062E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300477E-01  7.74858747615995E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799724E-01  7.97821468767062E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300456E-01  7.74858747615994E+00
 (PID.TID 0000.0001) whio : write lev 2 rec   2
- cg2d: Sum(rhs),rhsMax =   4.95270753311083E-01  7.65934820675233E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207482574E-01  7.61970515877206E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042799527E-01  7.59584828994222E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243680710E-01  7.57582533116127E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753311075E-01  7.65934820675242E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207482588E-01  7.61970515877205E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042799534E-01  7.59584828994225E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243680721E-01  7.57582533116114E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) whio : write lev 2 rec   3
  cg2d: Sum(rhs),rhsMax =   4.95270620995285E-01  7.65935025998748E+00
- cg2d: Sum(rhs),rhsMax =   5.92660475395579E-01  7.61970724306709E+00
- cg2d: Sum(rhs),rhsMax =   6.88070473820574E-01  7.59585024200483E+00
- cg2d: Sum(rhs),rhsMax =   7.82661729692791E-01  7.57582726826315E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660475395544E-01  7.61970724306709E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070473820570E-01  7.59585024200484E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661729692805E-01  7.57582726826315E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
  Calling cg2d from S/R CG2D_MAD
  cg2d: Sum(rhs),rhsMax =   3.55271367880050E-15  2.69820681560877E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -3.44169137633799E-15  3.63339520242778E-03
+ cg2d: Sum(rhs),rhsMax =  -4.99600361081320E-15  3.63339520242778E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5160,14 +5160,14 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   9.7045337537243E-01
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -9.2105185264483E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6367239275270E-04
-(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8157598344035E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =  -9.6367239275186E-04
+(PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   8.8157598344036E-02
 (PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   2.3143093306287E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   8.1218851813390E-01
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -1.2255595067415E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4491995791722E-03
-(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0728080174618E-02
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5361216836386E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -7.4491995791733E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   9.0728080174617E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   2.5361216836385E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   1.9196606522189E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -2.0875435268828E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -7.1269086036142E-05
@@ -5181,7 +5181,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   4.6946736696820E-04
 (PID.TID 0000.0001) %MON ad_exf_adqsw_min             =  -4.3345665282855E-04
 (PID.TID 0000.0001) %MON ad_exf_adqsw_mean            =   1.6228171838034E-05
-(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584140455E-05
+(PID.TID 0000.0001) %MON ad_exf_adqsw_sd              =   9.3546584140456E-05
 (PID.TID 0000.0001) %MON ad_exf_adqsw_del2            =   1.3311872051252E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR EXF statistics for iwhen =  3
@@ -5198,7 +5198,7 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adeta_del2        =   5.8721406077750E-02
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_max        =   1.1342764875801E+01
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_min        =  -1.1395601493684E+01
-(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -6.0189355824485E-03
+(PID.TID 0000.0001) %MON ad_dynstat_aduvel_mean       =  -6.0189355824486E-03
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_sd         =   2.0501305394603E+00
 (PID.TID 0000.0001) %MON ad_dynstat_aduvel_del2       =   2.0663774579512E-03
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_max        =   1.3082629986706E+01
@@ -5208,17 +5208,17 @@
 (PID.TID 0000.0001) %MON ad_dynstat_advvel_del2       =   2.0037041212531E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_max        =   5.6089533244490E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adwvel_min        =  -5.5276666948148E+01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4575335907348E-03
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3553761272761E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0418160234641E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_mean       =  -6.4575335907354E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_sd         =   4.3553761272762E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adwvel_del2       =   4.0418160234642E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_max       =   3.2009860319563E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_min       =  -3.4401545318305E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_mean      =  -4.5695883007646E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_sd        =   3.6738905626461E-01
-(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691863714650E-03
+(PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   2.1691863714651E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   1.1325180910331E+02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -5.3217398715748E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.1583823271522E-02
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   3.1583823271519E-02
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   3.9305607594882E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   8.3576913803983E-04
 (PID.TID 0000.0001) // =======================================================
@@ -5231,18 +5231,18 @@
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.2237330644795E-02
 (PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -5.7331954001379E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7928821489839E-05
-(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5342656827721E-03
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5300207023660E-05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.7928821489847E-05
+(PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   3.5342656827722E-03
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   6.5300207023661E-05
 (PID.TID 0000.0001) %MON ad_seaice_advice_max         =   9.0587728901345E-02
 (PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -7.0326037498826E-02
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3269290217095E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -3.3269290217137E-05
 (PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   4.1518130001679E-03
-(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0870237942785E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   7.0870237942784E-05
 (PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   8.0378915894083E-02
 (PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -7.1451095551669E-02
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.7357533449603E-06
-(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0913172371214E-03
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.7357533449686E-06
+(PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   5.0913172371215E-03
 (PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   1.3911927948773E-04
 (PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   2.1559218914596E+02
 (PID.TID 0000.0001) %MON ad_seaice_adheff_min         =  -2.3505985939261E+02
@@ -5253,21 +5253,21 @@
 (PID.TID 0000.0001) %MON ad_seaice_adhsnow_min        =  -8.5242189980498E+01
 (PID.TID 0000.0001) %MON ad_seaice_adhsnow_mean       =  -2.3474524594115E+00
 (PID.TID 0000.0001) %MON ad_seaice_adhsnow_sd         =   1.6015608544014E+01
-(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879285584803E-01
+(PID.TID 0000.0001) %MON ad_seaice_adhsnow_del2       =   2.1879285584804E-01
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -7.49400541621981E-16  7.18267427172082E-03
+ cg2d: Sum(rhs),rhsMax =   1.05471187339390E-15  7.18267427172082E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   2.99760216648792E-15  3.65368418840651E-03
+ cg2d: Sum(rhs),rhsMax =   2.22044604925031E-16  3.65368418840651E-03
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689202E-01  6.80494402321960E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537588E-01  8.23075697484955E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799723E-01  7.97821468767062E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103300477E-01  7.74858747615995E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799724E-01  7.97821468767062E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103300456E-01  7.74858747615994E+00
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -1.33226762955019E-15  4.17414199128834E-03
+ cg2d: Sum(rhs),rhsMax =   3.10862446895044E-15  4.17414199128833E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5275,19 +5275,19 @@
 (PID.TID 0000.0001) %MON ad_exf_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_exf_adfu_max              =   2.3103746475365E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.8264580223694E+00
-(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0220444511756E-02
+(PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   2.0220444511757E-02
 (PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   1.9722099812988E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2825300907327E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   5.2825300907328E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.7300827889170E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -2.9072078409125E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6332972025066E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.6332972025065E-02
 (PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.0018907911149E-01
-(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388429984220E-03
+(PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   5.7388429984219E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   3.0393738970130E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_min            =  -3.2933733622022E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_mean           =  -4.6167081762205E-05
 (PID.TID 0000.0001) %MON ad_exf_adqnet_sd             =   6.7459234437588E-04
-(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615165665890E-06
+(PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   8.8615165665889E-06
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5714508527757E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -9.5830837285141E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   2.8955919846182E+00
@@ -5346,17 +5346,17 @@
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   4.1741116020898E-01
 (PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -2.2155758449553E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4531772051721E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   5.4531772051727E-04
 (PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   1.5198725882708E-02
-(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9193239134568E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   2.9193239134569E-04
 (PID.TID 0000.0001) %MON ad_seaice_advice_max         =   4.0299192314778E-01
 (PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -2.7471781261002E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1528192530689E-04
-(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5799504882585E-02
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -1.1528192530696E-04
+(PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   1.5799504882584E-02
 (PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.2194924114186E-04
 (PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   3.4306487302569E-01
 (PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3613590374729E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.4948470220141E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   9.4948470220152E-04
 (PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.4494814210112E-02
 (PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.5504922874008E-04
 (PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   3.4089567405067E+02
@@ -5373,11 +5373,11 @@
 (PID.TID 0000.0001) // End AD_MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =  -2.30371277609720E-15  4.27053409103837E-03
+ cg2d: Sum(rhs),rhsMax =  -1.66533453693773E-16  4.27053409103838E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   1.77635683940025E-15  5.79944903126073E-03
+ cg2d: Sum(rhs),rhsMax =   5.55111512312578E-16  5.79944903126074E-03
  Calling cg2d from S/R CG2D_MAD
- cg2d: Sum(rhs),rhsMax =   2.27595720048157E-15  4.44099757422374E-03
+ cg2d: Sum(rhs),rhsMax =  -8.88178419700125E-16  4.44099757422374E-03
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin AD_MONITOR EXF statistics for iwhen =  3
 (PID.TID 0000.0001) // =======================================================
@@ -5387,10 +5387,10 @@
 (PID.TID 0000.0001) %MON ad_exf_adfu_min              =  -2.3594792859110E+00
 (PID.TID 0000.0001) %MON ad_exf_adfu_mean             =   1.9983927651073E-02
 (PID.TID 0000.0001) %MON ad_exf_adfu_sd               =   2.7800994814571E-01
-(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1549607360046E-03
+(PID.TID 0000.0001) %MON ad_exf_adfu_del2             =   7.1549607360045E-03
 (PID.TID 0000.0001) %MON ad_exf_adfv_max              =   2.5237592802036E+00
 (PID.TID 0000.0001) %MON ad_exf_adfv_min              =  -3.0449043114004E+00
-(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8832968272140E-02
+(PID.TID 0000.0001) %MON ad_exf_adfv_mean             =  -2.8832968272139E-02
 (PID.TID 0000.0001) %MON ad_exf_adfv_sd               =   2.6410548781658E-01
 (PID.TID 0000.0001) %MON ad_exf_adfv_del2             =   7.5364533589851E-03
 (PID.TID 0000.0001) %MON ad_exf_adqnet_max            =   4.5956055544770E-03
@@ -5400,7 +5400,7 @@
 (PID.TID 0000.0001) %MON ad_exf_adqnet_del2           =   1.1419835660370E-05
 (PID.TID 0000.0001) %MON ad_exf_adempmr_max           =   1.5363179083266E+02
 (PID.TID 0000.0001) %MON ad_exf_adempmr_min           =  -1.5397120414514E+02
-(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.8008985851180E+00
+(PID.TID 0000.0001) %MON ad_exf_adempmr_mean          =   3.8008985851181E+00
 (PID.TID 0000.0001) %MON ad_exf_adempmr_sd            =   1.8359272202370E+01
 (PID.TID 0000.0001) %MON ad_exf_adempmr_del2          =   1.5422703667654E-01
 (PID.TID 0000.0001) %MON ad_exf_adqsw_max             =   1.0052948278543E-03
@@ -5446,7 +5446,7 @@
 (PID.TID 0000.0001) %MON ad_dynstat_adtheta_del2      =   3.8700858060010E-03
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_max        =   7.0169554383020E+01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_min        =  -8.4861128796441E+00
-(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.5867422157369E-01
+(PID.TID 0000.0001) %MON ad_dynstat_adsalt_mean       =   1.5867422157368E-01
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_sd         =   1.3391543630407E+00
 (PID.TID 0000.0001) %MON ad_dynstat_adsalt_del2       =   2.6756320589923E-03
 (PID.TID 0000.0001) // =======================================================
@@ -5459,17 +5459,17 @@
 (PID.TID 0000.0001) %MON ad_seaice_time_sec           =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON ad_seaice_aduice_max         =   6.8133786762970E-01
 (PID.TID 0000.0001) %MON ad_seaice_aduice_min         =  -3.1829291619234E-01
-(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0953857336549E-04
+(PID.TID 0000.0001) %MON ad_seaice_aduice_mean        =   9.0953857336555E-04
 (PID.TID 0000.0001) %MON ad_seaice_aduice_sd          =   2.2608662005103E-02
 (PID.TID 0000.0001) %MON ad_seaice_aduice_del2        =   4.1069734675302E-04
 (PID.TID 0000.0001) %MON ad_seaice_advice_max         =   5.5890407620056E-01
 (PID.TID 0000.0001) %MON ad_seaice_advice_min         =  -3.5618406633246E-01
-(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9591900913330E-05
+(PID.TID 0000.0001) %MON ad_seaice_advice_mean        =  -2.9591900913407E-05
 (PID.TID 0000.0001) %MON ad_seaice_advice_sd          =   2.1006181750318E-02
 (PID.TID 0000.0001) %MON ad_seaice_advice_del2        =   2.9937130331444E-04
 (PID.TID 0000.0001) %MON ad_seaice_adarea_max         =   2.1713742643341E-01
 (PID.TID 0000.0001) %MON ad_seaice_adarea_min         =  -1.3354047294240E-01
-(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6376937286526E-04
+(PID.TID 0000.0001) %MON ad_seaice_adarea_mean        =   5.6376937286533E-04
 (PID.TID 0000.0001) %MON ad_seaice_adarea_sd          =   1.3713082445734E-02
 (PID.TID 0000.0001) %MON ad_seaice_adarea_del2        =   3.2627521698398E-04
 (PID.TID 0000.0001) %MON ad_seaice_adheff_max         =   4.9825362978077E+02
@@ -5509,12 +5509,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689274E-01  6.80494402321544E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537750E-01  8.23075697484161E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800145E-01  7.97821468765922E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301184E-01  7.74858747614568E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312116E-01  7.65934820673533E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207483927E-01  7.61970515875250E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042801311E-01  7.59584828992035E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243682654E-01  7.57582533113793E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800142E-01  7.97821468765922E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301209E-01  7.74858747614563E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312106E-01  7.65934820673535E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207483970E-01  7.61970515875243E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042801321E-01  7.59584828992047E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243682696E-01  7.57582533113801E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5553,12 +5553,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689136E-01  6.80494402322376E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537402E-01  8.23075697485752E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799286E-01  7.97821468768214E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299696E-01  7.74858747617459E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309963E-01  7.65934820676950E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207481075E-01  7.61970515879129E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042797786E-01  7.59584828996338E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243678646E-01  7.57582533118370E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799278E-01  7.97821468768214E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299703E-01  7.74858747617459E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309985E-01  7.65934820676950E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207481082E-01  7.61970515879137E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042797737E-01  7.59584828996350E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243678689E-01  7.57582533118372E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5589,10 +5589,10 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894337202240E+04
 grad-res -------------------------------
  grad-res     0    1    1    1    1    1    1    1   3.31894343818E+04  3.31894351070E+04  3.31894337202E+04
- grad-res     0    1    1    1    0    1    1    1   5.09827286005E-02  6.93373240210E-02 -3.60015949016E-01
+ grad-res     0    1    1    1    0    1    1    1   5.09827286005E-02  6.93373236572E-02 -3.60015941880E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  5.09827286005020E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.93373240210349E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  6.93373236572370E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   1 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   2 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            2         594           2
@@ -5609,12 +5609,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689302E-01  6.80494402321359E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537837E-01  8.23075697483809E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800344E-01  7.97821468765414E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301554E-01  7.74858747613875E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312631E-01  7.65934820672701E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207484599E-01  7.61970515874313E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042802202E-01  7.59584828991022E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243683648E-01  7.57582533112692E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800335E-01  7.97821468765414E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301550E-01  7.74858747613875E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312642E-01  7.65934820672700E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207484624E-01  7.61970515874308E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042802128E-01  7.59584828991020E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243683673E-01  7.57582533112705E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5653,12 +5653,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689107E-01  6.80494402322561E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537318E-01  8.23075697486113E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650799124E-01  7.97821468768741E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299312E-01  7.74858747618166E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309448E-01  7.65934820677782E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207480392E-01  7.61970515880061E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042796863E-01  7.59584828997374E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243677715E-01  7.57582533119476E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650799106E-01  7.97821468768740E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299330E-01  7.74858747618165E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309438E-01  7.65934820677782E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207480431E-01  7.61970515880058E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042796920E-01  7.59584828997367E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243677676E-01  7.57582533119481E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5709,12 +5709,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689321E-01  6.80494402321269E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537874E-01  8.23075697483626E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800442E-01  7.97821468765121E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301777E-01  7.74858747613505E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753312873E-01  7.65934820672280E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207485036E-01  7.61970515873796E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042802654E-01  7.59584828990425E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243684203E-01  7.57582533112046E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800453E-01  7.97821468765121E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301749E-01  7.74858747613507E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753312880E-01  7.65934820672281E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207485043E-01  7.61970515873796E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042802639E-01  7.59584828990428E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243684192E-01  7.57582533112053E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5754,11 +5754,11 @@ grad-res -------------------------------
  cg2d: Sum(rhs),rhsMax =   1.13674863689084E-01  6.80494402322651E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537270E-01  8.23075697486299E+00
  cg2d: Sum(rhs),rhsMax =   2.87992650798975E-01  7.97821468769039E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103299116E-01  7.74858747618519E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753309185E-01  7.65934820678221E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207480051E-01  7.61970515880569E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042796429E-01  7.59584828997952E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243677140E-01  7.57582533120106E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103299106E-01  7.74858747618519E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753309207E-01  7.65934820678221E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207480023E-01  7.61970515880570E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042796404E-01  7.59584828997948E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243677165E-01  7.57582533120113E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5789,10 +5789,10 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894340588699E+04
 grad-res -------------------------------
  grad-res     0    3    3    1    1    1    1    1   3.31894343818E+04  3.31894347136E+04  3.31894340589E+04
- grad-res     0    3    3    3    0    1    1    1   2.86160372198E-02  3.27373145410E-02 -1.44019847668E-01
+ grad-res     0    3    3    3    0    1    1    1   2.86160372198E-02  3.27373141772E-02 -1.44019834955E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  2.86160372197628E-02
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27373145410093E-02
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27373141772114E-02
 (PID.TID 0000.0001) ====== End of gradient-check number   3 (ierr=  0) =======
 (PID.TID 0000.0001) ====== Starts gradient-check number   4 (=ichknum) =======
  ph-test icomp, ncvarcomp, ichknum            4         594           4
@@ -5809,12 +5809,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689329E-01  6.80494402321186E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537919E-01  8.23075697483461E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650800554E-01  7.97821468764866E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103301902E-01  7.74858747613166E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753313171E-01  7.65934820671813E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207485430E-01  7.61970515873198E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042803190E-01  7.59584828989755E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243684906E-01  7.57582533111277E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650800552E-01  7.97821468764866E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103301905E-01  7.74858747613168E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753313136E-01  7.65934820671813E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207485451E-01  7.61970515873198E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042803179E-01  7.59584828989759E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243684924E-01  7.57582533111260E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5853,12 +5853,12 @@ grad-res -------------------------------
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
  cg2d: Sum(rhs),rhsMax =   1.13674863689076E-01  6.80494402322734E+00
  cg2d: Sum(rhs),rhsMax =   1.86851253537231E-01  8.23075697486459E+00
- cg2d: Sum(rhs),rhsMax =   2.87992650798884E-01  7.97821468769249E+00
- cg2d: Sum(rhs),rhsMax =   3.94276103298974E-01  7.74858747618816E+00
- cg2d: Sum(rhs),rhsMax =   4.95270753308908E-01  7.65934820678656E+00
- cg2d: Sum(rhs),rhsMax =   5.92660207479643E-01  7.61970515881127E+00
- cg2d: Sum(rhs),rhsMax =   6.88070042795839E-01  7.59584828998612E+00
- cg2d: Sum(rhs),rhsMax =   7.82661243676444E-01  7.57582533120883E+00
+ cg2d: Sum(rhs),rhsMax =   2.87992650798889E-01  7.97821468769249E+00
+ cg2d: Sum(rhs),rhsMax =   3.94276103298978E-01  7.74858747618816E+00
+ cg2d: Sum(rhs),rhsMax =   4.95270753308933E-01  7.65934820678658E+00
+ cg2d: Sum(rhs),rhsMax =   5.92660207479582E-01  7.61970515881126E+00
+ cg2d: Sum(rhs),rhsMax =   6.88070042795847E-01  7.59584828998609E+00
+ cg2d: Sum(rhs),rhsMax =   7.82661243676451E-01  7.57582533120885E+00
 (PID.TID 0000.0001) Did not write pickup because writePickupAtEnd = FALSE
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) == profiles_cost: begin ==
@@ -5889,10 +5889,10 @@ grad-res -------------------------------
 (PID.TID 0000.0001) grdchk perturb(-)fc: fcpertminus =  3.31894343205481E+04
 grad-res -------------------------------
  grad-res     0    4    4    1    1    1    1    1   3.31894343818E+04  3.31894343861E+04  3.31894343205E+04
- grad-res     0    4    4    4    0    1    1    1   4.69273794442E-03  3.27781999658E-03  3.01512243939E-01
+ grad-res     0    4    4    4    0    1    1    1   4.69273794442E-03  3.27781926899E-03  3.01512398986E-01
 (PID.TID 0000.0001)  ADM  ref_cost_function      =  3.31894343817657E+04
 (PID.TID 0000.0001)  ADM  adjoint_gradient       =  4.69273794442415E-03
-(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27781999658328E-03
+(PID.TID 0000.0001)  ADM  finite-diff_grad       =  3.27781926898751E-03
 (PID.TID 0000.0001) ====== End of gradient-check number   4 (ierr=  0) =======
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
@@ -5907,7 +5907,7 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   1     1     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   1  3.3189434381766E+04  3.3189435106970E+04  3.3189433720224E+04
-(PID.TID 0000.0001) grdchk output (g):   1     6.9337324021035E-02  5.0982728600502E-02 -3.6001594901596E-01
+(PID.TID 0000.0001) grdchk output (g):   1     6.9337323657237E-02  5.0982728600502E-02 -3.6001594188025E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   2     2     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   2  3.3189434381766E+04  3.3189435011531E+04  3.3189433704306E+04
@@ -5915,262 +5915,262 @@ grad-res -------------------------------
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   3     3     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   3  3.3189434381766E+04  3.3189434713616E+04  3.3189434058870E+04
-(PID.TID 0000.0001) grdchk output (g):   3     3.2737314541009E-02  2.8616037219763E-02 -1.4401984766780E-01
+(PID.TID 0000.0001) grdchk output (g):   3     3.2737314177211E-02  2.8616037219763E-02 -1.4401983495473E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) grdchk output (p):   4     4     1     1    1    1   0.000000000E+00 -1.000000000E-02
 (PID.TID 0000.0001) grdchk output (c):   4  3.3189434381766E+04  3.3189434386105E+04  3.3189434320548E+04
-(PID.TID 0000.0001) grdchk output (g):   4     3.2778199965833E-03  4.6927379444242E-03  3.0151224393897E-01
+(PID.TID 0000.0001) grdchk output (g):   4     3.2778192689875E-03  4.6927379444242E-03  3.0151239898615E-01
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9196696096456E-01
+(PID.TID 0000.0001) grdchk  summary  :  RMS of    4 ratios =  2.9196699722613E-01
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Gradient check results  >>> END <<<
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   97.206560136750340
-(PID.TID 0000.0001)         System time:  0.44249100424349308
-(PID.TID 0000.0001)     Wall clock time:   98.141612052917480
+(PID.TID 0000.0001)           User time:   97.327368784230202
+(PID.TID 0000.0001)         System time:  0.60032402444630861
+(PID.TID 0000.0001)     Wall clock time:   98.448120832443237
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.46267701406031847
-(PID.TID 0000.0001)         System time:   3.4939999692142010E-002
-(PID.TID 0000.0001)     Wall clock time:  0.50069880485534668
+(PID.TID 0000.0001)           User time:  0.43350501358509064
+(PID.TID 0000.0001)         System time:   7.1151999756693840E-002
+(PID.TID 0000.0001)     Wall clock time:  0.63379597663879395
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "ADTHE_MAIN_LOOP          [ADJOINT RUN]":
-(PID.TID 0000.0001)           User time:   43.733761817216873
-(PID.TID 0000.0001)         System time:  0.25557598844170570
-(PID.TID 0000.0001)     Wall clock time:   44.013284921646118
+(PID.TID 0000.0001)           User time:   44.509283334016800
+(PID.TID 0000.0001)         System time:  0.34907501190900803
+(PID.TID 0000.0001)     Wall clock time:   45.168809175491333
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   58.588659644126892
-(PID.TID 0000.0001)         System time:   7.5638011097908020E-002
-(PID.TID 0000.0001)     Wall clock time:   58.693045377731323
+(PID.TID 0000.0001)           User time:   57.826608180999756
+(PID.TID 0000.0001)         System time:   8.1828191876411438E-002
+(PID.TID 0000.0001)     Wall clock time:   57.937952280044556
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99812769889831543
-(PID.TID 0000.0001)         System time:   9.3996524810791016E-005
-(PID.TID 0000.0001)     Wall clock time:  0.99895668029785156
+(PID.TID 0000.0001)           User time:   1.0008796453475952
+(PID.TID 0000.0001)         System time:   4.6491622924804688E-004
+(PID.TID 0000.0001)     Wall clock time:   1.0018486976623535
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.48167109489440918
-(PID.TID 0000.0001)         System time:   4.0410012006759644E-003
-(PID.TID 0000.0001)     Wall clock time:  0.48574304580688477
+(PID.TID 0000.0001)           User time:  0.49094295501708984
+(PID.TID 0000.0001)         System time:   8.2178860902786255E-003
+(PID.TID 0000.0001)     Wall clock time:  0.50193929672241211
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.43381047248840332
-(PID.TID 0000.0001)         System time:   3.9920210838317871E-003
-(PID.TID 0000.0001)     Wall clock time:  0.43789386749267578
+(PID.TID 0000.0001)           User time:  0.44395101070404053
+(PID.TID 0000.0001)         System time:   7.9729408025741577E-003
+(PID.TID 0000.0001)     Wall clock time:  0.45473146438598633
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.0316581726074219E-004
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8599967956542969E-004
+(PID.TID 0000.0001)           User time:   3.8754940032958984E-004
+(PID.TID 0000.0001)         System time:   4.9918889999389648E-006
+(PID.TID 0000.0001)     Wall clock time:   3.7980079650878906E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10829925537109375
-(PID.TID 0000.0001)         System time:   2.4981796741485596E-005
-(PID.TID 0000.0001)     Wall clock time:  0.10835862159729004
+(PID.TID 0000.0001)           User time:  0.10596752166748047
+(PID.TID 0000.0001)         System time:   1.5430748462677002E-003
+(PID.TID 0000.0001)     Wall clock time:  0.10754156112670898
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6279916763305664E-002
-(PID.TID 0000.0001)         System time:   1.1987984180450439E-005
-(PID.TID 0000.0001)     Wall clock time:   3.6309480667114258E-002
+(PID.TID 0000.0001)           User time:   3.7734866142272949E-002
+(PID.TID 0000.0001)         System time:   6.2094628810882568E-004
+(PID.TID 0000.0001)     Wall clock time:   3.8432359695434570E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   11.228682875633240
-(PID.TID 0000.0001)         System time:   1.5842020511627197E-002
-(PID.TID 0000.0001)     Wall clock time:   11.250275850296021
+(PID.TID 0000.0001)           User time:   10.931012988090515
+(PID.TID 0000.0001)         System time:   1.8268182873725891E-002
+(PID.TID 0000.0001)     Wall clock time:   10.959438800811768
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   1.1132563352584839
-(PID.TID 0000.0001)         System time:   4.1998922824859619E-005
-(PID.TID 0000.0001)     Wall clock time:   1.1142530441284180
+(PID.TID 0000.0001)           User time:   1.1208181381225586
+(PID.TID 0000.0001)         System time:   2.1850615739822388E-003
+(PID.TID 0000.0001)     Wall clock time:   1.1232256889343262
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:  0.82263386249542236
-(PID.TID 0000.0001)         System time:   1.9006431102752686E-005
-(PID.TID 0000.0001)     Wall clock time:  0.82344079017639160
+(PID.TID 0000.0001)           User time:  0.81645965576171875
+(PID.TID 0000.0001)         System time:   1.9390136003494263E-003
+(PID.TID 0000.0001)     Wall clock time:  0.81856560707092285
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   2.8561478853225708
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8568546772003174
+(PID.TID 0000.0001)           User time:   2.8060597181320190
+(PID.TID 0000.0001)         System time:   4.5031309127807617E-005
+(PID.TID 0000.0001)     Wall clock time:   2.8070535659790039
 (PID.TID 0000.0001)          No. starts:         240
 (PID.TID 0000.0001)           No. stops:         240
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   14.229704618453979
-(PID.TID 0000.0001)         System time:   6.8977475166320801E-005
-(PID.TID 0000.0001)     Wall clock time:   14.237637519836426
+(PID.TID 0000.0001)           User time:   14.223140954971313
+(PID.TID 0000.0001)         System time:   1.4200806617736816E-004
+(PID.TID 0000.0001)     Wall clock time:   14.229609727859497
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.52908098697662354
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-006
-(PID.TID 0000.0001)     Wall clock time:  0.52938342094421387
+(PID.TID 0000.0001)           User time:  0.43745303153991699
+(PID.TID 0000.0001)         System time:   1.3203918933868408E-004
+(PID.TID 0000.0001)     Wall clock time:  0.43769669532775879
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.97060990333557129
-(PID.TID 0000.0001)         System time:   3.7929788231849670E-003
-(PID.TID 0000.0001)     Wall clock time:  0.97464275360107422
+(PID.TID 0000.0001)           User time:  0.97865259647369385
+(PID.TID 0000.0001)         System time:   2.4989247322082520E-005
+(PID.TID 0000.0001)     Wall clock time:  0.97883844375610352
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30726265907287598
-(PID.TID 0000.0001)         System time:   9.9003314971923828E-005
-(PID.TID 0000.0001)     Wall clock time:  0.30750966072082520
+(PID.TID 0000.0001)           User time:  0.29221260547637939
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.29239225387573242
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.49397659301757812
-(PID.TID 0000.0001)         System time:   1.6018748283386230E-005
-(PID.TID 0000.0001)     Wall clock time:  0.49442434310913086
+(PID.TID 0000.0001)           User time:  0.48187422752380371
+(PID.TID 0000.0001)         System time:   1.0903179645538330E-004
+(PID.TID 0000.0001)     Wall clock time:  0.48210763931274414
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.6119451522827148E-002
-(PID.TID 0000.0001)         System time:   1.3992190361022949E-005
-(PID.TID 0000.0001)     Wall clock time:   4.6136140823364258E-002
+(PID.TID 0000.0001)           User time:   4.4572234153747559E-002
+(PID.TID 0000.0001)         System time:   2.5004148483276367E-005
+(PID.TID 0000.0001)     Wall clock time:   4.4646024703979492E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5162745714187622
-(PID.TID 0000.0001)         System time:   3.5533025860786438E-002
-(PID.TID 0000.0001)     Wall clock time:   1.5525424480438232
+(PID.TID 0000.0001)           User time:   1.4519644975662231
+(PID.TID 0000.0001)         System time:   3.5962998867034912E-002
+(PID.TID 0000.0001)     Wall clock time:   1.4883871078491211
 (PID.TID 0000.0001)          No. starts:         160
 (PID.TID 0000.0001)           No. stops:         160
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   15.059634089469910
-(PID.TID 0000.0001)         System time:   5.1021575927734375E-005
-(PID.TID 0000.0001)     Wall clock time:   15.067534685134888
+(PID.TID 0000.0001)           User time:   15.003066301345825
+(PID.TID 0000.0001)         System time:   1.0603666305541992E-004
+(PID.TID 0000.0001)     Wall clock time:   15.007397174835205
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.2104721069335938E-004
+(PID.TID 0000.0001)           User time:   4.1747093200683594E-004
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.2915344238281250E-004
+(PID.TID 0000.0001)     Wall clock time:   4.1198730468750000E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12185132503509521
-(PID.TID 0000.0001)         System time:   5.9999525547027588E-005
-(PID.TID 0000.0001)     Wall clock time:  0.12188982963562012
+(PID.TID 0000.0001)           User time:  0.12512826919555664
+(PID.TID 0000.0001)         System time:   2.0116567611694336E-006
+(PID.TID 0000.0001)     Wall clock time:  0.12520194053649902
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1971931457519531E-004
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   3.3497810363769531E-004
+(PID.TID 0000.0001)           User time:   3.4260749816894531E-004
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.3283233642578125E-004
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.5953722000122070E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   7.5787544250488281E-002
+(PID.TID 0000.0001)           User time:   7.7995777130126953E-002
+(PID.TID 0000.0001)         System time:   3.9339959621429443E-003
+(PID.TID 0000.0001)     Wall clock time:   8.1736326217651367E-002
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6259007453918457E-002
-(PID.TID 0000.0001)         System time:   1.5935003757476807E-002
-(PID.TID 0000.0001)     Wall clock time:  0.10217952728271484
+(PID.TID 0000.0001)           User time:   9.1583132743835449E-002
+(PID.TID 0000.0001)         System time:   1.2055024504661560E-002
+(PID.TID 0000.0001)     Wall clock time:  0.10363006591796875
 (PID.TID 0000.0001)          No. starts:          80
 (PID.TID 0000.0001)           No. stops:          80
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.2610411643981934
-(PID.TID 0000.0001)         System time:   1.9964009523391724E-002
-(PID.TID 0000.0001)     Wall clock time:   1.2816660404205322
+(PID.TID 0000.0001)           User time:   1.2157464027404785
+(PID.TID 0000.0001)         System time:   1.5922918915748596E-002
+(PID.TID 0000.0001)     Wall clock time:   1.2333977222442627
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.27277183532714844
-(PID.TID 0000.0001)         System time:   1.2014001607894897E-002
-(PID.TID 0000.0001)     Wall clock time:  0.28482270240783691
+(PID.TID 0000.0001)           User time:  0.26673984527587891
+(PID.TID 0000.0001)         System time:   1.2048989534378052E-002
+(PID.TID 0000.0001)     Wall clock time:  0.27896308898925781
 (PID.TID 0000.0001)          No. starts:           9
 (PID.TID 0000.0001)           No. stops:           9
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK           [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.11747741699218750
-(PID.TID 0000.0001)         System time:   4.0100216865539551E-003
-(PID.TID 0000.0001)     Wall clock time:  0.12177419662475586
+(PID.TID 0000.0001)           User time:  0.11392593383789062
+(PID.TID 0000.0001)         System time:   7.9749822616577148E-003
+(PID.TID 0000.0001)     Wall clock time:  0.16400814056396484
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_PACK     [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.11560821533203125
-(PID.TID 0000.0001)         System time:   3.9969980716705322E-003
-(PID.TID 0000.0001)     Wall clock time:  0.11961889266967773
+(PID.TID 0000.0001)           User time:  0.11161804199218750
+(PID.TID 0000.0001)         System time:   3.9950013160705566E-003
+(PID.TID 0000.0001)     Wall clock time:  0.11561203002929688
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "GRDCHK_MAIN         [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   52.776988983154297
-(PID.TID 0000.0001)         System time:  0.14396199584007263
-(PID.TID 0000.0001)     Wall clock time:   53.386186122894287
+(PID.TID 0000.0001)           User time:   52.158996582031250
+(PID.TID 0000.0001)         System time:  0.16812002658843994
+(PID.TID 0000.0001)     Wall clock time:   52.365847826004028
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.7369956970214844
-(PID.TID 0000.0001)         System time:   3.5967051982879639E-002
-(PID.TID 0000.0001)     Wall clock time:   3.7759630680084229
+(PID.TID 0000.0001)           User time:   3.6979484558105469
+(PID.TID 0000.0001)         System time:   3.2030999660491943E-002
+(PID.TID 0000.0001)     Wall clock time:   3.7311158180236816
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   49.009090423583984
-(PID.TID 0000.0001)         System time:  0.10796099901199341
-(PID.TID 0000.0001)     Wall clock time:   49.579324245452881
+(PID.TID 0000.0001)           User time:   48.425941467285156
+(PID.TID 0000.0001)         System time:  0.13206192851066589
+(PID.TID 0000.0001)     Wall clock time:   48.585590839385986
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.51087570190429688
-(PID.TID 0000.0001)         System time:   7.9859793186187744E-003
-(PID.TID 0000.0001)     Wall clock time:  0.94960927963256836
+(PID.TID 0000.0001)           User time:  0.49463272094726562
+(PID.TID 0000.0001)         System time:   1.9922971725463867E-002
+(PID.TID 0000.0001)     Wall clock time:  0.51702666282653809
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.35552978515625000
-(PID.TID 0000.0001)         System time:   7.9909861087799072E-003
-(PID.TID 0000.0001)     Wall clock time:  0.36373734474182129
+(PID.TID 0000.0001)           User time:  0.35327148437500000
+(PID.TID 0000.0001)         System time:   4.0419101715087891E-003
+(PID.TID 0000.0001)     Wall clock time:  0.35747241973876953
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   46.501670837402344
-(PID.TID 0000.0001)         System time:   4.4033020734786987E-002
-(PID.TID 0000.0001)     Wall clock time:   46.568268299102783
+(PID.TID 0000.0001)           User time:   45.977874755859375
+(PID.TID 0000.0001)         System time:   5.6133180856704712E-002
+(PID.TID 0000.0001)     Wall clock time:   46.050034999847412
 (PID.TID 0000.0001)          No. starts:          64
 (PID.TID 0000.0001)           No. stops:          64
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.7314147949218750E-002
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:   7.5578212738037109E-002
+(PID.TID 0000.0001)           User time:   7.6187133789062500E-002
+(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
+(PID.TID 0000.0001)     Wall clock time:   8.4799766540527344E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   8.3541870117187500E-004
-(PID.TID 0000.0001)         System time:   9.8347663879394531E-007
-(PID.TID 0000.0001)     Wall clock time:   8.3422660827636719E-004
+(PID.TID 0000.0001)           User time:   8.6593627929687500E-004
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   8.6116790771484375E-004
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.3586158752441406
-(PID.TID 0000.0001)         System time:   2.7990013360977173E-002
-(PID.TID 0000.0001)     Wall clock time:   1.3871238231658936
+(PID.TID 0000.0001)           User time:   1.3160018920898438
+(PID.TID 0000.0001)         System time:   2.4005919694900513E-002
+(PID.TID 0000.0001)     Wall clock time:   1.3403539657592773
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   5.6228637695312500E-003
-(PID.TID 0000.0001)         System time:   1.4036893844604492E-005
-(PID.TID 0000.0001)     Wall clock time:   5.6321620941162109E-003
+(PID.TID 0000.0001)         System time:   1.6957521438598633E-005
+(PID.TID 0000.0001)     Wall clock time:   5.6428909301757812E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001) // ======================================================

--- a/global_oce_llc90/results/output.core2.txt
+++ b/global_oce_llc90/results/output.core2.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
+(PID.TID 0000.0001) // Build date:        Wed Aug 12 18:12:23 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -4562,89 +4562,89 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -1.46974705685466E-01  1.33762099639416E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.47823081867847E+01
+ cg2d: Sum(rhs),rhsMax =  -1.46974701102591E-01  1.33762099639416E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.47823082022917E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     141
-(PID.TID 0000.0001)      cg2d_last_res =   6.64325002939744E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.64325002970090E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2829369845406E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5433303076922E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.4388469550313E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0510379110931E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6549227387739E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.8939135842725E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.7434093528128E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9586101363393E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.4841894649410E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.7974057457539E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.6455503193963E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9442124592385E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2234194688368E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.4134132112185E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7421771757568E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2829371541025E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5433302107090E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.4388467230797E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0510379199312E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6549217185941E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   2.8939156935565E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -2.7434093534254E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9586102647319E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.4841894871820E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.7974042757113E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   2.6455503197363E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9442124571497E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2234193274861E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.4134133613378E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.7421778034044E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5209980752152E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9063716716029E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6543703159251E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915975192357E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2630244740207E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9063716724559E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6543716430573E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915975192340E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2630244329303E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1236607045720E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006897523980E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920460854146E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366238156168E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3103846211154E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006897523984E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920460854140E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366238156171E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3103846186758E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701817293653E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0261095249882E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0261095250325E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611345588E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183957018339E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451188012279E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3313336200503E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5452465823252E+03
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8076264403968E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3605379405461E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8058634625034E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183957018264E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451188005957E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3313336201497E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5452465772410E+03
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8076264449148E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3605379379119E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8058635429573E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1870783737789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402300808046E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1471386232969E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2451057950583E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.9756615718267E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2343720744564E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1262704213132E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8740933790859E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5320849767613E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   7.7487727598731E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.4631979500249E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0910323735632E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.2708450104366E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1159601814038E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   5.2340487564790E-01
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402300808182E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1471386230532E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2451057840578E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   6.9756615024967E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.2343720920405E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1262703550137E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8740934599453E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5320865973634E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   7.7487727272892E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.4631974852958E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0910369814911E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.2708453727606E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1159161553802E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   5.2340487508779E-01
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5853743342117E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -8.4384426777975E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.2201019766437E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5393624947922E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6773136256344E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9591764259509E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6987531897463E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4800971857989E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9118886439716E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5979454588278E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6796836239872E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8331156960749E-07
-(PID.TID 0000.0001) %MON ke_max                       =   4.5258411259819E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   4.1133673880811E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -8.4385447375232E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.2201090273451E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5394920984590E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6773135703307E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9591764507866E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6987531907484E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4800971863527E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9118886439715E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5979454598136E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6796836249893E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8331069744132E-07
+(PID.TID 0000.0001) %MON ke_max                       =   4.5258539001612E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   4.1133674791094E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1185617196228E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.4213491899388E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -7.1263893465368E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.4213491046572E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542346159832E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542346159841E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760527755546E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246696830552E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9306375579137E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.7150404472011E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246696828638E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9306376206043E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.7150432526702E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4655,29 +4655,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0572959353059E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.8167078746235E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.8612697803213E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0572961668537E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   9.8167072887333E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.8612355719474E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.0816250248410E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.1386694940874E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.7452583855470E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.0816364526470E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.1386695888322E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.7452496757443E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5024526865021E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9274806825501E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4404304858243E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8292510728642E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5024526747674E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9274806764084E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4404308397010E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8292510730714E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4822397734755E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2589005912154E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7424777464961E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4822397737300E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2589006023487E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7424762946703E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8159630745076E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5188402391600E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5280275161133E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.0003455462850E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5188402393759E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5280275352815E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   5.0003458498750E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4686,26 +4686,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     1
 (PID.TID 0000.0001) %MON exf_time_sec                 =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON exf_ustress_max              =   8.2706254077132E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.1622581599242E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4769663016750E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.3794523006453E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.3301653482966E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   5.1065588453960E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9421075569251E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9254068881121E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.4037150302010E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.4802893903159E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0746167681734E+03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   8.2706254076454E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.1622581600109E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4769663020548E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.3794523005793E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.3301653477148E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   5.1065588453949E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9421075569262E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9254068875509E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.4037150300238E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.4802893830776E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0746167681560E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5777890722903E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.3631123983538E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5334026129468E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   2.9730448113096E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.3631123994408E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5334026126651E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   2.9730448108756E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9596994233695E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935342722974E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.3355796164772E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4862331970551E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834256583713E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.3355796182855E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4862331970270E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834256577428E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.7909514465496E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.5472462207317E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   4.0259440308204E-01
@@ -4731,16 +4731,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0863231607036E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3142124339145E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4449102036184E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226299430886E+02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226299411880E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0761648575035E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8871619669432E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7654519209058E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4333371402295E-02
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8871619668484E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7654519209243E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4333371402396E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.3963031225247E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.6689805202220E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6046448213313E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.4772429637331E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.4722338566920E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6046448211505E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.4772429635542E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.4722338557966E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8691348354493E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0209653692469E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689458656738E-08
@@ -4774,89 +4774,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.98346437575719E-01  1.31165860336181E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.78966340287414E+00
+ cg2d: Sum(rhs),rhsMax =  -2.98346425248981E-01  1.31165860336177E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.78966351092865E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.32917362123142E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.32917366824127E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5902151157993E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234141596814E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100241081308E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379284858949E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433531912840E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5744483066822E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4878994071172E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728461940518E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359417518262E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383718136773E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5864656337756E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5772926731760E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5460951622654E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838094422226E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931435366632E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8989891142392E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251161206281E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434126540594E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213746516264E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987530192831E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5902153064428E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5234142138160E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5100240457415E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0379284855402E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7433517342293E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.5744313828056E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.4879013496116E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5728462859711E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1359417815354E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.4383709752678E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5864656458018E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5772926542596E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5460934435659E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.1838094555977E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.2931419468241E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8989891142393E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251161206282E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.4434136168903E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6213746512183E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.0987530212134E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1222710237771E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002308879297E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920380579552E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366232204334E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3007629843347E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002308879323E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920380579549E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366232204337E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3007629697122E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699562851827E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0288918844698E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0288918844926E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610141667E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184137900619E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2201121442685E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3210319497847E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8258508812940E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7380830296743E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3468135696151E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400280377636E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184137901142E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2201121335247E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3210319465955E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8258508075069E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.7380830467873E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3468135574460E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400283317082E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1849455478432E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8405072599645E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1429926688056E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2368558159546E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.7434619962840E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1968835489810E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1898818210941E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6699776127285E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6780013517565E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   8.1726355276371E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.8468589124393E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.4633749907108E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4238387091792E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8513239429262E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   5.7330360373610E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.8736297951233E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.6837435134663E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.4243215045596E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5676477242133E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.9749831227015E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1245903057909E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7527316886657E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9960752233858E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2265403250378E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6602383920052E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7474710096473E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691379969079E-05
-(PID.TID 0000.0001) %MON ke_max                       =   9.9293436527262E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3333756575919E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8405072599755E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1429926685961E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2368558168016E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.7434619639410E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1968832585321E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1898817090643E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6699775618508E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6780034085424E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   8.1726356329277E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -5.8468569284151E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.4633755558195E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.4238405318358E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8512226086721E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   5.7330360396107E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.8736297951239E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.6837742061664E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.4243277999789E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.5673992225351E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.9749866649591E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1245903374960E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7527316903407E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.9960782880918E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2265403075710E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6602383944669E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7474710113287E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4691380491367E-05
+(PID.TID 0000.0001) %MON ke_max                       =   9.9292903182721E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3333757062573E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979035714E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0938784277352E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.3293075971785E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.0938694033614E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.3293075908502E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292617E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525964223E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410425692E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729598913382E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636222296724E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541838292656E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525964222E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243410424178E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1729599263539E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4636224735367E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4867,29 +4867,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0086850799613E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.0495722758574E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.1636398787268E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0086848289609E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.0495721803333E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.1636296982785E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5495160274221E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.2020422086414E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.1595846770606E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.5495201324701E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.2020427971803E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.1595261434844E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4920745060339E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9245969272118E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4386198004152E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8287443139695E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4920744925140E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9245969206494E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4386209063886E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8287443143055E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4739078409116E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2565681648271E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7252987455664E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4739078416080E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2565681761392E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7252966584598E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8126036291323E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5097033930164E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5249147710877E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9842298234266E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5097033932661E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5249148016270E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9842302178515E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4898,26 +4898,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     2
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON exf_ustress_max              =   8.7395092646221E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.8535529900266E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.5409209925933E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.6115582061138E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.5228782849043E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   5.6070078284158E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.4232352997439E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.0729257328602E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.7095342896634E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.7171873888685E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1058757018562E+03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   8.7395092641379E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.8535529902871E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.5409209922454E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.6115582061533E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.5228782896212E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   5.6070078284204E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.4232352997430E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.0729257342605E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   7.7095342899844E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.7171873805021E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1058757013885E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5770376042171E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.2506779108212E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5569779887577E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0097862315472E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.2506779019725E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5569779921589E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0097862349184E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.1263204911274E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947255065370E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.0852240176253E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4932097459238E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834179459853E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -2.0852240057256E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4932097466857E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2834179511892E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8143659315325E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6386292701266E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.9995680111159E-01
@@ -4943,16 +4943,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0859175242602E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3091213923571E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4450134252705E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157563255516E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0706584532386E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8870052568600E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7619904853711E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4299739974138E-02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157563193311E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0706584532387E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8870052582788E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7619904893846E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4299739978367E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.5629559171084E-07
 (PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9581136089416E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6296948193119E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5123038383471E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5321680772104E-11
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6296948205018E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5123038389539E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5321680803382E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8682981508973E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0258273948293E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689307363123E-08
@@ -4986,89 +4986,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.43229186209859E-01  1.27904872486847E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.36967565807600E+00
+ cg2d: Sum(rhs),rhsMax =  -4.43229174427041E-01  1.27904872486824E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.36967556404727E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.88784009141309E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.88783991459672E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852435797554E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371647067441E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433207583861E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239322362663E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6943715972380E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0998083666458E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8580665326517E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757932950788E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478448655192E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058941347460E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992064376081E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8025999262904E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9250121752582E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391087858710E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392834181959E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051642E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093199E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7368524714466E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668621164615E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568143592103E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9852435797726E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1371648594110E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2433206987501E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8239322217790E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6943699051951E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0997969191556E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.8580699611505E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0757934041503E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4478448974933E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7058937506016E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.7992070926489E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.8025997910668E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9250129975632E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5391088006849E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.5392817375171E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1346607051645E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3465591093203E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.7368521248466E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3668621050216E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9568143884166E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1210551784617E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661226353E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072971E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260845968E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511365184523E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001661226351E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920405072973E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366260845967E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2511365013211E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697156897790E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0318797488038E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0318797485983E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609342287E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184382253342E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1927566930563E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3096939494550E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3350571892100E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6826174271750E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3588579553094E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2384060658262E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184382253967E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1927566701419E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3096939444137E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3350571518056E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6826173943779E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3588579853860E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2384078123444E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1828127219075E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407189624568E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1397079568199E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2221256477236E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   4.8444611682995E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1532645150341E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0960062586464E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6666087727276E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6622671570899E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   8.6356523069977E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3148202708265E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5790205982737E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.6596922998005E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8748715515116E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.1945932327456E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.2931863274809E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8246903420095E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7334803532792E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1063142799300E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995153452836E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1099979666076E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419693E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3062376814339E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327805582203E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312206E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789214938E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521023576792E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.3316048840203E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.2348147068866E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407189624643E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1397079565585E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2221256554617E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   4.8444612199440E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1532638641681E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0960062665159E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6666089116237E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6622723172676E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   8.6356523109008E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3148200451635E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5790258910777E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.6596922616181E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8748780917214E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.1945932360592E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.2931863274780E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.8247035723223E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   7.7334831397556E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.1061794253568E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.0995195727858E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1103791712364E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7961965419690E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.3062406195459E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3327811328422E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8762256312203E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9694789214935E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4521022779628E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.3315974131798E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.2348147782606E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979310002E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5013291546771E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2237599900537E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.5013213707230E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2237601579493E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956902E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524076729E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720186159E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160966251319E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6605938298897E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541273956951E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524076730E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239720185469E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3160965974326E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6605936287416E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5079,29 +5079,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1111725158506E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337711190034E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8143935390962E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1111722043855E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.2337711952295E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   5.8144058313676E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6533003575814E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853346058567E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8427090465787E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6533016936773E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.3853351572109E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   5.8426568546139E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4809170738964E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9217614478689E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4359207988034E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8282464655762E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4809170530456E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9217614366729E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4359220266624E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8282464659763E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4659438629728E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2542787378088E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7093935678451E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4659438636732E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2542787469309E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7093908140995E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8092477912793E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5006608897798E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5217769066925E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9704020343916E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5006608890591E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5217769422180E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9704026087851E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5110,26 +5110,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     3
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   9.2344675692342E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.6473925103629E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.6381821864417E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9198891571638E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.7897002456990E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.1973395471047E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.9669975185873E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.1709856742956E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1143958770599E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0215486753565E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1371212055746E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5759648456968E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078476700244E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342561061E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564287454116E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961398E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   9.2344675682469E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.6473925098560E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.6381821846920E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9198891576187E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.7897002478805E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.1973395472146E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.9669975185837E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.1709856785005E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1143958781823E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0215486628379E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1371212049870E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5759648456967E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1078476509580E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5854342630310E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0564287446364E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.3076926961397E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1959313010779E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967618022E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671457475E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2983093851801E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7484967347067E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.5071671472182E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2983093940886E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8377804165155E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7300123195215E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.9731919914113E-01
@@ -5155,16 +5155,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0855118878168E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.3049237339092E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4452384486965E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5090023047454E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0610391611114E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867058653098E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7589416067668E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4265976267551E-02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5090022977429E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0610391611115E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867058679461E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7589416129858E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4265976227318E-02
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.7443598489465E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.3273191857036E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6633819829895E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5611002428356E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6183285505398E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -4.3273191857034E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6633819856990E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5611002447636E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6183285497252E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8674614663454E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0306894204118E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689156069507E-08
@@ -5198,89 +5198,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.84050173838804E-01  1.25697846847363E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.10916404308707E+00
+ cg2d: Sum(rhs),rhsMax =  -5.84050178125053E-01  1.25697846847354E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.10916400681810E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.57919988167320E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.57920094278355E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514900176E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125980155718E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560595729621E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068862492546E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6893312645950E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5267298155061E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2153042195729E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646873967420E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820811893995E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8425014229115E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529781E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1332511419587E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354471781587E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819364824366E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6562015889022E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366747940E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851166574E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2070884546504E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769616603508E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161278359698E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1205582170132E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920322462E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137830E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315522131E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857746592136E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0013514900335E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1125981228837E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9560595946550E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4068862319519E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6893292059324E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5267229149507E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2153070712957E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8646874432641E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.6820812208948E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8425009455935E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7117233529768E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.1332270414164E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1354471771520E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.7819364978191E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.6562003841109E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2296366747939E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3128851166556E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.2070877995185E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2769616384082E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161278462192E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1205582170133E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000920322461E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920481137829E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366315522128E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1857745109157E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694681496380E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0349721712134E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0349721707973E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608743669E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184629312460E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1661357905619E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3067404342678E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.0717773910393E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5891695924809E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3742348715489E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2008964849562E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184629313256E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1661357530587E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3067404276699E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.0717757304586E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.5891694750749E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3742349040489E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2008963615187E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409268144304E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1365542220538E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2153583051035E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.8660117549349E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1245278609030E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0372451116611E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6379113678407E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5177464380593E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.1348105059781E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.9128357838762E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.6926660323102E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9715696904424E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1320637594446E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.6912298839077E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.9128743130540E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9473002552148E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1312897661412E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9563933353690E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3880519194623E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0015560907266E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316521802E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6123787735408E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5034277647091E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2601661688341E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372785240E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452267999361E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.6808934165968E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.0314901966410E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409268144320E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1365542216930E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2153583090255E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.8660306052318E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1245270670845E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0372453441288E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6379114667695E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5177427664815E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.1348105069035E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.9128354783921E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.6926710937640E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9715696338934E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1320413142044E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.6912298776669E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.9128743130468E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9473154325370E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.1312910898989E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9562475242271E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3880571356553E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0078587289987E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1620316521799E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.6123812173746E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5034247052864E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2601661688337E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3759372785236E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0452267827119E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.6808864826729E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.0314902763102E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979572533E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7467664078278E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4423531641952E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7467604091658E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4423575666630E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876467593E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523225477E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196519604E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026188757404E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6680610088885E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540876467659E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523225478E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236196519326E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9026188499630E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6680607099861E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5291,29 +5291,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1041820554956E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3468223595255E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8142549756035E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.1041819135679E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3468223608488E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   6.8142650829967E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6719694501925E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956689921719E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8874597765719E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6719692264165E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4956694273841E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   6.8873720878343E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713006617257E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9191237241467E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4226715649393E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8277576073071E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4713006356248E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9191237102428E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4226733559365E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8277576077474E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4582083315534E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2521047306375E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6951252698449E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4582083313506E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2521047363800E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6951220970727E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8059127359744E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4917291076465E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5187740588672E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9572257918500E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4917291064753E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5187740967000E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9572265365296E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5322,26 +5322,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     4
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   9.5970547480660E-01
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.4364361223001E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4894529625444E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8160220421878E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6664086155990E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.4453638277411E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.5031145427106E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2253458350575E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0377375579796E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.9870190905628E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1048775067532E+03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   9.5970547486905E-01
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.4364361228801E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.4894529594345E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8160220430005E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6664086124699E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.4453638281442E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.5031145427007E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2253458414999E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0377375597668E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   3.9870190775144E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.1048775062294E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5711805916621E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516932894272E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794436549056E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532603111569E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877178490E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1516932633015E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5794436641911E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0532603002663E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.1638877178489E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1953168675345E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688493821066E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941367671794E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777138175E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8688493443452E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4941367690991E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2733777201005E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8655087463369E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7050055040743E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.8836561680071E-01
@@ -5367,16 +5367,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0854532945828E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2992477109139E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4444818183202E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5023324959205E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530496700265E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423650647E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322658444E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236187017483E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865974816E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945773E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611590544E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460848194149E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5994548148012E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5023324883091E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530496700266E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8864423685165E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7559322733933E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4236186901244E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6005865974814E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.8035060945764E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6513611628305E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5460848223266E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5994548040157E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8666247817934E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0355514459942E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5689004775892E-08
@@ -5410,89 +5410,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.22692663326199E-01  1.23313465318446E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.04940178251669E+00
+ cg2d: Sum(rhs),rhsMax =  -7.22692688069241E-01  1.23313465318267E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.04940173808012E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   7.05014952239370E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.05015255769260E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558352013185E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368942032834E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577723309168E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793095176438E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6743315392833E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8944943890812E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690525571E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274846765468E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837464662813E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8725057867256E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399847968E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8648367843179E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303177177731E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662446712564E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373634742923E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0558352013176E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3368942032997E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.6577724561486E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7793095068702E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6743294955442E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.8944841596086E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.0511690525513E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1274846463191E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.8837465050714E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.8725054210264E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.5976399847975E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.8648132384674E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4303176635061E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9662446855435E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6373626336430E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1886122267755E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589358867E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9967565854213E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191361199682E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854465296233E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2282589358855E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9967561194616E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6191360953822E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0854465481027E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1199063567496E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001248404E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901184E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404809521E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215815509575E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000001248402E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920578901178E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366404809517E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1215813608750E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692092293856E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0380533054230E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0380533047748E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608317521E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873182882E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416879925246E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027835014706E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0047157101858E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396659293911E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662378151831E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577911545708E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184873183735E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1416879408171E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3027834971464E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.0045891160785E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6396657817119E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3662378568799E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1577909584717E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411340673200E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336241417603E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2090852064955E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1351655989138E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1120703174771E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057289664884E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013337085849E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699749156482E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948572597E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281699171760E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5373608208363E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8723028205796E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9517976278184E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   6.8999768005902E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.4686855382039E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0409380333935E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0553861242355E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8400315472903E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5097446621883E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596818049974E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472413340E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8656584376310E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1463946035425E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378185359E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502540136E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3418640387056E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0687156514284E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.7587517743583E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411340673141E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1336241412792E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2090851722565E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   3.1351665037855E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.1120694802027E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0057292624357E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6013338450253E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3699687183676E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.4838948567879E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.7281693736411E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.5373615018969E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8723027767108E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9517887327089E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   6.8999767615048E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.4686855381889E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0409514446951E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0553877789954E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.8398007062628E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.5097408169892E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.4596805121060E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4177472413333E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8656604066255E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1463885525942E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5297378185351E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6633502540128E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3418640175562E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.0687052188884E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.7587518686026E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979827703E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9655695523177E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6836646781668E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9655630533669E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6836712548677E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661220023E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523297319E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776598446E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2767993643974E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5068118595309E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540661220126E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523297321E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232776598054E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2767993552309E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.5068116963545E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5503,29 +5503,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0686250617686E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235444460058E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7436333155015E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0686248294103E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4235444454637E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   7.7436454967112E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7214392339526E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668228641368E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8739495022452E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7214380865241E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.5668232477713E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   7.8738444131453E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625504079357E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9166185799115E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4009400800399E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8272812549117E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4625503807416E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9166185666184E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4009422643941E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8272812553755E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4505975190546E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2500350654210E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6811240252322E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4505975176300E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2500350673902E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6811209576545E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8025983941197E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4827962317258E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5159061673416E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9424707147290E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4827962319603E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5159062080413E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9424724159757E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5534,26 +5534,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     5
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945423002E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083029219E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417943914343E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770526303E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075019978342E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546632187E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.0611177972871E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2507508244586E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0258392920310E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0158958261752E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0733640778142E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5670986343356E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688227250260E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355247374E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535212914374E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859535642E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0057945423422E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.2505083036813E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.3417943869946E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.7799770537335E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6075019902983E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.7046546642163E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -6.0611177972655E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2507508324887E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0258392942701E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.0158958166787E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0733640774429E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5670986343355E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1688226952141E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5760355352063E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0535212752237E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0316859535640E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1947146923263E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068549629026E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846873904064E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2551448089191E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.9068549191964E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4846873925155E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2551448159438E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.8932370761583E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6799986886272E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.7941203446030E-01
@@ -5579,16 +5579,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0853947013489E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2944037231979E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4438385083419E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4957464098279E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282919931E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704950847E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616386674E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205939756265E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165600226E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897167026E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750390701E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696232678E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5985773829796E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4957464017931E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0455282919933E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8862704988539E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530616464526E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4205939594350E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4684165600224E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3425897166994E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6475750434408E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5400696268332E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.5985773674929E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8657880972414E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0404134715766E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688853482276E-08
@@ -5622,89 +5622,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.59042374055238E-01  1.21310756350857E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.00015367122284E+00
+ cg2d: Sum(rhs),rhsMax =  -8.59042114772611E-01  1.21310756350533E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.00015357485521E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.53656882009818E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53656850006340E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942960962E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271797311689E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478806225066E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685285025033E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6637977965284E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0259161559300E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541687201E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555134797084E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547431524331E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7824176002143E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465043575463E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4817211673655E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830786518281E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926325409445E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873851013695E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046824292E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565039753E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4217681999772E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179391653094E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145355634100E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1375942961104E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4271797311821E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.3478793101968E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9685285167040E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6637962644628E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.0259030423559E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9807541686984E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9555133769181E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0547431980200E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.7824174399380E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3465043575475E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.4817474945173E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2830785519632E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0926325509367E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.4873847160929E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0185046824287E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0802565039688E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4217633630867E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6179391393162E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1145355912871E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192840140288E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880816911E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764890E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518611928E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553149975536E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998880816906E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920680764914E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366518611884E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0553147985495E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689419470061E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410364560306E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031616E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185105870762E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1192245319126E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2993680730220E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0690719167556E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661632627048E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609641584170E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310930543521E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0410364550712E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608031617E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185105871063E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1192244681471E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2993680714734E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.0690876609998E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6661645632488E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3609641469146E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.1310921823610E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413322304772E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1309103082882E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1875742094198E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.6712626030986E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0980049773845E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725595334623E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711230905127E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974049577791E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525520363546E-01
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282166321294E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3678297523328E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8374201171866E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8853670810552E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.1085945391545E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453479819E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0871867034506E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0443851494711E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9149363092678E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3858977304006E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8788112833153E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808965116E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324477640578E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5655712082508E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177159047E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018205381E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992469855724E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.3698389222394E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3541989569258E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413323788775E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1309074939685E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1875823022652E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.6712631211203E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0980041212037E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9725554244873E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5711223782618E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.2974039980744E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   9.9525520311658E-01
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.5282161574105E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.3678270885411E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8374197818210E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.8853143150708E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.1085945023906E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -6.0446453479550E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0871973644350E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0443873540877E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   3.9146559921769E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.3858979517236E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.8788086210042E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5716808965083E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.2324474622618E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5655649142869E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6934177159014E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8404018205347E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.4992469658565E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.3698600350406E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3541990583514E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980078926E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1075559612577E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.8806137810628E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1075478973150E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.8806216393263E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629617352E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523961197E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230148845459E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149929624808E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2101609269225E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540629617502E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523961200E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230148844503E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6149929607506E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2101607173704E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5715,29 +5715,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0322841989359E-02
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849417527448E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5787361495371E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.0322842208137E-02
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.4849416876240E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   8.5787459028192E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7256531567807E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180481127894E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7456139640403E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.7256512895079E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6180484421480E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   8.7455021437430E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550147128904E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142972115911E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3759642673940E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8268173286163E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4550147059618E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142972092062E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3759669818434E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8268173290917E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4431169792643E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480641238807E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6677396501725E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4431169940713E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2480641301302E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6677371906071E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7993069954691E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738894707760E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131614478268E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9273504277200E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.7105054312138E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4738894716630E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5131614889971E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9273531134272E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5746,26 +5746,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0533610297026E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.0751292914040E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.1920978236449E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8121410402650E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6143335943718E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   6.9754450745616E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.6406961718443E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2475183425877E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0785986861128E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.1017497495473E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0425509036791E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5630237585668E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618379100029E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594147667E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585907940984E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171384512E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.0533610296998E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -6.0751292922555E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.1920978179013E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.8121410416508E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6143335837756E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   6.9754450764919E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.6406961718069E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2475183520619E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.0785986887652E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.1017497417610E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0425509034496E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5630237585667E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1618378765115E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5753594262144E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0585907748346E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9119171384511E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1941211875677E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702413398426E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346685305E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955797442E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.8702412908941E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4798346707885E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2509955875997E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9209654059797E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6549918731801E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.7045845211988E-01
@@ -5791,16 +5791,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0853361081149E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2903940562447E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4433086702889E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4892376459153E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0379666247758E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692237824E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503491770433E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177224603250E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794717354E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007330761E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508394715E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867064830E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6172929656896E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4892376351570E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0379666247761E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861692282495E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7503491846533E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4177224421861E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3486794717353E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9394007330652E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6512508443663E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5440867106090E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6172929476058E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8649514126894E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0452754971591E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688702188661E-08
@@ -5834,89 +5834,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.93281344523042E-01  1.19642857671107E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.42681738545532E-01
+ cg2d: Sum(rhs),rhsMax =  -9.93281114042344E-01  1.19642857670449E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.42681620838579E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.50657093879882E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.50657024150098E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217255009556E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719599473921E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0273058011820E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323780510137E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6592919996900E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5593753702634E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237835565E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4854943023628E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897810730962E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5530452915444E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588131848637E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2718602630044E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5639071999583E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582298789362E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2163126770615E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005440768E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237618020E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3916115113210E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503793507573E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138450585812E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2217255009708E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3719599466521E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.0273046346479E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0323780914688E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6592912402111E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.5592682661148E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8506237834983E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4854941350376E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.1897811213247E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.5530454091101E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9588131848668E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2718874181582E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5639070691901E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1582298838784E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.2163126419838E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7272005440746E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8507237617841E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.3916079883461E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5503793281588E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1138450987142E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192003518503E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554775465E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820789E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644691372E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9927057719158E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997554775450E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920769820809E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366644691329E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9927055207975E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686687532166E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439362840448E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773912E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326320801E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989533953318E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962449245121E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237585668E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695363614307E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586511524412E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880471883983E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0439362824132E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607773913E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185326321089E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0989533270787E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2962449258865E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5630237585667E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6695361728143E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3586512077156E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0880471689850E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415255622500E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284268964354E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521172204644E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721414228684E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0837335290346E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420236357128E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456700533150E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902316109753E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820658270E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860459936392E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1932659975281E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8725350851900E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9748361488522E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.3236139944882E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074182346E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1045338089232E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0978874221138E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0626205363346E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0188177900418E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8066792927899E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462859199E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6243054118318E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7951538168621E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893860702541E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204843074E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430857015281E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9032139284800E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.7555987190730E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415255620321E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1284268993539E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1521170148705E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.3721415949227E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0837326593882E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9420240523903E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5456702744753E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1902271576727E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0432820646352E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3860459018027E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.1932605454172E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.8725349102211E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   3.9747622732334E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.3236138779830E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.6405074181918E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1045424525273E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.0978901102885E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.0624145820675E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0188181877513E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.8197553232097E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6309462859094E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.6243044370898E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.7951450582121E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7893831663677E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9146204842963E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5430856968966E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9032390897466E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.7555988181684E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980325994E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1827287823092E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0132246852828E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.1827193207155E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0132325619977E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761403072E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525021077E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228685744160E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867033618150E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9346575626291E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540761403276E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525021083E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228685742394E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0867033875153E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.9346564826222E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5927,29 +5927,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5676216961826E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328755238703E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3461054566347E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   9.5676241921162E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5328754676950E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.3461118177747E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6912729428511E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529741472216E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4811405764577E-05
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6912702083717E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6529744280984E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   9.4810317507475E-05
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465945779352E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120184842735E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3695067638978E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8263657268392E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4465945698542E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9120184835283E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3695104227321E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8263657273221E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357569207015E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461867790350E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6548596560414E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960394127656E-01
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4357569338293E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2461867798784E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6548580230590E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7960394127595E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649915375518E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5105194825351E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9117922717874E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4649915392891E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5105195213270E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9117956999496E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5958,26 +5958,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1024633358141E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.9099628159468E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.0390491503063E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9160983058007E-02
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6924953514964E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   7.3777813863273E-01
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9564202349128E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2150175398329E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1976381287577E-02
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295746872E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124039002695E+03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.1024633358058E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -5.9099628168013E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   6.0390491430698E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   6.9160983075338E-02
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   3.6924953379290E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   7.3777813866326E-01
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -5.9564202348567E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.2150175508959E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   8.1976381318459E-02
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   4.2465295664785E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0124039001241E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.5589638243596E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902678032E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020358404E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676964810087E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263099914E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.1306902303433E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.5775020485847E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.0676964597311E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8151263099915E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1935326777509E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591614067104E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510524764E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557590193443E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =  -1.7591613514479E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.4795510549421E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.2557590271731E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   1.9486937358010E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.6299850577329E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =   3.6150486977946E-01
@@ -6003,16 +6003,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.0852775148810E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.2872206082251E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4428924291636E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828129849342E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187945636E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125084771E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477969398595E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150370338141E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433442275E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204527273E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732708800E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585774590E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495460832E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4828129728134E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0303187945640E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8861125132821E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7477969477457E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4150370141198E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2410433442271E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5886204526968E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   3.6623732764063E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.5581585821874E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   5.6560495260354E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8641147281375E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   3.0501375227415E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5688550895045E-08
@@ -6046,89 +6046,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.12530006886069E+00  1.18154085852529E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.79604998809564E-01
+ cg2d: Sum(rhs),rhsMax =  -1.12529986742064E+00  1.18154085851659E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.79604888861103E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.62997211571649E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.62996732167877E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744428391E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430630752265E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954936236825E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316073183037E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6542023465795E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0982221272274E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174686624E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279699614737E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802506410044E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184657015961E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401972716785E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8660397961926E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249570950075E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751695548867E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8593493178116E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182446770E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221871843E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4811859507218E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5980774239508E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926353450666E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1423744428577E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2430630747802E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6954926041329E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0316073890515E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6542021887249E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0981168435410E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.6424174685324E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9279697524489E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2802506894671E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0184657537764E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4401972716826E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.8660621563645E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3249569506444E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1751695555385E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.8593495294916E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3231182446690E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5252221871461E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.4811960941783E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5980774048753E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0926354001559E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190755067678E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013010156E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144674E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772148177E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368792198676E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996013010110E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920838144685E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366772148137E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9368786780131E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684631335866E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467135714543E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471401E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534492813E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803819856115E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929083218009E+03
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0467135688103E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607471402E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185534493101E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803819258116E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2929083250962E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.5589638243596E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512270444822E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591373266620E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644632726052E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6512268528047E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.3591373857436E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.0644631464464E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316241994E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261771581509E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1523092670668E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834643161026E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0690212786165E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099035259808E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217437833014E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1169247442182E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890611455E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041349530654E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0077830364605E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9785468369225E-02
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1398480017901E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522392275198E-01
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423055540E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0858027075971E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2168843654967E-02
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2300573572439E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7271257398371E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2804626645172E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286555905004E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9070229059085E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4681204540303E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4028141012502E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361808218341E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228881856383E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.3895817951412E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9531123357145E-04
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417316239797E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1261771608708E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1523090762285E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.1834643455776E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.0690203927707E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9099039461094E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5217440449921E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.1169213159284E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.0924890592133E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -6.3041353677544E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   6.0077748184201E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   6.9785468473822E-02
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   4.1398099591933E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   7.5522393821210E-01
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9210423055028E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0858075658262E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   8.2168872297517E-02
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   4.2299050583318E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.7271262411762E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.2961758488434E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1286512525912E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9080979385696E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4681137002011E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4028097674454E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.4361764470456E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5228882044904E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.3896049974075E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9531124296581E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980569238E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2711889827737E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0993283495296E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2726611479373E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0993346326461E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000836835E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261701E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228398266971E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872284906065E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3276481551867E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541000837102E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526261708E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228398264320E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.6872290702039E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   6.3276486059748E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6139,29 +6139,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2489783526474E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679351956634E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9966311085247E-05
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   8.2489844789917E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.5679351503837E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   9.9966341693489E-05
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6327428697719E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744476624374E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0137374440955E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -1.6327391130479E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.6744478475830E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0137254596704E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399639495385E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099227644781E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3409979202498E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266874089E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4399639387198E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9099227636510E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3410018865023E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8259266878933E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285202884565E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443845490714E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6424469665771E-04
-(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927871112480E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561940420794E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079793967223E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8959002568141E-05
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4285202998908E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2443845441577E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6424461257442E-04
+(PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7927871112388E-01
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4561940446833E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079794331434E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8959045769572E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6174,255 +6174,255 @@
 (PID.TID 0000.0001) // Start of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
-(PID.TID 0000.0001)  --> f_gencost  =  1.16966788110521E+04  1  1.00E+00 (thetaatlas)
-(PID.TID 0000.0001)  --> f_gencost  =  1.78494807821327E+04  2  1.00E+00 (saltatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.16966784478713E+04  1  1.00E+00 (thetaatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.78494805937925E+04  2  1.00E+00 (saltatlas)
 (PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
 (PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
 (PID.TID 0000.0001)   early fc =   0.00000000000000E+00
-(PID.TID 0000.0001)   local fc =   1.11803803139429E+03
+(PID.TID 0000.0001)   local fc =   1.11803803189150E+03
 (PID.TID 0000.0001) Writing global cost function info to costfunction.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
-(PID.TID 0000.0001)  global fc =   2.95461595931848E+04
+(PID.TID 0000.0001)  global fc =   2.95461590416638E+04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   91.385783310979605
-(PID.TID 0000.0001)         System time:   1.2350300541147590
-(PID.TID 0000.0001)     Wall clock time:   94.947281122207642
+(PID.TID 0000.0001)           User time:   91.616501195356250
+(PID.TID 0000.0001)         System time:   1.4982559513300657
+(PID.TID 0000.0001)     Wall clock time:   95.908603191375732
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2.4778129886835814
-(PID.TID 0000.0001)         System time:  0.21174800163134933
-(PID.TID 0000.0001)     Wall clock time:   2.6937949657440186
+(PID.TID 0000.0001)           User time:   2.4219340458512306
+(PID.TID 0000.0001)         System time:  0.28635600954294205
+(PID.TID 0000.0001)     Wall clock time:   2.9269249439239502
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   88.907944202423096
-(PID.TID 0000.0001)         System time:   1.0232800543308258
-(PID.TID 0000.0001)     Wall clock time:   92.253453969955444
+(PID.TID 0000.0001)           User time:   89.194546222686768
+(PID.TID 0000.0001)         System time:   1.2118939459323883
+(PID.TID 0000.0001)     Wall clock time:   92.981647968292236
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8153679370880127
-(PID.TID 0000.0001)         System time:  0.40388797223567963
-(PID.TID 0000.0001)     Wall clock time:   6.2213039398193359
+(PID.TID 0000.0001)           User time:   5.8259975910186768
+(PID.TID 0000.0001)         System time:  0.42001003026962280
+(PID.TID 0000.0001)     Wall clock time:   6.2562720775604248
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   83.092553138732910
-(PID.TID 0000.0001)         System time:  0.61939007043838501
-(PID.TID 0000.0001)     Wall clock time:   86.032130002975464
+(PID.TID 0000.0001)           User time:   83.368523597717285
+(PID.TID 0000.0001)         System time:  0.79188197851181030
+(PID.TID 0000.0001)     Wall clock time:   86.725355863571167
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.83727836608886719
-(PID.TID 0000.0001)         System time:   1.8703937530517578E-004
-(PID.TID 0000.0001)     Wall clock time:  0.83750915527343750
+(PID.TID 0000.0001)           User time:  0.85263729095458984
+(PID.TID 0000.0001)         System time:   2.6601552963256836E-004
+(PID.TID 0000.0001)     Wall clock time:  0.85452723503112793
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   3.0250549316406250E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.0236244201660156E-003
+(PID.TID 0000.0001)           User time:   3.0260086059570312E-003
+(PID.TID 0000.0001)         System time:   2.8014183044433594E-005
+(PID.TID 0000.0001)     Wall clock time:   3.0467510223388672E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   80.046506881713867
-(PID.TID 0000.0001)         System time:  0.47535306215286255
-(PID.TID 0000.0001)     Wall clock time:   80.624016046524048
+(PID.TID 0000.0001)           User time:   80.333519935607910
+(PID.TID 0000.0001)         System time:  0.63592296838760376
+(PID.TID 0000.0001)     Wall clock time:   81.207264661788940
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   80.046436309814453
-(PID.TID 0000.0001)         System time:  0.47535306215286255
-(PID.TID 0000.0001)     Wall clock time:   80.623946905136108
+(PID.TID 0000.0001)           User time:   80.333440780639648
+(PID.TID 0000.0001)         System time:  0.63592296838760376
+(PID.TID 0000.0001)     Wall clock time:   81.207194089889526
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99443149566650391
-(PID.TID 0000.0001)         System time:   1.9669532775878906E-006
-(PID.TID 0000.0001)     Wall clock time:  0.99471712112426758
+(PID.TID 0000.0001)           User time:   1.0486078262329102
+(PID.TID 0000.0001)         System time:   7.0333480834960938E-006
+(PID.TID 0000.0001)     Wall clock time:   1.0541343688964844
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.26002025604248047
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:  0.26008844375610352
+(PID.TID 0000.0001)           User time:  0.25872611999511719
+(PID.TID 0000.0001)         System time:   8.0540180206298828E-003
+(PID.TID 0000.0001)     Wall clock time:  0.26725316047668457
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.45521068572998047
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.45733141899108887
+(PID.TID 0000.0001)           User time:  0.45853519439697266
+(PID.TID 0000.0001)         System time:   3.9550065994262695E-003
+(PID.TID 0000.0001)     Wall clock time:  0.47592711448669434
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.45388126373291016
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.45600891113281250
+(PID.TID 0000.0001)           User time:  0.45732688903808594
+(PID.TID 0000.0001)         System time:   3.9550065994262695E-003
+(PID.TID 0000.0001)     Wall clock time:  0.47472286224365234
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   4.7683715820312500E-005
+(PID.TID 0000.0001)           User time:   4.6730041503906250E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.7683715820312500E-005
+(PID.TID 0000.0001)     Wall clock time:   4.3153762817382812E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.9335441589355469E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9352846145629883E-002
+(PID.TID 0000.0001)           User time:   9.5067024230957031E-002
+(PID.TID 0000.0001)         System time:   6.9975852966308594E-005
+(PID.TID 0000.0001)     Wall clock time:   9.5878839492797852E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8714179992675781E-002
+(PID.TID 0000.0001)           User time:   2.9109001159667969E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8736352920532227E-002
+(PID.TID 0000.0001)     Wall clock time:   2.9113292694091797E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   13.834168434143066
-(PID.TID 0000.0001)         System time:   3.8950443267822266E-003
-(PID.TID 0000.0001)     Wall clock time:   13.842002868652344
+(PID.TID 0000.0001)           User time:   13.964002609252930
+(PID.TID 0000.0001)         System time:   2.0202934741973877E-002
+(PID.TID 0000.0001)     Wall clock time:   14.072925806045532
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.9239578247070312
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.9249224662780762
+(PID.TID 0000.0001)           User time:   3.9809789657592773
+(PID.TID 0000.0001)         System time:   1.1382937431335449E-002
+(PID.TID 0000.0001)     Wall clock time:   4.0490210056304932
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   3.6115322113037109
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6124591827392578
+(PID.TID 0000.0001)           User time:   3.6715135574340820
+(PID.TID 0000.0001)         System time:   7.4909925460815430E-003
+(PID.TID 0000.0001)     Wall clock time:   3.7341134548187256
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.0398483276367188
-(PID.TID 0000.0001)         System time:   1.2993812561035156E-005
-(PID.TID 0000.0001)     Wall clock time:   3.0401666164398193
+(PID.TID 0000.0001)           User time:   2.9578275680541992
+(PID.TID 0000.0001)         System time:   8.3209872245788574E-003
+(PID.TID 0000.0001)     Wall clock time:   2.9862022399902344
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.469201087951660
-(PID.TID 0000.0001)         System time:   3.7090778350830078E-003
-(PID.TID 0000.0001)     Wall clock time:   16.477412223815918
+(PID.TID 0000.0001)           User time:   16.628314971923828
+(PID.TID 0000.0001)         System time:   4.0869712829589844E-003
+(PID.TID 0000.0001)     Wall clock time:   16.640476942062378
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.50016975402832031
+(PID.TID 0000.0001)           User time:  0.24976634979248047
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.50017571449279785
+(PID.TID 0000.0001)     Wall clock time:  0.24984169006347656
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4183092117309570
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.4194130897521973
+(PID.TID 0000.0001)           User time:   2.4678134918212891
+(PID.TID 0000.0001)         System time:   7.8139901161193848E-003
+(PID.TID 0000.0001)     Wall clock time:   2.4795565605163574
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31035518646240234
-(PID.TID 0000.0001)         System time:   1.6033649444580078E-005
-(PID.TID 0000.0001)     Wall clock time:  0.31039357185363770
+(PID.TID 0000.0001)           User time:  0.32712459564208984
+(PID.TID 0000.0001)         System time:   8.1956386566162109E-005
+(PID.TID 0000.0001)     Wall clock time:  0.32737708091735840
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56855869293212891
-(PID.TID 0000.0001)         System time:   3.3974647521972656E-005
-(PID.TID 0000.0001)     Wall clock time:  0.56861662864685059
+(PID.TID 0000.0001)           User time:  0.61018943786621094
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.61033606529235840
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3044815063476562E-002
-(PID.TID 0000.0001)         System time:   2.0265579223632812E-006
-(PID.TID 0000.0001)     Wall clock time:   3.3058404922485352E-002
+(PID.TID 0000.0001)           User time:   2.9005050659179688E-002
+(PID.TID 0000.0001)         System time:   3.8809776306152344E-003
+(PID.TID 0000.0001)     Wall clock time:   3.2950162887573242E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.41590023040771484
-(PID.TID 0000.0001)         System time:   1.1913955211639404E-002
-(PID.TID 0000.0001)     Wall clock time:  0.42816734313964844
+(PID.TID 0000.0001)           User time:  0.38789367675781250
+(PID.TID 0000.0001)         System time:   2.3937046527862549E-002
+(PID.TID 0000.0001)     Wall clock time:  0.41191601753234863
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.703849792480469
-(PID.TID 0000.0001)         System time:   3.8880109786987305E-003
-(PID.TID 0000.0001)     Wall clock time:   16.712599992752075
+(PID.TID 0000.0001)           User time:   16.871442794799805
+(PID.TID 0000.0001)         System time:   1.1891961097717285E-002
+(PID.TID 0000.0001)     Wall clock time:   16.899867296218872
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7193298339843750E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.9815902709960938E-005
-(PID.TID 0000.0001)          No. starts:           8
-(PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1059923171997070
-(PID.TID 0000.0001)         System time:   1.5974044799804688E-005
-(PID.TID 0000.0001)     Wall clock time:   3.1126337051391602
-(PID.TID 0000.0001)          No. starts:           8
-(PID.TID 0000.0001)           No. stops:           8
-(PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.3869018554687500E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)           User time:   4.4822692871093750E-005
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
 (PID.TID 0000.0001)     Wall clock time:   4.3869018554687500E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
+(PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   3.0871553421020508
+(PID.TID 0000.0001)         System time:   4.0079951286315918E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0923919677734375
+(PID.TID 0000.0001)          No. starts:           8
+(PID.TID 0000.0001)           No. stops:           8
+(PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
+(PID.TID 0000.0001)           User time:   3.0517578125000000E-005
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   3.5047531127929688E-005
+(PID.TID 0000.0001)          No. starts:           8
+(PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.8459224700927734
-(PID.TID 0000.0001)         System time:  0.21990597248077393
-(PID.TID 0000.0001)     Wall clock time:   4.0748059749603271
+(PID.TID 0000.0001)           User time:   3.6302986145019531
+(PID.TID 0000.0001)         System time:  0.30793702602386475
+(PID.TID 0000.0001)     Wall clock time:   4.0299000740051270
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4075088500976562
-(PID.TID 0000.0001)         System time:  0.23193597793579102
-(PID.TID 0000.0001)     Wall clock time:   1.7034130096435547
+(PID.TID 0000.0001)           User time:   1.4191818237304688
+(PID.TID 0000.0001)         System time:  0.23992598056793213
+(PID.TID 0000.0001)     Wall clock time:   1.6599371433258057
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.38598632812500000
-(PID.TID 0000.0001)         System time:   3.1870961189270020E-002
-(PID.TID 0000.0001)     Wall clock time:  0.42749404907226562
+(PID.TID 0000.0001)           User time:  0.40615081787109375
+(PID.TID 0000.0001)         System time:   2.3967027664184570E-002
+(PID.TID 0000.0001)     Wall clock time:  0.47462010383605957
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.8909912109375000E-004
-(PID.TID 0000.0001)         System time:   5.0067901611328125E-006
+(PID.TID 0000.0001)           User time:   3.8146972656250000E-004
+(PID.TID 0000.0001)         System time:   5.9604644775390625E-006
 (PID.TID 0000.0001)     Wall clock time:   3.8695335388183594E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.8157424926757812
-(PID.TID 0000.0001)         System time:  0.11195898056030273
-(PID.TID 0000.0001)     Wall clock time:   4.1360750198364258
+(PID.TID 0000.0001)           User time:   1.7680282592773438
+(PID.TID 0000.0001)         System time:  0.13166904449462891
+(PID.TID 0000.0001)     Wall clock time:   4.1509649753570557
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.3996353149414062
-(PID.TID 0000.0001)         System time:   9.1961026191711426E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6358230113983154
+(PID.TID 0000.0001)           User time:   1.3671722412109375
+(PID.TID 0000.0001)         System time:   9.9537014961242676E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6977729797363281
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.41608428955078125
-(PID.TID 0000.0001)         System time:   1.9997954368591309E-002
-(PID.TID 0000.0001)     Wall clock time:   2.5002331733703613
+(PID.TID 0000.0001)           User time:  0.40083312988281250
+(PID.TID 0000.0001)         System time:   3.2132029533386230E-002
+(PID.TID 0000.0001)     Wall clock time:   2.4531750679016113
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   9.9945068359375000E-004
-(PID.TID 0000.0001)         System time:   1.4066696166992188E-005
-(PID.TID 0000.0001)     Wall clock time:   1.0058879852294922E-003
+(PID.TID 0000.0001)           User time:   1.2893676757812500E-003
+(PID.TID 0000.0001)         System time:   2.0980834960937500E-005
+(PID.TID 0000.0001)     Wall clock time:   9.7060203552246094E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================

--- a/global_oce_llc90/results/output.ecmwf.txt
+++ b/global_oce_llc90/results/output.ecmwf.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
+(PID.TID 0000.0001) // Build date:        Wed Aug 12 18:12:23 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -4516,89 +4516,89 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -5.89140516204759E-02  1.31464430486456E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.47659836370240E+01
+ cg2d: Sum(rhs),rhsMax =  -5.89140477411995E-02  1.31464430486456E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.47659837690463E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     141
-(PID.TID 0000.0001)      cg2d_last_res =   6.64506082904171E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.64506025863361E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2250774858912E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5455737119153E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9818233788026E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0519212918957E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6315297255727E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5818549968409E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.4007815400268E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.8961407340341E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6938425416341E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.9088300259206E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.0885192875182E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9447436495395E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2333627273355E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5843277497163E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8353483974550E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.2250782877225E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5455732669574E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.9818231824581E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0519213083269E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6315294155717E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5818549971841E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.4007797840450E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.8961407911661E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6938425838356E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.9088272042212E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.0885194879751E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.9447436477066E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2333625793815E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.5843278573816E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8353499818263E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5211289297434E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9057617573682E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6127427369456E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6920878380405E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2669233915718E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9057617584091E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6127443738095E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6920878456290E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2669233093204E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1233044478864E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006925518286E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920420050545E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366017375270E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3115588881279E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006925518271E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920420050537E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366017375273E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3115588867177E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701869665075E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0265447233098E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0265447232469E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611701369E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183711433177E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2447932293714E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.5233619379673E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183711433316E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2447932279609E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.5233618718954E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4511655522929E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -7.8218577950735E-01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0594227507445E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.4513610813757E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -7.8218598757170E-01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0594227443292E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.4513613928640E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.0351378290490E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7555691894310E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7866254080579E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5036033733093E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8440615776353E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9819507243961E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.5230451577455E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5381569299528E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.0197647064113E-06
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7555691894122E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7866254080736E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.5036033757667E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.8440618240736E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.9819507505221E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.5230445965304E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5381568386629E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   1.0197647160629E-06
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7296464770212E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8167594409082E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3609460247054E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1376192238624E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.7564168888665E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.1571511091293E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.2199235862291E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.0622993666782E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1076759272896E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3639808707676E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6905400786154E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9549808348860E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6959206392182E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9457909740421E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5898897256143E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5949584891739E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6768510734591E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -6.8770571882725E-07
-(PID.TID 0000.0001) %MON ke_max                       =   2.0170591744083E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.3543995643591E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8167589594346E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3609470755749E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1376192709577E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.7563948306805E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.1571511371507E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -7.2199115891346E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.0621985704493E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1076763092747E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3640981537265E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6905399746512E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9549809015244E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6959206400862E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9457896172205E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.5898899016238E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.5949584899947E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6768510743271E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -6.8770487597785E-07
+(PID.TID 0000.0001) %MON ke_max                       =   2.0170584771190E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.3543996427908E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2536262799494E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.9089261971882E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.2536257543933E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.9089256734959E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542349970251E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542349970259E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760527755546E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246676593569E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9324383852468E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4454680288111E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246676591183E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9324384780118E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4454735621283E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4607,31 +4607,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     1
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   6.9027976410772E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -9.2815475308318E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6915142447324E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   3.1718688496212E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5375743206952E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   7.7143451398072E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.3817860801969E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1644892069336E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.1128642572964E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3554101584226E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   6.9027976410771E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -9.2815443353640E-01
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6917069527503E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   3.1718677950031E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.5375748924531E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   7.7143896538789E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.3817860801548E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.1644087419086E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.1128794669888E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3554169316795E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5636615607441E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9573039019293E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4343247707954E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8300420938059E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5636615816607E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9573039126839E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4343259069638E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8300420868020E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4873038322942E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2609767245650E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7147517977440E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4873038324460E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2609767298963E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7147514489021E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8190910111795E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5181730796114E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5275710254980E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9462326061068E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5181730815496E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5275710356959E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9462329428358E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4650,16 +4650,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.3676690098333E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1243215476666E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5099646428395E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3787773654377E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3787773654136E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -6.4790185087149E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   7.5589063465376E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3816907296301E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1070536214541E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   7.5589063358728E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3816907295187E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1070536206376E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9947461553270E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.0629814892892E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.3791687192546E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.4392311897482E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.1235932911805E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.3791687176516E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.4392311897151E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.1235932911384E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8558225299134E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   1.0088437682558E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0219492112999E+00
@@ -4677,14 +4677,14 @@
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4949215076321E-05
 (PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2710385599680E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1404423392578E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7174446854059E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8102794400445E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0669512364128E-01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7174446852203E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8102794398251E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0669512362775E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2687483075050E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.0716540391163E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2175242204691E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7396207229149E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7260138431567E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.0716540391738E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2175242203088E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7396207229590E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7260138422709E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.5566883251364E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -2.0080626496280E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6749569332377E-08
@@ -4718,89 +4718,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.19688486635188E-01  1.26290039336226E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.86194901966413E+00
+ cg2d: Sum(rhs),rhsMax =  -1.19688482578459E-01  1.26290039336263E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.86194935125980E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.41810111120125E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.41809422574732E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.4916083240376E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5341286394237E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.0578065470911E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0406778434068E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7162193527306E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8845838178572E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0352557067617E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5572967270154E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1625913197733E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5832431784956E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7710204833805E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5538791320226E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7319236671587E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2065457264705E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4121545118978E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8992772067893E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3234476889855E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3698317929361E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6218467992600E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1026221703838E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.4916084253240E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5341287258687E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   6.0578063417735E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0406778383577E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7162180815832E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8845838156174E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0352555979204E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5572967964997E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1625913364931E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5832425304701E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.7710209401711E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5538791189480E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.7319219771462E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2065457642181E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4121513342928E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8992772067895E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3234476889876E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3698329548348E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6218467929682E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1026220931895E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1213683154668E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002439203207E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307598253E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002439203158E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307598250E+00
 (PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365804699329E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3029170768322E-05
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3029170526358E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0699647638151E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0297872773455E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610891714E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183483020406E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2172871220557E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3806214443639E+03
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0297872771188E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610891713E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183483020576E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2172871142168E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3806214722052E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.4790185087149E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -3.5237274972250E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1220922117650E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.2745581507375E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -3.5237274653656E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1220921882480E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.2745467441685E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.1565804996112E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7870020560167E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8702987274190E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.4985225184040E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7226247858035E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6474972903373E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7921852226924E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5407424604806E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.7411433592239E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.7870020559598E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8702987274534E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.4985225040951E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7226251344720E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6474973626088E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7921851970362E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5407420676717E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.7411049184826E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5899234024015E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2975240760430E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4294363601113E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1055054737660E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9048669851907E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.2975242815272E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4294359545802E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1055055824882E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.9048838997116E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.0806687658770E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.9273030279997E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4462849254527E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1183102339951E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.5539427755138E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0965467681066E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.3104126994360E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7532049487796E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9992705551804E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2049209349524E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6606893541811E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7479436370724E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4568725064938E-05
-(PID.TID 0000.0001) %MON ke_max                       =   4.8780133970881E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3888871306869E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4462643111434E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1183109828553E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   7.5538418761988E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0965459325349E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.3104076944171E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7532049358011E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.9992697141789E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2049209228797E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6606893418970E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7479436241017E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4568726094801E-05
+(PID.TID 0000.0001) %MON ke_max                       =   4.8780124512624E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3888871936419E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978876146E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4340300448275E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.0874772511261E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4340289205370E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.0874769265248E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541846685110E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526217662E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243370890704E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1814545340190E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4169478414800E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541846685137E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526217661E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243370888665E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1814545723930E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4169480474165E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4809,31 +4809,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     2
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON seaice_uice_max              =   9.4517609650786E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.2939691411632E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8211395914305E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.1370722466705E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7407539475785E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0931924915522E+00
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.6810610405776E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.6612282472277E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.5395678466941E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4035783418251E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   9.4517611031471E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.2939689174090E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.8212719825337E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.1370766102657E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7407542914453E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0931928921176E+00
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.6810550430523E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.6611682185934E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   3.5395950701642E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4035627931634E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5553276391669E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9558377590263E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4451293600320E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8303187105513E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5553276580274E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9558377660937E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4451314991361E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8303186964743E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4843126584249E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607745429863E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6912248930182E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4843126582417E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607745398295E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6912232104675E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8187448763248E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5047422172168E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5223457729906E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9101505541713E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5047422286696E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5223457787129E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9101495295745E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4852,16 +4852,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6627740987673E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1380292359207E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8647225187899E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4784767492732E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4784767492154E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -7.7084629272701E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   4.9588257102397E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5559065251890E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2921783691649E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   4.9588257186561E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5559065254123E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2921783676457E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.9897065761924E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.0707600314396E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7379181953976E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6722394214771E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2715482810571E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7379181962641E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6722394214914E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2715482808955E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.9662385819350E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   6.7645036785843E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0288462093920E+00
@@ -4877,16 +4877,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1077737181743E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7235707829470E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943555151673E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2931647028203E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2088942452120E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7415531833980E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8363761191190E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0742930422302E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.2931647028204E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2088942452121E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7415531834081E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8363761186451E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0742930422306E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2646032027147E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1711878434119E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2285726648315E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7563030681170E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8070271146787E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.1711878436694E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2285726649181E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7563030682251E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8070271118008E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.8974578178756E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.0040313248140E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6501756512671E-08
@@ -4920,89 +4920,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.79846042118140E-01  1.22134604221502E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.46406753623172E+00
+ cg2d: Sum(rhs),rhsMax =  -1.79846055949690E-01  1.22134604221800E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.46406781095243E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.97333052912414E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.97332942908413E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9894472617826E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1516516021007E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.1025675237472E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8296430334592E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6657374818890E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2121742522497E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2015551110950E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0535501347166E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4754360484053E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8853306351716E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.2361244310937E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0587384279786E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6753477513522E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5636311458469E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6973101869843E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351248392942E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438935914186E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6510444904735E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3674138339227E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9580159673837E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9894472618821E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1516518707046E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   9.1025682238147E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8296430169155E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6657353895126E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2121730692465E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2015545437632E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0535501768318E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4754360789435E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8853301434280E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.2361268186048E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.0587384261113E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.6753482263750E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5636311966084E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6973062704802E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1351248392946E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3438935914171E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6510440395007E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3674137775075E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9580158261778E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1198300696375E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001666226909E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307698999E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365644986572E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2549104340722E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001666226919E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920307699003E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365644986565E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2549103501362E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0697287354658E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0332725839920E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0332725838768E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610458411E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183305031900E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1882153337021E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3905941630858E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183305032126E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1882153063925E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3905941945368E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.7084629272701E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.1089375023244E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3079231741125E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1739455162782E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.1089365296311E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.3079231937280E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1739484882306E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.0593549145477E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8183887297628E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0822004864371E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8484095125097E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6585630484902E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6578821528380E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7029417916108E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5423647477800E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.4293267524684E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8183887296412E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0822004864988E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.8484095298522E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6585630594544E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6578822340844E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7029443794976E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5423647371656E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.4293306741761E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7707957663300E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.4427091658100E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4258716768006E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1044989072211E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4696944461730E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.4427083814736E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4258708513144E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1044989454742E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.4696906512557E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.2153963510475E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4076876459203E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8472842421178E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1372133841747E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.0854061543629E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3660287175436E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5565386491881E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7984765532231E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2842419103134E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5863429937430E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8786037710190E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9717955980918E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4565621904181E-05
-(PID.TID 0000.0001) %MON ke_max                       =   6.6169254302184E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3093819675325E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8472794918936E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1372141337795E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.0852799709837E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3660242614426E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.5565467121385E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7984765532235E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2842375266228E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.5863450849739E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8786037710193E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9717955980922E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4565622402513E-05
+(PID.TID 0000.0001) %MON ke_max                       =   6.6169205938426E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3093820894288E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978986271E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5252847249847E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.5834374514912E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5252841330230E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.5834357595188E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541286060065E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524680313E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239637642970E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3273170475086E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6013701458443E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541286060118E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524680315E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239637642386E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3273169786864E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6013698752564E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5011,31 +5011,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     3
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   7.8486234992960E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.6457144016200E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.0414383734692E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7043223728035E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8615493892800E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   8.1117414948192E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.9555923663387E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4504016879320E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.1503556944008E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4245596805914E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   7.8486231429766E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.6457143221732E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.0497211348255E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7041977908034E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8593876751450E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   8.1117413142442E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -5.9556082066280E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.4503581627073E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.1503931903211E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4245439591456E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5462191525472E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9543234916853E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4519209479411E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8305960839805E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5462191714306E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9543234984268E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4519240332899E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8305960625334E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4813629627396E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606596786173E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6726962753078E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4813629614839E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606596653392E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6726937477901E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8182992609085E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4911411271732E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5173006451313E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8865034476762E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4911411399710E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5173006423048E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8865006296398E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5054,16 +5054,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.9578791877013E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1587407852827E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   9.4837461086138E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5816987827334E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5816987825189E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -8.9304796726687E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.4057204027878E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8167486551626E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5759867556353E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9834911056969E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.4057204363412E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.8167486557316E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.5759867538979E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9834911056970E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.1862228750185E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.1048805076034E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0382910374242E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5164973332112E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.1048805119273E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   9.0382910374621E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.5164973330201E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   3.1023215152125E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.4405696746102E-02
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0357432074842E+00
@@ -5079,16 +5079,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1072639590902E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7228877080768E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4943211487414E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3152906999907E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2836928126932E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7656152741699E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8805373913199E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0846464068818E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2673489980902E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2989438766403E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2404423928002E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7871477291659E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9311216796575E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3152906999910E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.2836928126933E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7656152744877E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8805373908095E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0846464069920E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2673489980901E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.2989438772368E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2404423932326E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7871477293543E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.9311216761295E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.2382273106148E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6253943692965E-08
@@ -5122,89 +5122,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.40005906457826E-01  1.19788297505574E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.22201794223906E+00
+ cg2d: Sum(rhs),rhsMax =  -2.40005894261319E-01  1.19788297506492E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.22201781172412E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.66621635082819E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.66621005529504E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0022978971686E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1299918192160E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.2147445358824E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4160334780253E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6584005993840E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4285343599218E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2348132656024E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8395404119372E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7120793429858E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.0543770910814E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3141193822337E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.6833580747708E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1048494989750E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8071103185675E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.8639102661530E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303499394513E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093734158085E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1245838133680E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2795586703660E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161598624233E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0022978971864E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1299920474162E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.2147444741525E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4160334666282E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6583983283121E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.4285354095664E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2348127381359E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8395403425140E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7120794003024E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.0543770522821E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3141195941591E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.6833774065034E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1048494486269E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8071103583052E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.8639051916654E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2303499394517E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3093734158093E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1245829113775E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2795585744563E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0161598435473E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190094577669E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000937096784E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920367869571E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365532121681E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1895605492909E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000937096788E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920367869578E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365532121671E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1895603490114E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0694842628172E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0369494166770E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610198146E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183158528586E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1607910430787E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3874677893888E+03
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0369494192208E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610198147E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183158528722E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1607909948500E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3874678368811E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.9304796726687E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.6145562868470E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.5859421751258E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1430177494870E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -8.6145572012053E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.5859421295941E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.1430106805935E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -9.2659486649252E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8497564584204E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3884716129153E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.5157611685854E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6234356167860E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6327947880545E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7032758119277E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5573784963670E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.3101044031847E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8497564582057E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.3884716130379E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.5157613357634E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6234356388138E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6327949102435E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.7032720464546E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5573777618855E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.3100796653641E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.9027013207119E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1826879336508E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4255117392415E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1054509645565E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.9426120084526E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1826885454527E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4255105040038E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1054510997254E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.9425801968664E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3501239362180E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -5.5651624980893E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0275105060902E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1540644060893E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7408046638346E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5253366682595E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.2238452435040E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653690733623E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.5412228420127E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4675505426470E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636475329814E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   4.0274923626582E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1540651026271E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.7406381096700E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5253327075773E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.2238452025217E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1653690733622E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.5412187663562E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.4675507261584E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2636475329813E-01
 (PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3793467785744E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0487330759296E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.1997946559273E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1223476735473E-04
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0487330763783E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.1997893526432E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1223478331497E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979095277E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5239910307419E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.6826243429860E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5239914507779E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.6826227699055E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540891261651E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524200570E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236052403324E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9119080408268E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6065725478963E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540891261746E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524200575E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236052403148E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9119079686141E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6065722967192E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5213,31 +5213,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     4
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7632020891897E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9079447905405E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -8.9566201571909E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9535697141897E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9284738587451E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   8.8051743116044E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -6.1637924601700E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2383713730635E-03
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.5356807345447E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4618743901449E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7631968319170E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9079426738496E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -8.9569242697220E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9535782994211E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9284777552132E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   8.8051752045546E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -6.1638085823752E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.2392817934161E-03
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.5355428246456E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4596619687277E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5378088473597E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9528014034320E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4733564138381E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8308740081282E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5378088464819E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9528014010780E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4733609888395E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8308739792006E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4784249171322E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606659070311E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6560887118682E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4784249171094E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2606658891693E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6560863385447E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8174618311634E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4772151335526E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5123236667828E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8646949054774E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4772151534295E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5123236573662E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8646905692442E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5256,16 +5256,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.8739079370912E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1469991562767E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.8335678507370E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5013990200199E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.5013990192384E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -7.5891368288968E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.9815020109478E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5441516981387E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2817272965571E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0058955779971E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.9815019140261E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.5441516997085E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2817272937822E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0058955779973E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.3119253644247E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8844545089824E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7879766554715E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3143029512949E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8844545222928E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7879766555346E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3143029512387E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.8848542238091E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   3.3040566798063E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   7.0151300912066E+00
@@ -5281,16 +5281,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1055539123253E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7073963366029E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4901468161263E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3168717701170E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1720930269827E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7634496940722E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8413648281029E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0809026132884E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3168717701178E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1720930269829E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7634496953870E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8413648279762E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0809026128575E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2760420250701E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022403144793E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2390604511349E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7428644298623E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8252088123471E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.8022403152924E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2390604524660E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7428644300067E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.8252088104666E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.3634510524544E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6461002487747E-08
@@ -5324,89 +5324,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.97742219301352E-01  1.18136806742891E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.16199255980500E+00
+ cg2d: Sum(rhs),rhsMax =  -2.97742167052455E-01  1.18136806746158E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.16199200628875E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.46547943353972E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.46547184209406E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0568914611171E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3443002331539E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5069659715291E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7914337548741E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6437774803047E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7766224397490E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2022143110926E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1019930712575E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9167712781425E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1193686948248E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3513903868384E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6852947242566E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3940783040307E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9917135616531E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.9034672335712E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896440932067E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243043399561E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9154448056448E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6252632652533E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0857879096156E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0568914611948E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3443002330554E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.5069657070807E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7914337548928E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6437754983091E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7766224203145E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.2022138605468E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1019929008464E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9167713663744E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1193687398505E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3513686564040E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.6853298549739E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.3940781911369E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.9917135925788E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.9034595097089E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1896440932074E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2243043399550E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9154440038968E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6252631430728E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0857878912113E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1187092658342E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000030710847E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920459821068E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365515689670E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1261949886291E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000030710826E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920459821077E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365515689652E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1261946828179E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692241849446E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0406960911471E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0406961029451E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610108022E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183037816029E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1362250848284E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3854909201861E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183037815315E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1362250332842E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3854909951260E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -7.5891368288968E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3348477057277E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2919261593888E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.0408537358629E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.3348478468132E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.2919260894705E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   3.0408463204098E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -8.1497703549041E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949176524975E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0597314377133E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9059611386477E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6387160396942E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6376920021870E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.3526627022226E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5197703299798E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.0142011564182E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8949176520717E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   2.0597314381381E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.9059613463768E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6387153957710E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6376921969980E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -8.3526569078753E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5197693545072E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   9.0141750909297E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7960612181076E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1120836156092E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4084828695510E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0769527326940E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.5318258758821E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.1120834834212E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.4084806484074E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0769528812065E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.5317142429490E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3447743192386E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4291134422033E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8700367655060E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1412151609163E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3747066801166E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8476482555828E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1136377304479E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222392636836E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2893354529975E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.5149657309789E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344239875206E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679757032578E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3482522466315E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.0437487268732E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.8654260235483E-04
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4292563600657E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.8700219064377E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1412159175254E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3743315769221E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.8476536166978E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.1136379268458E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4222392636846E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.2893319716950E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   5.5149468622599E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5344239875217E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6679757032589E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3482522396920E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.0437441022692E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.8654262339191E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979204288E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5389024997003E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.5854034053936E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5389038728180E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.5854020617158E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540678114310E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524611307E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232563472726E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2824267787255E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4459843388276E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540678114469E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524611314E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232563471986E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2824267235319E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4459843742382E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5415,31 +5415,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     5
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.9061053631640E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9490117556483E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -9.1997141654685E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   5.0127375337298E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9743449121668E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   9.3855011472002E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.1508332265356E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1796222295592E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6816100420629E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5358048088490E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.9061069653805E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.9490086141605E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -9.2001067590854E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   5.0127483390238E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9743442931373E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   9.3855015220770E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -7.1508541216663E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   9.1796350499396E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6816485190502E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5357890724922E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5290624451058E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9513299101232E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4616111661819E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8311529787119E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5290624503407E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9513299122052E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4616180289904E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8311529421527E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4755808296647E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607935584596E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6406635748570E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4755808310908E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2607935406552E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6406617522337E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8170457902006E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4645230433287E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079691365598E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8434464056343E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4645230864623E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5079691318450E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8434412851955E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5458,16 +5458,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7899366864812E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1419459236811E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.4517337306647E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4235379577071E+03
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.4235379570116E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -6.3824595097354E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3098792189418E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3764461924179E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1144208016852E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -6.3098790365885E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3764461952943E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.1144208044572E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   2.0268554198432E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.4382817221068E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6749883194329E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6849619203872E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052625241180E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6749883450425E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.6849619206159E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2052625241428E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.6673869324057E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.1954436301909E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9945169749291E+00
@@ -5483,16 +5483,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1038438655604E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6937182364123E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4865810313694E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3184530964184E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281934575939E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7615789324731E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8168203270595E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0797337161957E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437416477E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510434056961E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2387744903768E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7130066859586E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7587927743171E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3184530964199E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1281934575943E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7615789352219E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8168203281442E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0797337184830E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2835437416476E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -1.7510434064108E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2387744929378E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7130066858535E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7587927797172E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.4886747942940E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6668061282529E-08
@@ -5526,89 +5526,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -3.52587480157008E-01  1.19855749451445E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.10752047697384E+00
+ cg2d: Sum(rhs),rhsMax =  -3.52587392095969E-01  1.19855749456998E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.10752027119077E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     127
-(PID.TID 0000.0001)      cg2d_last_res =   7.07363617490756E-06
+(PID.TID 0000.0001)      cg2d_last_res =   7.07363373847024E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442198166644E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4345565059978E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.7845548939293E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9824222046860E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6354373600168E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3246028840807E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0940110554042E+00
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9316302561697E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0890761806101E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0699399077914E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9150045556204E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5657848315344E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2416434268758E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1184863332441E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8215776859682E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199447982928E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763002235152E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.5755425381968E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6269401807627E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154900256143E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1442198167021E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4345565058477E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.7845544482259E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9824222307831E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6354358311762E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.3246029266158E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.0940094671813E+00
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9316299935059E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0890762920993E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.0699387097792E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9149793788714E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5658338849172E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2416432530076E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1184863553175E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8215685180688E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0199447982922E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0763002234992E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.5755348141633E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6269400374598E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154899998576E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1178154506836E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998915673985E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920566332277E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365586894216E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0613841728561E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998915673900E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920566332287E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365586894189E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0613838640301E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689476169931E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0444125769068E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0444126049908E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610161495E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182929181057E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1140247279450E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3791251789481E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182929175748E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1140245345520E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3791252922370E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -6.3824595097354E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8029831710688E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1089818553382E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9810886579937E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.8029832749492E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1089818409513E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9811055451791E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.5483533497909E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400438173719E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437630732486E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6259264445515E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6784583325970E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6309787146070E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.9344166986206E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4923816162553E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.8723548037349E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9400438166525E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8437630743900E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.6259275128232E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.6784576658938E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6309790110849E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.9344115177239E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4923812552116E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.8723999121367E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6894211155033E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0522192404372E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3909156294945E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0551608102692E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2091851591945E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -2.0522149192141E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3909129644800E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0551609108432E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2091068390481E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3394247022593E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4103276922723E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7318847310878E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1350781736538E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1818186739797E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5381923828758E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0218569646577E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775559237470E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.4532646044622E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.1576353634910E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995474465442E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8464971371962E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5069881563313E-04
-(PID.TID 0000.0001) %MON ke_max                       =   6.1275381039337E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4724518231493E-04
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4104398251037E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.7318718114519E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1350790334897E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1816535449267E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.5382029476333E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.0218571860501E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5775559237464E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.4532523324948E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.1576352367099E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.6995474465436E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8464971371955E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5069881495471E-04
+(PID.TID 0000.0001) %MON ke_max                       =   6.1275264893820E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4724520731806E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979308908E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4380288785603E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2627052659351E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.4380290065310E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.2627005293257E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540648084570E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525594528E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229868866701E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6160453048313E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1494624919035E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540648084816E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525594537E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7229868864916E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6160452604379E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1494628050882E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5617,31 +5617,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     6
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7429374337762E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8972966250028E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.9457498029771E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9646506462470E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9769321283462E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   9.9430121280081E-01
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -8.1526570895000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   6.0041899993219E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.7350719352716E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6060091039449E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7429406232899E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.8972961564208E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -7.9490060779656E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.9646281156377E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9746857109310E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   9.9429903213196E-01
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -8.1526939968128E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   6.0043712105043E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.7351097287081E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6059987986722E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5219244204720E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9499978781234E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4625016118900E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8314329670568E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5219244853659E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9499978930457E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4625096838918E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8314329227240E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4728435459670E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2610036684906E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6262996444967E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4728435495869E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2610036514986E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6262982464229E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8166566984709E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4534484419154E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5045287385380E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8236498070391E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4534484810723E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5045287322020E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8236435722246E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5660,16 +5660,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.7059654358712E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1436697477044E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.3750275518406E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3500514938900E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302680100153E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0583641758498E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3355262408929E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0884472751310E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437045508E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.3500514932049E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.7302680100150E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.0583641515290E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.3355262453727E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.0884472757565E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0478437045509E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.5653315588947E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4759934434907E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7343128185127E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2032120804415E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.4759934778059E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.7343128191089E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.2032120806645E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.4499196410023E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.3180892612649E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9739038586515E+00
@@ -5685,16 +5685,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1021338187955E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6818665029210E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4836281822693E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3200352992506E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461429317252E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7598661493427E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8073110088421E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0811389698423E-01
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946589481E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881864883307E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2395356609795E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6977774862085E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7306652798671E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3200352992523E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1461429317255E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7598661528984E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8073110110520E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0811389706660E-01
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2904946589480E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.0881864892018E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2395356644110E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6977774863607E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7306652881499E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.6138985361336E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.6875120077310E-08
@@ -5728,89 +5728,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.04590174088916E-01  1.21492254456750E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.04163917221775E+00
+ cg2d: Sum(rhs),rhsMax =  -4.04590823378709E-01  1.21492254468136E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.04163996633377E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.44825196492215E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.44823852814798E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379036163834E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3804467408099E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.0477567010733E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0467035691150E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6337680492292E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6489138381423E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.2740678467845E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4645384525242E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2227135341360E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.8824127114251E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.0302526428270E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2996742019079E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5178157980026E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1850210679423E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6143887591723E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291311149129E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8471807951107E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.1648189365912E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5582477282902E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154616648039E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960864915E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997576925836E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920670880966E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365734712352E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0006486083975E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2379036164368E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3804467409479E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.0477599873314E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0467036224289E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6337670905595E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.6489140021549E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.2740189068436E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4645380956697E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2227136691423E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.8824094745118E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.0302256141606E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.2997325579024E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5178155745677E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1850210813273E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.6143791731958E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7291311149133E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8471807951142E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -5.1648540523882E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5582475721502E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1154616353857E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1161960864917E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997576925633E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920670880878E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365734712408E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0006482635596E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0686527096960E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0480849582757E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610245182E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182832588646E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0944887623682E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3682215702630E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302680100153E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.2658679355039E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0655913015661E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9338891525196E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0480850137393E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610245179E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182832580223E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0944883753700E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3682217245769E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.7302680100150E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.2658639486826E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.0655914970365E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9339005604639E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.2856876703622E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851619094192E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821106955902E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.7211328119950E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7144954768806E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6121141519285E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.5231849875305E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4737576265619E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.7322128900794E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.9851615323991E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.7821108757486E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   7.7210693609394E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7144946892179E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.6121145584583E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.5232916594362E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4737617880706E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.7322446182148E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5334456274282E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9873879533787E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3739357441560E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0410150099290E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0351255161780E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.9873830205229E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3739329378003E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0410151327732E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0350072720953E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3340750852800E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4138057731549E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6045378631524E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1357421868209E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1775650026308E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3700366398297E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5642110574173E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6384415255600E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.1659375909726E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.4741256684842E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7661307006336E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9224445318978E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5502664482813E-04
-(PID.TID 0000.0001) %MON ke_max                       =   4.6441647943810E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8788493287998E-04
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.4138988994437E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.6045334238298E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1357431364612E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.1774187908750E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3700491461290E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.5642113174148E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6384415255640E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.1658997757907E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.4741275358521E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7661307006377E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9224445319019E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5502664507533E-04
+(PID.TID 0000.0001) %MON ke_max                       =   4.6441393066562E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8788496211877E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979408288E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3894599431338E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.7658358524689E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3894601153628E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.7658212569489E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540781003406E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526965204E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228350885388E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0826595423108E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.3446779833343E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540781003793E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526965215E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228350881846E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0826595408961E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.3446859932903E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5819,31 +5819,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     7
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7601354374605E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7627268355294E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.6734194227098E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7722338686208E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9027703981827E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0570686291629E+00
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.0226685187963E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   3.2707825447646E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6601122975067E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5888845607904E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   8.7601355423789E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.7627245208404E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.6719237403935E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.7722743339090E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.9040010753616E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0570660503281E+00
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.0227191687519E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   3.2714069970453E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.6601387735456E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.5886893440650E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5141897608912E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9486158002151E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4725683121106E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8317139261900E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5141897548452E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9486157948766E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4725780693184E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8317138739720E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4702123215836E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2612718438483E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6135047439352E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4702122823825E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2612718247612E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6135038958166E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8162768728596E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4439353386842E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5018873053405E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8058480863044E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4439353949707E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5018872963070E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8058405044486E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5862,16 +5862,16 @@
 (PID.TID 0000.0001) %MON exf_vstress_mean             =   3.6219941852612E-03
 (PID.TID 0000.0001) %MON exf_vstress_sd               =   1.1521402093961E-01
 (PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6116067776970E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2786433324025E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953776577E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4791080458674E+01
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4270483095276E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2066450548808E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104033654E-07
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.2786433318167E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -5.9683953776578E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =  -1.4791080196126E+01
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   2.4270483155762E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   4.2066450596431E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   2.0687104033655E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -2.6931169388107E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2873764835971E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9333994392587E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084731119757E-10
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.2873765192900E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   8.9333994403039E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   2.3084731126040E-10
 (PID.TID 0000.0001) %MON exf_wspeed_max               =   2.2324523495989E+01
 (PID.TID 0000.0001) %MON exf_wspeed_min               =   4.4407348923388E-01
 (PID.TID 0000.0001) %MON exf_wspeed_mean              =   6.9532907423740E+00
@@ -5887,16 +5887,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1004237720306E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.6718525851041E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4812919343602E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3216182456521E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651281186958E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7582924898452E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8129965362377E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0851077031950E-01
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   2.3216182456534E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =  -1.1651281186961E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.7582924932652E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   2.8129965416081E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   1.0851077030598E-01
 (PID.TID 0000.0001) %MON exf_evap_max                 =   2.2970735740708E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539357818471E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2413346231870E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6974237237704E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7418745740955E-11
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.5539357826567E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.2413346267563E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.6974237252411E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   6.7418745878166E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   2.7391222779732E-06
 (PID.TID 0000.0001) %MON exf_precip_min               =  -1.3183406187123E-09
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.7082178872092E-08
@@ -5930,89 +5930,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.53523902339107E-01  1.23047996869711E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.72550947979282E-01
+ cg2d: Sum(rhs),rhsMax =  -4.53523451435449E-01  1.23047996944882E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.72548962185977E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.61754188287246E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.61752445725985E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484080671835E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2540328303929E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2954255184359E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0454797841382E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6322602664450E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7747818022384E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4517966565050E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9102428595644E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3095265312956E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0554663814845E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4397179593305E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.9210081191907E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2746635400150E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2034213539320E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0302830724716E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256000080035E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224105127779E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0980622895127E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5990677638800E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0947543797097E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154934366063E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996010899948E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920765866079E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365949604463E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9462883284671E-05
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1484080672462E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2540328296986E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.2954232362721E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0454799037625E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6322602195392E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.7747821374615E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.4517418001078E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9102424408188E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3095266983334E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0554658572536E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4397179593279E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.9210692656440E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2746633027765E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2034213624919E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0302821860360E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3256000080104E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5224105127887E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.0980638518911E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5990676259290E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0947543672114E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1154934366064E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0996010899561E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920765866106E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4365949604383E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9462878319554E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0684477676945E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0516783130919E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610286282E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182746806458E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0769915079430E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3530084862828E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953776577E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7240611319903E+01
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1691678421243E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8753234598494E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0516784119433E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610286283E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8182746791669E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0769907400953E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3530086849593E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.9683953776578E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -2.7240663378900E+01
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   2.1691677085966E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.8753200463171E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -7.3307341038221E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302639101887E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8899446887111E+02
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1739525276947E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7469562227888E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5815396747668E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.0792003629305E-06
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4628607884670E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5312932412824E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -2.0302644251472E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   1.8899442842441E+02
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   8.1739224322734E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7469552732479E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5815401999316E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -7.0790411988782E-06
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.4628567620317E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.5312753754228E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4303429119628E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8794673699109E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3570658015386E-02
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0346577993951E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0827369487187E-05
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -1.8794629178784E+00
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   1.3570621823713E-02
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.0346579797696E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.0825980117648E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.3287254683007E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.3989679352437E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4871316997719E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1427782329610E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.4137902073704E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7949466570837E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7505546411805E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9510683452096E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7578950966643E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.0325702292846E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.2058147782110E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2373799050741E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5281193690228E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.1456980825824E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.0747946734492E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979502518E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2876036047406E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2223739030565E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -5.3990435139084E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =   3.4871209612823E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.1427792380847E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.4136367881960E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7949474778443E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   8.7505380198925E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.9510574607121E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.7578527099225E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   6.0325493622879E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.2058038756176E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.2373688996893E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5281193744355E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.1457404887198E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.0747950379491E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349979502519E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.2876038151383E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2223575430522E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541021476111E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760528508153E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228025698506E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.5984996425533E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.7731413911341E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541021476710E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760528508162E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228025692587E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.5984999758167E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.7731480201450E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6021,31 +6021,31 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON seaice_tsnumber              =                     8
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON seaice_uice_max              =   9.0634354073064E-01
-(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.5611631709752E+00
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.1489689975491E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.4846820873223E-02
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8291362058306E-04
-(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0708727592457E+00
-(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.7414177008977E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.8424668655428E-04
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.4891487159527E-02
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6030034173014E-04
+(PID.TID 0000.0001) %MON seaice_uice_max              =   9.0634356698917E-01
+(PID.TID 0000.0001) %MON seaice_uice_min              =  -1.5611595457390E+00
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -3.1494089057267E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   4.4847186797227E-02
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.8291533856893E-04
+(PID.TID 0000.0001) %MON seaice_vice_max              =   1.0708698992848E+00
+(PID.TID 0000.0001) %MON seaice_vice_min              =  -9.7414771691693E-01
+(PID.TID 0000.0001) %MON seaice_vice_mean             =   1.8429847194374E-04
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   4.4891909681862E-02
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.6030791927505E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   1.0000000000000E+00
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5067370236000E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9472839586974E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4911793680953E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8319957400816E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5067370069995E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9472839640031E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4911890277535E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8319956798930E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4677074530118E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2615641063907E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6026884440797E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4677074764031E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2615641158935E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6026885274909E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8159042896602E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4357813468587E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4998353555009E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7909201636563E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -1.0842021724855E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4357814134436E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4998353408894E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7909117789070E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6058,255 +6058,255 @@
 (PID.TID 0000.0001) // Start of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
-(PID.TID 0000.0001)  --> f_gencost  =  1.21119195798602E+04  1  1.00E+00 (thetaatlas)
-(PID.TID 0000.0001)  --> f_gencost  =  2.08958220993274E+04  2  1.00E+00 (saltatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.21119198254938E+04  1  1.00E+00 (thetaatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  2.08958164881980E+04  2  1.00E+00 (saltatlas)
 (PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
 (PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
 (PID.TID 0000.0001)   early fc =   0.00000000000000E+00
-(PID.TID 0000.0001)   local fc =   1.43361503881918E+03
+(PID.TID 0000.0001)   local fc =   1.43361500480950E+03
 (PID.TID 0000.0001) Writing global cost function info to costfunction.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
-(PID.TID 0000.0001)  global fc =   3.30077416791876E+04
+(PID.TID 0000.0001)  global fc =   3.30077363136917E+04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   101.63780805934221
-(PID.TID 0000.0001)         System time:   1.3736010454595089
-(PID.TID 0000.0001)     Wall clock time:   103.30646586418152
+(PID.TID 0000.0001)           User time:   102.19769624620676
+(PID.TID 0000.0001)         System time:   1.5550900148227811
+(PID.TID 0000.0001)     Wall clock time:   104.04892611503601
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2.6923229042440653
-(PID.TID 0000.0001)         System time:  0.29737798683345318
-(PID.TID 0000.0001)     Wall clock time:   3.0001740455627441
+(PID.TID 0000.0001)           User time:   2.7055500987917185
+(PID.TID 0000.0001)         System time:  0.37267999676987529
+(PID.TID 0000.0001)     Wall clock time:   3.2068519592285156
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   98.945453405380249
-(PID.TID 0000.0001)         System time:   1.0762120485305786
-(PID.TID 0000.0001)     Wall clock time:   100.30625581741333
+(PID.TID 0000.0001)           User time:   99.492102622985840
+(PID.TID 0000.0001)         System time:   1.1824090182781219
+(PID.TID 0000.0001)     Wall clock time:   100.84203004837036
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   5.8239722251892090
-(PID.TID 0000.0001)         System time:  0.42243403196334839
-(PID.TID 0000.0001)     Wall clock time:   6.3778529167175293
+(PID.TID 0000.0001)           User time:   5.7966229915618896
+(PID.TID 0000.0001)         System time:  0.41974899172782898
+(PID.TID 0000.0001)     Wall clock time:   6.2194538116455078
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   93.121467590332031
-(PID.TID 0000.0001)         System time:  0.65377801656723022
-(PID.TID 0000.0001)     Wall clock time:   93.928385972976685
+(PID.TID 0000.0001)           User time:   93.695462226867676
+(PID.TID 0000.0001)         System time:  0.76265794038772583
+(PID.TID 0000.0001)     Wall clock time:   94.622555017471313
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.83652305603027344
-(PID.TID 0000.0001)         System time:   2.8496980667114258E-004
-(PID.TID 0000.0001)     Wall clock time:  0.83738994598388672
+(PID.TID 0000.0001)           User time:  0.85302257537841797
+(PID.TID 0000.0001)         System time:   3.0994415283203125E-005
+(PID.TID 0000.0001)     Wall clock time:  0.85336303710937500
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.8457641601562500E-003
-(PID.TID 0000.0001)         System time:   3.7014484405517578E-005
-(PID.TID 0000.0001)     Wall clock time:   2.8848648071289062E-003
+(PID.TID 0000.0001)           User time:   2.8333663940429688E-003
+(PID.TID 0000.0001)         System time:   1.9669532775878906E-006
+(PID.TID 0000.0001)     Wall clock time:   2.8362274169921875E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   90.087476730346680
-(PID.TID 0000.0001)         System time:  0.54945701360702515
-(PID.TID 0000.0001)     Wall clock time:   90.718245029449463
+(PID.TID 0000.0001)           User time:   90.475448608398438
+(PID.TID 0000.0001)         System time:  0.63465899229049683
+(PID.TID 0000.0001)     Wall clock time:   91.270694971084595
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   90.087392807006836
-(PID.TID 0000.0001)         System time:  0.54945600032806396
-(PID.TID 0000.0001)     Wall clock time:   90.718173742294312
+(PID.TID 0000.0001)           User time:   90.475375175476074
+(PID.TID 0000.0001)         System time:  0.63465899229049683
+(PID.TID 0000.0001)     Wall clock time:   91.270628213882446
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99890041351318359
-(PID.TID 0000.0001)         System time:   1.9401311874389648E-004
-(PID.TID 0000.0001)     Wall clock time:  0.99915480613708496
+(PID.TID 0000.0001)           User time:   1.0267114639282227
+(PID.TID 0000.0001)         System time:   6.0975551605224609E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0275106430053711
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25966930389404297
-(PID.TID 0000.0001)         System time:   1.7046928405761719E-005
-(PID.TID 0000.0001)     Wall clock time:  0.25974416732788086
+(PID.TID 0000.0001)           User time:  0.26208686828613281
+(PID.TID 0000.0001)         System time:   1.2040138244628906E-005
+(PID.TID 0000.0001)     Wall clock time:  0.26299166679382324
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.59866333007812500
-(PID.TID 0000.0001)         System time:   2.3675978183746338E-002
-(PID.TID 0000.0001)     Wall clock time:  0.62314319610595703
+(PID.TID 0000.0001)           User time:  0.50701522827148438
+(PID.TID 0000.0001)         System time:   3.2287895679473877E-002
+(PID.TID 0000.0001)     Wall clock time:  0.54210591316223145
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.59742259979248047
-(PID.TID 0000.0001)         System time:   2.3670017719268799E-002
-(PID.TID 0000.0001)     Wall clock time:  0.62190365791320801
+(PID.TID 0000.0001)           User time:  0.50583171844482422
+(PID.TID 0000.0001)         System time:   3.2279968261718750E-002
+(PID.TID 0000.0001)     Wall clock time:  0.54092717170715332
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
 (PID.TID 0000.0001)           User time:   4.1961669921875000E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6239624023437500E-005
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   4.4107437133789062E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.3695640563964844E-002
-(PID.TID 0000.0001)         System time:   2.9402971267700195E-004
-(PID.TID 0000.0001)     Wall clock time:   9.4022035598754883E-002
+(PID.TID 0000.0001)           User time:   9.2358589172363281E-002
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   9.2403650283813477E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8830528259277344E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8847694396972656E-002
+(PID.TID 0000.0001)           User time:   2.8719902038574219E-002
+(PID.TID 0000.0001)         System time:   4.7981739044189453E-005
+(PID.TID 0000.0001)     Wall clock time:   2.8777122497558594E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   23.979264259338379
-(PID.TID 0000.0001)         System time:   3.2422959804534912E-002
-(PID.TID 0000.0001)     Wall clock time:   24.068958997726440
+(PID.TID 0000.0001)           User time:   23.947491645812988
+(PID.TID 0000.0001)         System time:   3.1053960323333740E-002
+(PID.TID 0000.0001)     Wall clock time:   23.990915060043335
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   14.149434089660645
-(PID.TID 0000.0001)         System time:   8.5149407386779785E-003
-(PID.TID 0000.0001)     Wall clock time:   14.162211894989014
+(PID.TID 0000.0001)           User time:   14.199598312377930
+(PID.TID 0000.0001)         System time:   7.7380537986755371E-003
+(PID.TID 0000.0001)     Wall clock time:   14.213247776031494
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   13.610671997070312
-(PID.TID 0000.0001)         System time:   4.2898654937744141E-003
-(PID.TID 0000.0001)     Wall clock time:   13.619206190109253
+(PID.TID 0000.0001)           User time:   13.658449172973633
+(PID.TID 0000.0001)         System time:   7.7220201492309570E-003
+(PID.TID 0000.0001)     Wall clock time:   13.671864032745361
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.0444355010986328
-(PID.TID 0000.0001)         System time:   3.0404329299926758E-004
-(PID.TID 0000.0001)     Wall clock time:   3.0459451675415039
+(PID.TID 0000.0001)           User time:   2.9505233764648438
+(PID.TID 0000.0001)         System time:   7.8369379043579102E-003
+(PID.TID 0000.0001)     Wall clock time:   2.9601869583129883
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.465397834777832
-(PID.TID 0000.0001)         System time:   2.4092197418212891E-004
-(PID.TID 0000.0001)     Wall clock time:   16.470492124557495
+(PID.TID 0000.0001)           User time:   16.663333892822266
+(PID.TID 0000.0001)         System time:   4.9054622650146484E-005
+(PID.TID 0000.0001)     Wall clock time:   16.680921316146851
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.33503055572509766
-(PID.TID 0000.0001)         System time:   6.9737434387207031E-006
-(PID.TID 0000.0001)     Wall clock time:  0.33504271507263184
+(PID.TID 0000.0001)           User time:  0.42260265350341797
+(PID.TID 0000.0001)         System time:   3.9950013160705566E-003
+(PID.TID 0000.0001)     Wall clock time:  0.42684388160705566
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.3973093032836914
-(PID.TID 0000.0001)         System time:   4.0020346641540527E-003
-(PID.TID 0000.0001)     Wall clock time:   2.4063684940338135
+(PID.TID 0000.0001)           User time:   2.3916702270507812
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.3972826004028320
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31028461456298828
-(PID.TID 0000.0001)         System time:   3.2961368560791016E-005
-(PID.TID 0000.0001)     Wall clock time:  0.31033396720886230
+(PID.TID 0000.0001)           User time:  0.28805160522460938
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.28833508491516113
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56422805786132812
-(PID.TID 0000.0001)         System time:   3.2007694244384766E-005
-(PID.TID 0000.0001)     Wall clock time:  0.56483292579650879
+(PID.TID 0000.0001)           User time:  0.60856342315673828
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.60884714126586914
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2586097717285156E-002
-(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
-(PID.TID 0000.0001)     Wall clock time:   3.2597303390502930E-002
+(PID.TID 0000.0001)           User time:   3.3495903015136719E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   3.3505916595458984E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.43068122863769531
-(PID.TID 0000.0001)         System time:   4.0049552917480469E-003
-(PID.TID 0000.0001)     Wall clock time:  0.43472123146057129
+(PID.TID 0000.0001)           User time:  0.41027450561523438
+(PID.TID 0000.0001)         System time:   7.7300667762756348E-003
+(PID.TID 0000.0001)     Wall clock time:  0.41829562187194824
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.673438072204590
-(PID.TID 0000.0001)         System time:   4.5609474182128906E-004
-(PID.TID 0000.0001)     Wall clock time:   16.678849935531616
+(PID.TID 0000.0001)           User time:   16.796551704406738
+(PID.TID 0000.0001)         System time:   3.7670135498046875E-003
+(PID.TID 0000.0001)     Wall clock time:   16.822916984558105
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0517578125000000E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.8146972656250000E-005
+(PID.TID 0000.0001)           User time:   4.5776367187500000E-005
+(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
+(PID.TID 0000.0001)     Wall clock time:   3.9815902709960938E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1525573730468750
-(PID.TID 0000.0001)         System time:   3.0398368835449219E-006
-(PID.TID 0000.0001)     Wall clock time:   3.1534171104431152
+(PID.TID 0000.0001)           User time:   3.0821189880371094
+(PID.TID 0000.0001)         System time:   3.9960145950317383E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0875723361968994
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.0517578125000000E-005
+(PID.TID 0000.0001)           User time:   3.6239624023437500E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6001205444335938E-005
+(PID.TID 0000.0001)     Wall clock time:   4.4107437133789062E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.7707881927490234
-(PID.TID 0000.0001)         System time:  0.23994696140289307
-(PID.TID 0000.0001)     Wall clock time:   4.0122189521789551
+(PID.TID 0000.0001)           User time:   3.7320537567138672
+(PID.TID 0000.0001)         System time:  0.30390405654907227
+(PID.TID 0000.0001)     Wall clock time:   4.0375888347625732
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4462604522705078
-(PID.TID 0000.0001)         System time:  0.24395203590393066
-(PID.TID 0000.0001)     Wall clock time:   1.6904900074005127
+(PID.TID 0000.0001)           User time:   1.3660278320312500
+(PID.TID 0000.0001)         System time:  0.23988592624664307
+(PID.TID 0000.0001)     Wall clock time:   1.6066596508026123
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.39550781250000000
-(PID.TID 0000.0001)         System time:   1.9937992095947266E-002
-(PID.TID 0000.0001)     Wall clock time:  0.41917300224304199
+(PID.TID 0000.0001)           User time:  0.40387725830078125
+(PID.TID 0000.0001)         System time:   1.9993066787719727E-002
+(PID.TID 0000.0001)     Wall clock time:  0.42401099205017090
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   3.5095214843750000E-004
-(PID.TID 0000.0001)         System time:   4.0531158447265625E-006
-(PID.TID 0000.0001)     Wall clock time:   3.5595893859863281E-004
+(PID.TID 0000.0001)           User time:   3.1280517578125000E-004
+(PID.TID 0000.0001)         System time:   3.9339065551757812E-006
+(PID.TID 0000.0001)     Wall clock time:   3.1304359436035156E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7948532104492188
-(PID.TID 0000.0001)         System time:   8.4056019783020020E-002
-(PID.TID 0000.0001)     Wall clock time:   1.9463560581207275
+(PID.TID 0000.0001)           User time:   1.9564590454101562
+(PID.TID 0000.0001)         System time:  0.10795402526855469
+(PID.TID 0000.0001)     Wall clock time:   2.0678269863128662
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.3833084106445312
-(PID.TID 0000.0001)         System time:   8.0062031745910645E-002
-(PID.TID 0000.0001)     Wall clock time:   1.5219299793243408
+(PID.TID 0000.0001)           User time:   1.5376739501953125
+(PID.TID 0000.0001)         System time:   9.5914006233215332E-002
+(PID.TID 0000.0001)     Wall clock time:   1.6369020938873291
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.41152191162109375
-(PID.TID 0000.0001)         System time:   3.9939880371093750E-003
-(PID.TID 0000.0001)     Wall clock time:  0.42441105842590332
+(PID.TID 0000.0001)           User time:  0.41876220703125000
+(PID.TID 0000.0001)         System time:   1.2038946151733398E-002
+(PID.TID 0000.0001)     Wall clock time:  0.43090796470642090
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.2741088867187500E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.3580322265625000E-003
+(PID.TID 0000.0001)           User time:   9.1552734375000000E-004
+(PID.TID 0000.0001)         System time:   1.3947486877441406E-005
+(PID.TID 0000.0001)     Wall clock time:   9.3197822570800781E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================

--- a/global_oce_llc90/results/output.txt
+++ b/global_oce_llc90/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69m
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Tue Apr 21 13:45:32 EDT 2026
+(PID.TID 0000.0001) // Build date:        Wed Aug 12 18:12:23 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -4562,89 +4562,89 @@
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =  -1.38868680054447E-01  1.31387004504432E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.47390262100532E+01
+ cg2d: Sum(rhs),rhsMax =  -1.38868678497193E-01  1.31387004504432E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.47390261938234E+01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     141
-(PID.TID 0000.0001)      cg2d_last_res =   6.62022974473912E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.62022953920494E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   3.6000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.3130452151768E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5422900473291E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.0285757876142E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0506624095793E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6508314351239E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9899858167257E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.1283969442519E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9850365503626E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6833104199050E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.8632813117431E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.5993892177469E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.9482662961196E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2235823815576E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.6875123357380E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8260026108292E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.3130454766343E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5422898928076E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   7.0285757087954E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   1.0506624112879E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6508303429028E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.9899858167329E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.1283969442471E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -7.9850367289524E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.6833103989934E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   2.8632804188958E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.5993892177466E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -3.9482662961199E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.2235822153187E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   6.6875122258226E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.8260025987904E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.5209619757452E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9082151282428E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6298278560748E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915848274753E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2677751715508E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9082151309950E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.6298293818491E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   3.6915848253854E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   4.2677751352997E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1235781719992E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006903056076E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920432876564E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366196409247E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3104771105362E-05
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701915445486E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0260375504551E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1006903056077E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920432876558E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366196409251E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3104771101840E-05
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0701915445485E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0260375504696E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725611386363E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183934949425E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451765014272E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3394002370662E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5566837056038E+03
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.3184477062418E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4490396353558E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9068846870852E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8183934949466E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2451765017470E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3394002372070E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.5566837054650E+03
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.3184476850253E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4490396358004E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.9068845673250E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1870783737789E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402297967042E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1470635881799E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2189591781047E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   5.5245693743014E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5364828572226E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0090012459599E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8202593424481E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.4542292578512E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8402297967177E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1470635878560E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.2189591606011E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   5.5245693657514E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5364828711884E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0090012234305E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.8202593377792E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   8.4542286260650E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.4705513033302E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -8.8698331221292E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1998962969883E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1172482340119E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9663977234940E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1999031028336E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1172482201386E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9663973060967E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.9550665185239E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.1540750854849E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.8573390992873E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2927810262443E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.6007071025763E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6813322108671E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9573049065930E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7024786594348E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4735507203708E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9114053303613E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6017607774636E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6834090936757E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8547738133314E-07
-(PID.TID 0000.0001) %MON ke_max                       =   2.2633553576992E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.4131737974996E-05
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.8574566809591E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.2927810428080E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.6007088354807E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.6813321586568E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9573049214999E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7024786620669E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.4735507182169E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.9114053303612E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6017607799980E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.6834090963078E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =  -5.8547623734074E-07
+(PID.TID 0000.0001) %MON ke_max                       =   2.2633553576985E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.4131736948552E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349978769393E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -6.9599990028029E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   7.5334556086761E-06
+(PID.TID 0000.0001) %MON vort_r_min                   =  -6.9599989967424E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   7.5334555561437E-06
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542347762446E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4542347762447E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760527755546E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246700419086E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9343384337833E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6133898755793E-07
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7246700416486E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.9343384997319E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.6133948087577E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4655,29 +4655,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.5415783073617E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3417476499335E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7079198131571E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.5415767961675E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3417476527892E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.7079199652958E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.0386262697887E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4138857220188E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.7597213273079E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.0386408286304E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4138855388481E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.7597186107732E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5072420033115E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9282253950364E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4216931225477E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8293906618174E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5072419783682E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9282253846590E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4216936594667E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8293906620425E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4827637522246E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2590240427009E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7393374825417E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4827637523220E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2590240595657E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7393360019632E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8152456681090E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.7105054312138E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5171841291493E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5274350712689E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9934380981997E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5171841289188E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5274350964886E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9934384567580E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4688,24 +4688,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   3.6000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.5358413892982E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -9.0286728185089E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3951481891995E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1235890606017E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2834339496567E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3951481898010E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1235890605928E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2834339464414E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.0090203280816E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.1638464927919E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9456020173233E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3048203509322E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6777503835930E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0678378328816E+03
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.9456020168474E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3048203509278E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.6777503811689E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0678378328839E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9486079634032E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.8586380055547E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7211888488517E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7052481901976E-01
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.8586380008971E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7211888488731E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7052481902748E-01
 (PID.TID 0000.0001) %MON exf_sflux_max                =   1.8554984245111E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9830721697300E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7967031789078E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2315548399971E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8064182276904E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7967031780251E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2315548400700E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8064182278310E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3693679918154E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.9665221975781E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.2496218946971E-02
@@ -4731,16 +4731,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1136747398460E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7683458659431E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4900239072660E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226481668246E+02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5226481689330E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0741097395700E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867070163253E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7655600359613E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4326333764298E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2571323952520E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2505107179267E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0880832515536E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7879334918363E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2769331310969E-11
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8867070162655E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7655600360188E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4326333763411E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2571323952521E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2505107179269E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0880832514653E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.7879334919371E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2769331310537E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590865049111E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.4113024360293E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5531398293978E-08
@@ -4774,89 +4774,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -2.85863273517481E-01  1.27535768940690E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.83643529889094E+00
+ cg2d: Sum(rhs),rhsMax =  -2.85863267191414E-01  1.27535768940679E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.83643536855152E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     140
-(PID.TID 0000.0001)      cg2d_last_res =   6.39427402088865E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.39427273296338E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   7.2000000000000E+03
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262792776567E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5171845862736E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468429324914E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0375520768526E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7368485120724E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2635037208215E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3848072840420E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766634748880E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598138616764E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318294712718E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4612559423083E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2013183711832E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5481014180091E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184245065822E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010690990365E-06
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   7.5262794198654E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -2.5171845843735E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   1.4468429004738E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.0375520373113E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.7368452547249E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2635037208901E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.3848072840182E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5766636046117E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1598138738224E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.5318293819571E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4612559423061E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.2013183711936E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.5480991156943E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.2184245088287E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.4010670296018E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.8990034776956E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251798245818E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967177639381E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204593231223E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009178855306E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -2.3251798245836E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.3967187328199E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.6204593273887E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   7.1009179124228E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1221846198577E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002431433276E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920325945725E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150249569E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3016215760523E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1002431433281E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920325945723E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150249572E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.3016215674845E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0696401789327E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0287397585787E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610216802E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063442654E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203331918141E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3301824596430E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8315837721102E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.0426662534824E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4261366956319E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3927134534577E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0287397582548E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725610216801E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184063443545E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.2203331799249E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3301824601021E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -4.8315837400270E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.0426664371056E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4261366891812E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3927141061962E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1849455478432E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8404988286605E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1430904182058E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1983928174239E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7783989405805E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5035915201604E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1265581360785E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6693331670435E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.8261923549851E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8404988286690E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1430904179336E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1983927777385E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.7783989314359E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.5035915200038E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.1265580670905E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6693331014982E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.8261940687887E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5179254362727E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -9.0136720875096E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.3144545274017E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1306700745556E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9764033293343E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.3144399461363E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1306701711976E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9764142226736E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   1.9976353440884E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.1602414877130E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.7958193456057E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3096168722875E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3507464548031E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8832988935680E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1412766094540E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7591245863386E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8942880426672E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2275957531403E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6664838827989E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7538624677090E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694765360369E-05
-(PID.TID 0000.0001) %MON ke_max                       =   2.7026108451937E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   1.3999957307112E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.7958777971433E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3096172121451E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3506900883343E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.8832895848058E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1412766588762E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7591245862965E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8942880426673E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2275957516436E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.6664838825563E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.7538624676881E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.4694766407605E-05
+(PID.TID 0000.0001) %MON ke_max                       =   2.7026108451923E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   1.3999957482524E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979021026E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -9.7282419032544E-06
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.3301755385977E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -9.7282371521795E-06
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.3301755378709E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541841737344E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541841737362E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526005832E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243419001326E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791902069405E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364247247452E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7243418998047E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.1791902336892E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4364252448259E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4867,29 +4867,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.2666845091992E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3964648261109E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.0670873185291E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   4.2665733957343E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.3964647087429E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.0670886531214E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.3723698940452E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4984103409619E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0505175266908E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.3723854604369E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.4984106730195E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.0505078626362E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5005836242363E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9260954540206E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4097293706094E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8290270129646E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.5005836419629E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9260954611436E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4097300060536E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8290270129969E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4748150088296E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2568509749522E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7213068171104E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4748150091953E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2568509978182E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7213033630644E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8111621258294E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5043885897402E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5225894832191E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9641890445679E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.5043885896412E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5225895293377E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9641885097524E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -4900,24 +4900,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   7.2000000000000E+03
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.6070752252851E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0721768894532E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4080400663371E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1683205126007E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6590444380512E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4080400639216E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1683205126271E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6590444242151E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.1828930560154E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2944199572626E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.6661604498065E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3564340237557E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0525238396646E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0632292207408E+03
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.6661604516011E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3564340237680E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.0525238269198E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0632292202614E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9877363613513E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.5243005383055E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7276262074206E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7166725248640E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8560368588294E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.5243006467066E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7276262099405E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7166725246080E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8560368588295E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9845852817752E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.0210824265910E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2445530592108E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8739733837914E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.0210824409505E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2445530596399E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8739733839948E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4419044704080E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.1151399871527E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.5722890313975E-02
@@ -4943,16 +4943,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1140840707321E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7700841752415E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4912465616232E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157609467114E+02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5157609477622E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0648186028147E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8854780540290E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627626087299E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4280611737188E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2468912299992E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -6.0639664185213E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1104960711198E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8185576413115E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3626270028967E-11
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8854780559816E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7627626142431E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4280611722563E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.2468912299993E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -6.0639664185217E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1104960725557E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8185576406961E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3626270022466E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590912547353E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.4010021173262E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5531116120526E-08
@@ -4986,89 +4986,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -4.29323547138751E-01  1.24223791494558E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.44236805566375E+00
+ cg2d: Sum(rhs),rhsMax =  -4.29323546091019E-01  1.24223791494533E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.44236804114262E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   6.97199908544985E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.97199899516600E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   1.0800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932698181767E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285521412364E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729399943086E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247170635812E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6821926151564E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883466883E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.7726823919283E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796551193497E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731534362990E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028589244171E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825251092E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318993951E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363832979379E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770078310957E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474848166878E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835719E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732045993E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641240679181E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645386141407E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519389915332E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9932698181351E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1285521366694E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.1729399890059E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.8247169878518E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6821883471670E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.3094883469836E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.7726823917516E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.0796552923792E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.4731534566243E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.8028584981064E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.9532825250846E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7476318994464E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -5.9363849064286E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.5770078483993E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   5.6474814629823E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   4.1349262835722E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -3.3468732045992E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -4.6641238084098E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   8.3645386098874E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   8.9519390590820E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1207805418010E+01
 (PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1001659990279E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920324139849E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138324219E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524402554808E-05
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920324139852E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366138324220E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.2524402661864E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0692030172818E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0316460025480E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0316460017944E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725609436489E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241198571E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931204011945E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3190711080412E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3996110713171E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025548474850E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4306291687981E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3794898300208E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184241199665E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1931203828277E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3190711099207E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -8.3996109868037E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.6025544835323E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4306291773850E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3794896125028E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1828127219075E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407069227348E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1398707893327E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1693298461210E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.8989783131319E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4639843185738E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0754274350273E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6506007669625E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7939590236620E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8407069227333E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1398707891266E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1693297680383E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.8989782516098E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4639843067815E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0754275113879E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6506007704197E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.7939568199368E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.6030889502423E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0596231973745E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2774328037690E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1759915798902E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4247143427443E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2774195767985E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1759916362050E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4247285768367E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2704322309957E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.5649122691536E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3598322636911E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8785567995030E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4917624497738E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337272191126E-02
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.5649718588674E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3598325631785E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8784842920744E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.4917848290974E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.1337273227557E-02
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.7973422510606E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209752545897E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758271670522E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8209752540521E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.1758271670990E-02
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   1.8774211804371E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511511738E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635938574918E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.7367852920508E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   2.3275678907695E-04
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   1.9706511511739E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   6.4635937690062E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.7367852920480E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   2.3275679536791E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979287383E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3711936407671E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2486409952468E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3711902363634E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2486409926179E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278304712E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541278304744E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524185540E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726111694E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236974211620E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6192724768184E-06
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7239726108737E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.3236973882150E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6192727738790E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5079,29 +5079,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3987159629194E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196402361097E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1810293090928E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =   1.3983230283977E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.6196402340728E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.1810316363260E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6969046840969E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158470420176E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1430086449031E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.6969172597170E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.7158476017674E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.1429928830051E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4925633215255E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9238692642015E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4041162463726E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8286763388691E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4925633528606E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9238692770471E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.4041164131328E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8286763385611E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4670683303204E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2547194969561E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7032177997255E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4670683304224E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2547195250913E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.7032135797537E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8070816627074E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4915988526895E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5176874089174E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9348026714388E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4915988515287E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5176874697430E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9348012812425E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5112,24 +5112,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.0800000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.7460812353987E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.2880075472116E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4062808549059E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2505564861280E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   9.4822093260147E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.4062808482218E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.2505564862168E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   9.4822093064833E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   2.4555929386903E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.4614409161054E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.3279354216276E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4511363644815E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.0168655740945E-04
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629898394828E+03
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -1.4614409161053E+00
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -7.3279354266410E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.4511363645217E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   1.0168655725072E-04
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629898388484E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -3.0274702987682E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   3.7985962792271E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7424649533177E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7565749166344E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9427654093929E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   3.7985964757306E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7424649573093E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7565749148904E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.9427654093928E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9860686757295E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.4299494564189E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2729065315018E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   6.0240569130031E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   3.4299494838397E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2729065319185E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   6.0240569163969E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.5385738615075E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.2700944862139E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -2.8949561680979E-02
@@ -5155,16 +5155,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144934016182E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7733491035386E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4927149202723E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5082612175921E+02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.5082612549215E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0530591785777E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8840084136931E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7603724575055E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4230833246403E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6040624655553E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -7.3102205391813E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1513576689004E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8778109370753E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.5407307030962E-11
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8840084169716E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7603724658072E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4230833169553E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.6040624655551E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -7.3102205391828E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1513576716425E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8778109357797E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.5407307015858E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4590960045594E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3907017986231E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530833947075E-08
@@ -5198,89 +5198,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -5.70534163392034E-01  1.22564170069960E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.18650860032171E+00
+ cg2d: Sum(rhs),rhsMax =  -5.70534143503715E-01  1.22564170069627E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.18650852597255E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   6.70451995527611E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.70451917901629E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   1.4400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284891059E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025476825903E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876508405283E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095706977185E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6717472770033E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532787918899E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959663348E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687168904656E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119897739487E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496590862892E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249251997E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067952596E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392523064507E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278668732587E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778900786491E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195453542E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274817028E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1060750534639E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746307051857E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151549454522E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0031284891091E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.1025476814751E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   2.8876507398680E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.4095706119272E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6717420655523E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.6532787918851E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.5480959658838E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8687170115472E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.7119898085189E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9496585725547E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3137249251113E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0092067953506E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.1392523648958E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.8278668887033E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.7778866182588E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   5.2304195453549E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -4.3137274817046E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.1060742177024E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.2746306908359E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0151549549356E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1200643921829E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884005265E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692795E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150500876E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849177026248E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.1000884005270E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920373692800E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366150500871E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1849176855988E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0689786989403E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0346463232759E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0346463228098E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608842230E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416090313E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666318761441E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123018640660E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097192517228E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5622835949435E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418858859577E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168407187806E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184416090924E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1666318408709E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3123018690393E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -5.4097195428178E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -4.5622843291324E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4418859327365E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.3168409642188E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1806798959718E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409094579651E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1368753725052E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1424656666738E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110279863140E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368297863293E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428818354445E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263044304629E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6025810526373E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8409094579542E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1368753722419E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1424655304875E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   2.0110280229212E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4368297683205E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0428815628805E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.6263047357009E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.6025803623531E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.7300591272463E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.2780756577411E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2200258332825E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2588427409100E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2341049887238E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.2200073309056E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.2588428455936E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   9.2340859498723E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.4344083006844E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.3731914007749E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442954147264E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8269925851577E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2225667535001E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7772512749505E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823277950E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479069783452E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3371195108790E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2633494681444E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937871386E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486187303830E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.9456878734836E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.1606567527671E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -7.3732274817591E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.4442955677319E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   9.8268831303963E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.2225668151652E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7799403287258E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.1650823277963E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.1479070789218E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.3371144828424E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.2633494681458E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.3790937871401E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.0486187050387E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.9456878734449E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.1606568439425E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979547336E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1935135326908E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.1824529928759E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.1935109283018E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.1824513391834E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881143025E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523419879E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236197153012E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9109996098498E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6194980538525E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540881143083E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523419880E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7236197150335E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.9109995720358E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.6194981792120E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5291,29 +5291,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4205965286260E-04
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457885054575E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2979108017996E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -5.4211736634228E-04
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.7457886661746E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.2979128295080E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9078956229604E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8345214393932E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2606289151498E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9079034558341E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8345218856467E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.2606128799556E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865603338680E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218585114442E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3807594717686E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8283388541418E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4865604001994E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9218585418988E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3807602568149E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8283388535471E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535507789E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527170569950E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6844106104927E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4594535519879E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2527170978181E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6844056344302E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.8030172870301E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223307241E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129077817363E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9050474379728E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4787223287717E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5129078536927E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.9050453940372E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5324,24 +5324,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.4400000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.5251081485486E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -1.0471809665164E+00
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3078855052426E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1771891326093E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6716140722444E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1721785446926E+00
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.3078854946790E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1771891327741E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.6716140446493E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.1721785446925E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.2359021092170E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.5776641326991E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3767193944272E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2290685716566E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0628146769571E+03
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -6.5776641403688E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3767193944970E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   9.2290685520344E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0628146764444E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.9413896956199E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.2757080493277E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7263840941939E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7097706553424E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8786874982633E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   2.2757082943921E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7263840986860E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.7097706506664E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8786874982631E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9838424676698E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.9738504317695E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2447985835216E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8876043530365E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.9738504667476E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2447985837003E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8876043586939E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.4147215850298E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -2.0031143515055E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -3.8456600374457E-02
@@ -5367,16 +5367,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144890175230E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7673323849956E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4922282378209E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4999703975272E+02
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4999704382892E+02
 (PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0424568039431E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8827381023832E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7578708428518E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4184447529034E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4458961751416E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2407463870693E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1057226612333E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8344423365575E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3558378952770E-11
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8827381063627E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7578708521346E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4184447365753E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4458961751410E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -5.2407463870728E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.1057226647312E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8344423346349E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.3558378914878E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591007543835E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3804014799200E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530551773623E-08
@@ -5410,89 +5410,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -7.09994961515039E-01  1.21024805243363E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.12094202470980E+00
+ cg2d: Sum(rhs),rhsMax =  -7.09994943781808E-01  1.21024805242349E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.12094186993944E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   6.53865909510528E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53865979494879E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   1.8000000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922344697E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3317105615058E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935053129880E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841986965498E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6521641340693E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965261981E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186373020E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324285199670E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180630021134E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9936030931227E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065427823E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868605457898E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359467606895E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197200284488E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742510579847E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790930273E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377422314E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687098653135E-07
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194085320028E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842546004214E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0585922345214E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3317105615591E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   3.5935052232348E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.7841986250830E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6521587183213E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.2528965261815E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.7503186364037E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1324285400059E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.9180630461523E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.9936026287940E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.9535065426131E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0868605466356E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.4359467330265E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.0197200426380E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.7742477293236E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.1900790930282E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.2299377422409E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.8687087877262E-07
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6194085211239E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0842546160710E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1192833239805E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496589E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446996956E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202810301E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200227392952E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0999920496603E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920446996962E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366202810292E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.1200226688415E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0687575469328E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0376344508642E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0376344513293E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608413644E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580065810E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420273369946E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029713529405E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990384871958E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312120821848E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282903095384E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928050524447E-01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184580065968E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1420272864358E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.3029713601671E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -3.2990288582505E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -5.9312118493308E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4282903565319E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2928069344263E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1785470700361E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411051354301E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1341267062540E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1289019485074E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3911619099576E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188906390193E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175673671134E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963837002172E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5677205122348E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8411051354107E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1341267059127E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1289017683539E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.3911590789982E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.4188906299395E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -2.0175673982895E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5963840007115E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.5677252317291E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.5073169292410E+00
 (PID.TID 0000.0001) %MON forcing_fu_min               =  -1.0413476444914E+00
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1110924995024E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861656025455E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4504084398888E-05
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   3.1110863694408E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1861656407798E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.4504018472391E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.2241321533689E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5752943936875E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795964912628E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8528022129223E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2603260790102E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6232114142679E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574523481E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745313056608E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9567531920802E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5353844471445E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6689883428373E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3480693019124E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.4761451359859E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   3.9248761722063E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.5753367011931E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3795967505832E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.8526962183511E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2603240068970E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6232666413914E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.4231574523508E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5745317478048E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   3.9567436389351E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.5353844471474E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.6689883428402E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.3480692680329E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.4761451359845E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   3.9248762813552E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349979803212E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426902283831E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787378182646E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.3426854368164E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.2787378790011E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665826057E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523573614E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771317530E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855804998131E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4560787201519E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540665826156E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760523573617E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7232771314537E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.2855804557384E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.4560788698526E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5503,29 +5503,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0116262787748E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156474090155E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3414988147209E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.0116721412792E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8156475131311E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3415018150113E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0126116078133E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937660249227E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3028034260571E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0126179373403E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.8937665340369E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3027882205384E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796509178322E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198103393734E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3605462223622E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8280086738760E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4796510188770E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9198103886985E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3605478164887E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8280086730075E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519272816230E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2508319087258E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6650457159477E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4519272825664E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2508319594525E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6650405665746E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7989692171325E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -5.4210108624275E-20
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4661666461874E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5084656469796E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8742789245470E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4661666481582E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5084657230558E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8742770769827E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5536,24 +5536,24 @@
 (PID.TID 0000.0001) %MON exf_time_sec                 =   1.8000000000000E+04
 (PID.TID 0000.0001) %MON exf_ustress_max              =   1.3889986822671E+00
 (PID.TID 0000.0001) %MON exf_ustress_min              =  -8.7557819176683E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.1862430769913E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1353663236876E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2226671108985E-05
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.1862430620617E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1353663239475E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.2226670824053E-05
 (PID.TID 0000.0001) %MON exf_vstress_max              =   1.9743039644202E+00
 (PID.TID 0000.0001) %MON exf_vstress_min              =  -1.0704230365837E+00
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8986287488629E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3384926281702E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.7112577104558E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629911165213E+03
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.8986287592811E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3384926282719E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.7112576931348E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0629911161091E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8757679947262E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920784933695E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173324438712E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755724594342E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481603E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.3920787779487E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7173324487359E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6755724530425E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.8174456481601E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9814667799294E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7081089583893E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2285801248389E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8080122728731E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.7081090000708E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2285801247619E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.8080122813533E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.3352358384690E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8681139737310E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -4.7963639067935E-02
@@ -5579,16 +5579,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144846334278E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7626414634741E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4919559013695E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4913728615871E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547215048E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503406044E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225177073E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141812637459E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730615704E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9685992421002E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234086932E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8121389058231E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2372243544299E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4913728990595E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0331547215049E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8816503451837E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7554225276421E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4141812401471E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.3878730615253E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.9685992421068E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0791234128613E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8121389032867E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.2372243489826E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591055042077E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3701011612169E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5530269600171E-08
@@ -5622,89 +5622,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -8.47514999923231E-01  1.20371012272577E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.05916353577405E+00
+ cg2d: Sum(rhs),rhsMax =  -8.47514988791863E-01  1.20371012271129E+00
+(PID.TID 0000.0001)      cg2d_init_res =   1.05916342381281E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     128
-(PID.TID 0000.0001)      cg2d_last_res =   6.60066741915739E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.60066833230687E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340967916E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215687039230E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895369969404E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755478905760E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6368996971500E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617102737E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345732867E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625788482181E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924764363880E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9231080159569E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006581839259E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518790172E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896931285535E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520102348447E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360650642403E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399143889E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455547390E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9403254156837E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217513032903E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133350245959E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1463340968215E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.4215687040347E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.2895369406017E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   3.9755478577580E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6368943104842E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.5488617102331E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.1321345733579E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.9625787675939E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.0924764918864E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.9231078196731E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.2006581835496E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.7900518803268E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.2896930303145E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.1520102474567E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.6360625208749E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.0207399143928E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.0830455547524E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -6.9403130857659E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6217512989293E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1133350488350E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1191979292714E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760081610E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525738998E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283390297E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518541885153E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0998760081635E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920525739001E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366283390283E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   8.0518540523175E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0685358737423E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405646936017E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0405646965713E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725608120269E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734357513E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196785778937E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916849916870E+03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184734357166E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.1196785151016E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2916849992379E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8729104564604E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511950391749E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203141979628E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400569965801E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.7511944560929E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4203142536461E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2400576649853E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1764142441004E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413084684673E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874774084E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1090873583197E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298867054453E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907321209228E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9894905632987E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693207390711E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276514887392E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8413084684516E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1314874766485E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.1090871912949E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2298867877890E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3907321222518E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9894906588077E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5693211126020E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.4276527907183E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.3668407825276E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.5617187280954E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9887405378209E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1447336542214E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0414263109453E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9655206104466E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -8.5617187280953E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.9887398928475E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1447337016028E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0414223762629E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9655206104465E+00
 (PID.TID 0000.0001) %MON forcing_fv_min               =  -1.0530327881972E+00
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8729430372224E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437764997699E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3752049664280E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2691774808340E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5436656664028E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625236054E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693777948123E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2448355769668E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509942985E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620890680E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081466264482E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.7885949793142E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.5518033878180E-04
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8729848536272E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3437767668736E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3751090956582E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.2691778319645E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5436691540368E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5796625236168E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.8693788544079E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.2448213250085E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7017509943104E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.8487620890801E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5081465940731E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.7885949795491E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.5518035180280E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980055918E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4304439158458E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4447941806886E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.4320566594807E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4447943820216E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633823827E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524311875E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230134906140E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237947130760E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610316403007E-06
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540633823987E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760524311879E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7230134902175E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.6237946772752E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.1610318011128E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5715,29 +5715,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.1600000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2488424531216E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656786911895E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854766443303E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.2488697161504E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8656787352174E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.3854791086617E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0125597640277E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297612723340E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462709763031E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -3.0125647747710E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9297617147239E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3462568428823E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734117130595E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178805290432E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3496816420411E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276856122615E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4734118114376E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9178805796205E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3496842947649E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8276856110898E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444996032545E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2490458675699E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6460705529570E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4444996039810E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2490459276864E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6460658460242E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7949413001252E-01
-(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4539551700481E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5043422392156E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8438436151790E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4539551675832E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5043423057886E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8438426506134E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5746,26 +5746,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     6
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.1600000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.2831318509792E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434041E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484230637554E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962356442E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600941630121E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9175555650666E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3287879803635E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.2423850667889E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3329377388074E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021696537410E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0634975995556E+03
-(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655891687E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995784501608E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148221590269E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587908337883E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299650E-07
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.2831318509791E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7811683434040E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   3.0484230460473E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1215962359592E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.0600940754413E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   1.9175555650665E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3287879803628E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -5.2423850785871E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3329377389212E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5021696095878E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0634975992115E+03
+(PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8543655891686E+02
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.1995787752875E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7148221642200E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6587908262658E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7611181299643E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9789290821009E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503308573474E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214312824284E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7690889521271E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.6503309053479E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2214312820878E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7690889636389E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2726117910117E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.7761128863488E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -5.7470677761413E-02
@@ -5791,16 +5791,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144802493326E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7592795785517E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4918980283005E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4831824342526E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0245718403156E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807419617627E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666619294E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101680166305E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373863849E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068079415E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733204933868E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074411504662E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765853711559E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4831824690872E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0245718403158E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8807419668985E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7530666724233E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4101679886483E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.4755373863286E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -3.3728068079552E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0733204981869E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8074411473173E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1765853649669E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591102540318E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3598008425138E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529987426719E-08
@@ -5834,89 +5834,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -9.83002431147267E-01  1.20159665199112E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.97597126902218E-01
+ cg2d: Sum(rhs),rhsMax =  -9.83001803215990E-01  1.20159665198056E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.97598033055837E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     129
-(PID.TID 0000.0001)      cg2d_last_res =   6.53034303475336E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.53034763866463E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300734047343E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662597323006E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9752810237838E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413304018479E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6278742502570E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721055392092E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160061843723E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954887761421E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301663105198E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176985944110E-06
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495073596E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870575179125E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705575286107E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230448699737E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3724017354905E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739641823E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771665044E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6293182625842E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564228292281E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126894826202E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.2300734047922E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.3662597324609E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   4.9752778456268E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0413304311889E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6278692003728E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.7721055391275E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9160061845727E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4954886105552E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.2301663737287E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.7176990431125E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4684495072788E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.5870575066343E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.5705573753474E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2230448795235E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.3723998952712E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   7.7301739641931E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -6.8547771665683E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.6294945789793E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.5564228307041E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.1126895197856E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1190811894468E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381289438E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188646E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377348269E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894029664255E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0997381289473E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920592188715E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366377348181E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9894027892994E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0683073388653E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434313727062E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852301E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882168097E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991861831291E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769002832294E+03
-(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655891687E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764514810051E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173630500760E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2240301730765E-01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0434313783028E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607852303E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8184882166184E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0991861031182E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2769002902797E+03
+(PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8543655891686E+02
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.9764806198812E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4173628775155E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2240399015727E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1742814181647E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415098916106E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289598394334E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0712984695820E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208735066317E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644295896960E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9600850100587E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460086650198E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3866200376241E-07
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8415102115685E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1289560593412E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0713488543443E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2208735934356E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3644295879228E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9600760868637E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5460043181641E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3866489080157E-07
 (PID.TID 0000.0001) %MON forcing_fu_max               =   1.2667053449446E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.5828157462729E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8450808203792E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1314858212837E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9397471434188E-05
-(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9061087909396E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.2507416138033E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2099011517696E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383651857680E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2095279373009E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8495942766976E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9734310459025E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452857533E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068517361720E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1520671929148E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711356929E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566412773E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541900831427E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.9025277074620E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   4.9793313668490E-04
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.5828157462724E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.8450830692615E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1314858701091E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   7.9397365985480E-05
+(PID.TID 0000.0001) %MON forcing_fv_max               =   1.9061087909395E+00
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.2507416138026E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.2099426828597E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3383654437166E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.2094491790109E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   7.8495948700698E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.9732210392741E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6413452857872E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.1068536464760E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1520487250519E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.7691711357283E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9255566413132E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5541900613123E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.9025277080241E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   4.9793315092881E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3349980305107E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6460066538431E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.6840660502870E-05
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.6478656275461E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.6840656775098E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765232138E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525443013E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228660242780E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948331659521E-05
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4853627729974E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4540765232371E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760525443018E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228660237453E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0948331569959E-05
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   8.4853615993114E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5927,29 +5927,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.5200000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6330338086945E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999432742291E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4297300826758E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -1.6330469757277E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.8999433168927E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4297308973727E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9477440607314E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499408066125E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889150983067E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.9477485712666E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9499411873780E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.3889020222253E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672876872282E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160082468921E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3280729277564E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8273693372674E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4672877997620E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9160083037292E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3280771038816E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8273693357583E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371768443710E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473448605137E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6278144014888E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4371768807241E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2473449343545E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6278101903351E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7909264973408E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -2.1684043449710E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420583381633E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5005006107571E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8147004845396E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4420583267052E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.5005006563268E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.8147006432583E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -5958,26 +5958,26 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON exf_tsnumber                 =                     7
 (PID.TID 0000.0001) %MON exf_time_sec                 =   2.5200000000000E+04
-(PID.TID 0000.0001) %MON exf_ustress_max              =   1.2371508581862E+00
-(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7514785530307E-01
-(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006523148866E-03
-(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419503391E-01
-(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659094532726E-05
-(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0591191646453E+00
-(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3794009108728E-01
-(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572468395939E-03
-(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460664143E-01
-(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776765659420E-05
-(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661034390048E+03
+(PID.TID 0000.0001) %MON exf_ustress_max              =   1.2371508581861E+00
+(PID.TID 0000.0001) %MON exf_ustress_min              =  -7.7514785530301E-01
+(PID.TID 0000.0001) %MON exf_ustress_mean             =   2.9006522912193E-03
+(PID.TID 0000.0001) %MON exf_ustress_sd               =   1.1349419507145E-01
+(PID.TID 0000.0001) %MON exf_ustress_del2             =   8.1659093722199E-05
+(PID.TID 0000.0001) %MON exf_vstress_max              =   2.0591191646451E+00
+(PID.TID 0000.0001) %MON exf_vstress_min              =  -9.3794009108720E-01
+(PID.TID 0000.0001) %MON exf_vstress_mean             =  -4.5572468474554E-03
+(PID.TID 0000.0001) %MON exf_vstress_sd               =   1.3605460665511E-01
+(PID.TID 0000.0001) %MON exf_vstress_del2             =   8.5776765283133E-05
+(PID.TID 0000.0001) %MON exf_hflux_max                =   1.0661034390050E+03
 (PID.TID 0000.0001) %MON exf_hflux_min                =  -2.8363753842843E+02
-(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962848136268E+00
-(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185811379909E+02
-(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662567788764E-01
-(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419677060E-07
+(PID.TID 0000.0001) %MON exf_hflux_mean               =   1.6962851946485E+00
+(PID.TID 0000.0001) %MON exf_hflux_sd                 =   1.7185811428115E+02
+(PID.TID 0000.0001) %MON exf_hflux_del2               =   3.6662567729799E-01
+(PID.TID 0000.0001) %MON exf_sflux_max                =   1.7573419676133E-07
 (PID.TID 0000.0001) %MON exf_sflux_min                =  -1.9762180582361E-06
-(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026206631151E-09
-(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211144161635E-08
-(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820073442682E-11
+(PID.TID 0000.0001) %MON exf_sflux_mean               =   2.8026207220756E-09
+(PID.TID 0000.0001) %MON exf_sflux_sd                 =   4.2211144152984E-08
+(PID.TID 0000.0001) %MON exf_sflux_del2               =   5.7820073593958E-11
 (PID.TID 0000.0001) %MON exf_uwind_max                =   2.2409841947187E+01
 (PID.TID 0000.0001) %MON exf_uwind_min                =  -1.8299208716971E+01
 (PID.TID 0000.0001) %MON exf_uwind_mean               =  -6.6977716454892E-02
@@ -6003,16 +6003,16 @@
 (PID.TID 0000.0001) %MON exf_aqh_mean                 =   1.1144758652374E-02
 (PID.TID 0000.0001) %MON exf_aqh_sd                   =   5.7572490584599E-03
 (PID.TID 0000.0001) %MON exf_aqh_del2                 =   1.4920546435694E-05
-(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755216052075E+02
-(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605609985E+01
-(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799444522377E+01
-(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508390882231E+01
-(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063438358264E-02
-(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873483378E-07
-(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426824185E-08
-(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885243687615E-08
-(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196463591286E-08
-(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820923017133E-11
+(PID.TID 0000.0001) %MON exf_lwflux_max               =   1.4755216399990E+02
+(PID.TID 0000.0001) %MON exf_lwflux_min               =   2.0163605609989E+01
+(PID.TID 0000.0001) %MON exf_lwflux_mean              =   5.8799444587098E+01
+(PID.TID 0000.0001) %MON exf_lwflux_sd                =   1.7508390982284E+01
+(PID.TID 0000.0001) %MON exf_lwflux_del2              =   9.4063438054340E-02
+(PID.TID 0000.0001) %MON exf_evap_max                 =   2.5753873482689E-07
+(PID.TID 0000.0001) %MON exf_evap_min                 =  -2.9957426824446E-08
+(PID.TID 0000.0001) %MON exf_evap_mean                =   4.0885243746575E-08
+(PID.TID 0000.0001) %MON exf_evap_sd                  =   2.8196463545287E-08
+(PID.TID 0000.0001) %MON exf_evap_del2                =   7.1820922962953E-11
 (PID.TID 0000.0001) %MON exf_precip_max               =   1.4591150038559E-07
 (PID.TID 0000.0001) %MON exf_precip_min               =   4.3495005238107E-10
 (PID.TID 0000.0001) %MON exf_precip_mean              =   3.5529705253267E-08
@@ -6046,89 +6046,89 @@
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR EXF statistics
 (PID.TID 0000.0001) // =======================================================
- cg2d: Sum(rhs),rhsMax =  -1.11614458967144E+00  1.19970634895043E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.23811666966917E-01
+ cg2d: Sum(rhs),rhsMax =  -1.11614398982408E+00  1.19970634903234E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.23811699702831E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     131
-(PID.TID 0000.0001)      cg2d_last_res =   6.67490673634086E-06
+(PID.TID 0000.0001)      cg2d_last_res =   6.67490812633367E-06
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   2.8800000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291870697E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378524894603E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491548960970E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422615065919E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6190618702548E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167305874E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569317648E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408310427202E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229668304302E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372992258789E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916520616E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0789875221634E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305489082809E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454357706092E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018579375609E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740298838E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304656104019E-03
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7349555111392E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6038978596299E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914825511226E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.1445291871370E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -3.2378524896144E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =   5.6491518600830E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.0422615934251E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.6190576482777E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.2203167304611E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.6212569322425E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -3.9408308215747E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3229668966550E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.0372993434034E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8197916519533E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -5.0789858628358E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -4.3305487245877E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.2454357777206E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0018577601797E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   8.3266740299160E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -7.5304656105498E-03
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   1.7349654170131E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   9.6038978623533E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.0914826044386E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   3.1189299556269E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766191100E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546419E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470786623E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352063632039E-05
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -2.0995766191149E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.5920637546483E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4366470786535E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   7.9352061171522E-05
 (PID.TID 0000.0001) %MON dynstat_salt_max             =   4.0680752819192E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461844784191E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539580E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185023628992E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803678121009E-05
-(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582322257417E+03
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.0461844866549E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4725607539583E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   3.8185023626411E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   2.0803676612718E-05
+(PID.TID 0000.0001) %MON forcing_qnet_max             =   1.2582322326691E+03
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -2.8363753842843E+02
-(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118758796073E+00
-(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189927298719E+02
-(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155957471098E-01
+(PID.TID 0000.0001) %MON forcing_qnet_mean            =  -6.6118739493722E+00
+(PID.TID 0000.0001) %MON forcing_qnet_sd              =   1.4189927991194E+02
+(PID.TID 0000.0001) %MON forcing_qnet_del2            =   2.2155956831426E-01
 (PID.TID 0000.0001) %MON forcing_qsw_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON forcing_qsw_min              =  -3.1721485922290E+02
-(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096221242E+02
-(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267321190075E+01
-(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0632348719266E-02
-(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2099053788155E-03
-(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214897098815E-03
-(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261561516956E-05
-(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240011542306E-04
-(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291533510128E-07
-(PID.TID 0000.0001) %MON forcing_fu_max               =   1.2357676847972E+00
-(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850236E-01
-(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6914239242181E-03
-(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452798581669E-01
-(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0529402058388E-05
+(PID.TID 0000.0001) %MON forcing_qsw_mean             =  -1.8417096214160E+02
+(PID.TID 0000.0001) %MON forcing_qsw_sd               =   8.1267321255402E+01
+(PID.TID 0000.0001) %MON forcing_qsw_del2             =   4.0632342617268E-02
+(PID.TID 0000.0001) %MON forcing_empmr_max            =   1.2099054673198E-03
+(PID.TID 0000.0001) %MON forcing_empmr_min            =  -3.3214897066818E-03
+(PID.TID 0000.0001) %MON forcing_empmr_mean           =  -1.9261565579870E-05
+(PID.TID 0000.0001) %MON forcing_empmr_sd             =   1.5240017142001E-04
+(PID.TID 0000.0001) %MON forcing_empmr_del2           =   6.3291535231747E-07
+(PID.TID 0000.0001) %MON forcing_fu_max               =   1.2357676847971E+00
+(PID.TID 0000.0001) %MON forcing_fu_min               =  -7.7090547850232E-01
+(PID.TID 0000.0001) %MON forcing_fu_mean              =   2.6914225038482E-03
+(PID.TID 0000.0001) %MON forcing_fu_sd                =   1.1452799009380E-01
+(PID.TID 0000.0001) %MON forcing_fu_del2              =   8.0529235071527E-05
 (PID.TID 0000.0001) %MON forcing_fv_max               =   2.0000000000000E+00
-(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3752841738352E-01
-(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5113958372010E-03
-(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659439213176E-01
-(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3007734528303E-05
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5589122411111E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9085714316850E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630551716E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682356914007E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446348628021E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660503030605E-01
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952123816478E-01
-(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356274783117E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.1301079212630E-01
-(PID.TID 0000.0001) %MON ke_mean                      =   5.1984329894228E-04
-(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550612E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9193546673521E-05
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.9211413796511E-05
+(PID.TID 0000.0001) %MON forcing_fv_min               =  -9.3752841738344E-01
+(PID.TID 0000.0001) %MON forcing_fv_mean              =  -4.5114389089196E-03
+(PID.TID 0000.0001) %MON forcing_fv_sd                =   1.3659441728579E-01
+(PID.TID 0000.0001) %MON forcing_fv_del2              =   8.3007283290022E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5589129582188E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.9085929149013E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.8130630551855E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.3682385655389E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.3446245521640E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.9660436104162E-01
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.9952056249379E-01
+(PID.TID 0000.0001) %MON pe_b_mean                    =   1.5356274789352E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.1301079218337E-01
+(PID.TID 0000.0001) %MON ke_mean                      =   5.1984331370479E-04
+(PID.TID 0000.0001) %MON ke_vol                       =   1.3349980550611E+18
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.9213484341297E-05
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.9211404013554E-05
 (PID.TID 0000.0001) %MON vort_a_mean                  =  -1.9727864647440E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004636499E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526752205E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228358492415E-05
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548583146237E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9257525543636E-07
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.4541004636819E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -2.1760526752214E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   9.7228358485372E-05
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   7.7548586367064E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   5.9257505069549E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6139,29 +6139,29 @@
 (PID.TID 0000.0001) %MON seaice_time_sec              =   2.8800000000000E+04
 (PID.TID 0000.0001) %MON seaice_uice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_uice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3164948759711E-03
-(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235171475991E-01
-(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794595262334E-04
+(PID.TID 0000.0001) %MON seaice_uice_mean             =  -2.3165040978766E-03
+(PID.TID 0000.0001) %MON seaice_uice_sd               =   1.9235171940634E-01
+(PID.TID 0000.0001) %MON seaice_uice_del2             =   1.4794590553528E-04
 (PID.TID 0000.0001) %MON seaice_vice_max              =   4.0000000000000E-01
 (PID.TID 0000.0001) %MON seaice_vice_min              =  -4.0000000000000E-01
-(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8469459400496E-02
-(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613427005015E-01
-(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376223505513E-04
+(PID.TID 0000.0001) %MON seaice_vice_mean             =  -2.8469505610172E-02
+(PID.TID 0000.0001) %MON seaice_vice_sd               =   1.9613430233601E-01
+(PID.TID 0000.0001) %MON seaice_vice_del2             =   1.4376111318656E-04
 (PID.TID 0000.0001) %MON seaice_area_max              =   9.7000000000000E-01
 (PID.TID 0000.0001) %MON seaice_area_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614043038957E-02
-(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142056067831E-01
-(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3245988622980E-04
-(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8270594777539E+00
+(PID.TID 0000.0001) %MON seaice_area_mean             =   4.4614043915121E-02
+(PID.TID 0000.0001) %MON seaice_area_sd               =   1.9142056537370E-01
+(PID.TID 0000.0001) %MON seaice_area_del2             =   2.3246045361815E-04
+(PID.TID 0000.0001) %MON seaice_heff_max              =   2.8270594758832E+00
 (PID.TID 0000.0001) %MON seaice_heff_min              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299750531195E-02
-(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457041800467E-01
-(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6107784451032E-04
+(PID.TID 0000.0001) %MON seaice_heff_mean             =   4.4299750881554E-02
+(PID.TID 0000.0001) %MON seaice_heff_sd               =   2.2457042590625E-01
+(PID.TID 0000.0001) %MON seaice_heff_del2             =   1.6107750899283E-04
 (PID.TID 0000.0001) %MON seaice_hsnow_max             =   7.7869219854306E-01
 (PID.TID 0000.0001) %MON seaice_hsnow_min             =  -4.3368086899420E-19
-(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305270621870E-03
-(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4968773981309E-02
-(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7879764279702E-05
+(PID.TID 0000.0001) %MON seaice_hsnow_mean            =   6.4305270427279E-03
+(PID.TID 0000.0001) %MON seaice_hsnow_sd              =   3.4968774168705E-02
+(PID.TID 0000.0001) %MON seaice_hsnow_del2            =   4.7879779736901E-05
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR SEAICE statistics
 (PID.TID 0000.0001) // =======================================================
@@ -6174,255 +6174,255 @@
 (PID.TID 0000.0001) // Start of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) Writing profiles cost function info to costfunction_profiles.0000
-(PID.TID 0000.0001)  --> f_gencost  =  1.18384997232580E+04  1  1.00E+00 (thetaatlas)
-(PID.TID 0000.0001)  --> f_gencost  =  1.83176156478632E+04  2  1.00E+00 (saltatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.18384991052572E+04  1  1.00E+00 (thetaatlas)
+(PID.TID 0000.0001)  --> f_gencost  =  1.83176158812667E+04  2  1.00E+00 (saltatlas)
 (PID.TID 0000.0001) Writing ecco cost function info to costfunction_ecco.0000
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 1  0.00E+00 (xx_kapgm)
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 2  0.00E+00 (xx_kapredi)
 (PID.TID 0000.0001)  --> f_genarr3d =  0.00000000000000E+00 3  0.00E+00 (xx_diffkr)
 (PID.TID 0000.0001) Writing generic ctrl cost function info to costfunction_ctrl.0000
 (PID.TID 0000.0001)   early fc =   0.00000000000000E+00
-(PID.TID 0000.0001)   local fc =   1.28993456297018E+03
+(PID.TID 0000.0001)   local fc =   1.28993427209508E+03
 (PID.TID 0000.0001) Writing global cost function info to costfunction.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_profiles.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_ecco.0000
 (PID.TID 0000.0001) Reading cost function info from costfunction_ctrl.0000
-(PID.TID 0000.0001)  global fc =   3.01561153711212E+04
+(PID.TID 0000.0001)  global fc =   3.01561149865239E+04
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End of S/R COST_FINAL
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   92.477321542799473
-(PID.TID 0000.0001)         System time:   1.4957150346599519
-(PID.TID 0000.0001)     Wall clock time:   94.342611789703369
+(PID.TID 0000.0001)           User time:   94.223988452926278
+(PID.TID 0000.0001)         System time:   1.8871420370414853
+(PID.TID 0000.0001)     Wall clock time:   100.70404005050659
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   2.3163510616868734
-(PID.TID 0000.0001)         System time:  0.30846100300550461
-(PID.TID 0000.0001)     Wall clock time:   2.6285309791564941
+(PID.TID 0000.0001)           User time:   2.7166710160672665
+(PID.TID 0000.0001)         System time:  0.29322801250964403
+(PID.TID 0000.0001)     Wall clock time:   3.2032651901245117
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   90.160944461822510
-(PID.TID 0000.0001)         System time:   1.1872490346431732
-(PID.TID 0000.0001)     Wall clock time:   91.714046955108643
+(PID.TID 0000.0001)           User time:   91.507283926010132
+(PID.TID 0000.0001)         System time:   1.5939070284366608
+(PID.TID 0000.0001)     Wall clock time:   97.500740051269531
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   6.0291235446929932
-(PID.TID 0000.0001)         System time:  0.40018495917320251
-(PID.TID 0000.0001)     Wall clock time:   6.4312090873718262
+(PID.TID 0000.0001)           User time:   6.3139634132385254
+(PID.TID 0000.0001)         System time:  0.86520496010780334
+(PID.TID 0000.0001)     Wall clock time:   9.3431451320648193
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   84.131797790527344
-(PID.TID 0000.0001)         System time:  0.78706204891204834
-(PID.TID 0000.0001)     Wall clock time:   85.282819986343384
+(PID.TID 0000.0001)           User time:   85.193306922912598
+(PID.TID 0000.0001)         System time:  0.72870099544525146
+(PID.TID 0000.0001)     Wall clock time:   88.157576084136963
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:  0.83638477325439453
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:  0.83668375015258789
+(PID.TID 0000.0001)           User time:  0.84717845916748047
+(PID.TID 0000.0001)         System time:   4.7910213470458984E-004
+(PID.TID 0000.0001)     Wall clock time:  0.86767911911010742
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   2.8667449951171875E-003
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8598308563232422E-003
+(PID.TID 0000.0001)           User time:   2.7713775634765625E-003
+(PID.TID 0000.0001)         System time:   8.7022781372070312E-005
+(PID.TID 0000.0001)     Wall clock time:   2.8514862060546875E-003
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   81.120486259460449
-(PID.TID 0000.0001)         System time:  0.64325398206710815
-(PID.TID 0000.0001)     Wall clock time:   81.986068248748779
+(PID.TID 0000.0001)           User time:   81.987647056579590
+(PID.TID 0000.0001)         System time:  0.55225586891174316
+(PID.TID 0000.0001)     Wall clock time:   82.976630926132202
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   81.120407104492188
-(PID.TID 0000.0001)         System time:  0.64325398206710815
-(PID.TID 0000.0001)     Wall clock time:   81.986000061035156
+(PID.TID 0000.0001)           User time:   81.987570762634277
+(PID.TID 0000.0001)         System time:  0.55225396156311035
+(PID.TID 0000.0001)     Wall clock time:   82.976557970046997
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.99564361572265625
-(PID.TID 0000.0001)         System time:   8.4936618804931641E-005
-(PID.TID 0000.0001)     Wall clock time:  0.99605679512023926
+(PID.TID 0000.0001)           User time:   1.0309171676635742
+(PID.TID 0000.0001)         System time:   3.2687187194824219E-004
+(PID.TID 0000.0001)     Wall clock time:   1.0315790176391602
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.25488281250000000
-(PID.TID 0000.0001)         System time:   3.9190649986267090E-003
-(PID.TID 0000.0001)     Wall clock time:  0.26841950416564941
+(PID.TID 0000.0001)           User time:  0.26534461975097656
+(PID.TID 0000.0001)         System time:   3.9209127426147461E-003
+(PID.TID 0000.0001)     Wall clock time:  0.29594540596008301
 (PID.TID 0000.0001)          No. starts:          24
 (PID.TID 0000.0001)           No. stops:          24
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.44970989227294922
-(PID.TID 0000.0001)         System time:   4.0299892425537109E-003
-(PID.TID 0000.0001)     Wall clock time:  0.45460057258605957
+(PID.TID 0000.0001)           User time:  0.46418762207031250
+(PID.TID 0000.0001)         System time:   1.2505888938903809E-002
+(PID.TID 0000.0001)     Wall clock time:  0.54946827888488770
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXF_GETFORCING     [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.44845962524414062
-(PID.TID 0000.0001)         System time:   4.0280222892761230E-003
-(PID.TID 0000.0001)     Wall clock time:  0.45336008071899414
+(PID.TID 0000.0001)           User time:  0.46301746368408203
+(PID.TID 0000.0001)         System time:   1.2495994567871094E-002
+(PID.TID 0000.0001)     Wall clock time:  0.54828572273254395
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   3.3378601074218750E-005
-(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
-(PID.TID 0000.0001)     Wall clock time:   4.5061111450195312E-005
+(PID.TID 0000.0001)           User time:   3.7193298339843750E-005
+(PID.TID 0000.0001)         System time:   1.0728836059570312E-006
+(PID.TID 0000.0001)     Wall clock time:   4.2915344238281250E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CTRL_MAP_FORCING  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.8994979858398438E-002
-(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
-(PID.TID 0000.0001)     Wall clock time:   8.9005470275878906E-002
+(PID.TID 0000.0001)           User time:   8.9632987976074219E-002
+(PID.TID 0000.0001)         System time:   1.1003017425537109E-004
+(PID.TID 0000.0001)     Wall clock time:   9.1415405273437500E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8727531433105469E-002
+(PID.TID 0000.0001)           User time:   2.8412818908691406E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.8748989105224609E-002
+(PID.TID 0000.0001)     Wall clock time:   2.8414487838745117E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   15.369031906127930
-(PID.TID 0000.0001)         System time:   8.1000328063964844E-003
-(PID.TID 0000.0001)     Wall clock time:   15.381288051605225
+(PID.TID 0000.0001)           User time:   15.386451721191406
+(PID.TID 0000.0001)         System time:   1.5220165252685547E-002
+(PID.TID 0000.0001)     Wall clock time:   15.470916986465454
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_MODEL    [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   5.4815969467163086
-(PID.TID 0000.0001)         System time:   2.7000904083251953E-005
-(PID.TID 0000.0001)     Wall clock time:   5.4831340312957764
+(PID.TID 0000.0001)           User time:   5.5001220703125000
+(PID.TID 0000.0001)         System time:   5.1021575927734375E-005
+(PID.TID 0000.0001)     Wall clock time:   5.5253348350524902
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SEAICE_DYNSOLVER   [SEAICE_MODEL]":
-(PID.TID 0000.0001)           User time:   5.1677360534667969
+(PID.TID 0000.0001)           User time:   5.1844520568847656
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   5.1692459583282471
+(PID.TID 0000.0001)     Wall clock time:   5.2088625431060791
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "GGL90_CALC [DO_OCEANIC_PHYS]":
-(PID.TID 0000.0001)           User time:   3.0366601943969727
-(PID.TID 0000.0001)         System time:   4.0610432624816895E-003
-(PID.TID 0000.0001)     Wall clock time:   3.0418250560760498
+(PID.TID 0000.0001)           User time:   2.9577531814575195
+(PID.TID 0000.0001)         System time:   2.9679536819458008E-003
+(PID.TID 0000.0001)     Wall clock time:   2.9798564910888672
 (PID.TID 0000.0001)          No. starts:          96
 (PID.TID 0000.0001)           No. stops:          96
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.494777679443359
-(PID.TID 0000.0001)         System time:   3.8540363311767578E-003
-(PID.TID 0000.0001)     Wall clock time:   16.515392065048218
+(PID.TID 0000.0001)           User time:   16.605000495910645
+(PID.TID 0000.0001)         System time:   3.9310455322265625E-003
+(PID.TID 0000.0001)     Wall clock time:   16.637964487075806
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.30253410339355469
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:  0.30254912376403809
+(PID.TID 0000.0001)           User time:  0.41620635986328125
+(PID.TID 0000.0001)         System time:   7.3075294494628906E-005
+(PID.TID 0000.0001)     Wall clock time:  0.41664981842041016
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.4047451019287109
-(PID.TID 0000.0001)         System time:   3.9519667625427246E-003
-(PID.TID 0000.0001)     Wall clock time:   2.4092507362365723
+(PID.TID 0000.0001)           User time:   2.4403753280639648
+(PID.TID 0000.0001)         System time:   6.4849853515625000E-005
+(PID.TID 0000.0001)     Wall clock time:   2.4424858093261719
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31227493286132812
-(PID.TID 0000.0001)         System time:   5.1081180572509766E-005
-(PID.TID 0000.0001)     Wall clock time:  0.31234622001647949
+(PID.TID 0000.0001)           User time:  0.28809070587158203
+(PID.TID 0000.0001)         System time:   1.2040138244628906E-005
+(PID.TID 0000.0001)     Wall clock time:  0.28832674026489258
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.56554698944091797
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.56582474708557129
+(PID.TID 0000.0001)           User time:  0.58477497100830078
+(PID.TID 0000.0001)         System time:   3.9669275283813477E-003
+(PID.TID 0000.0001)     Wall clock time:  0.58895373344421387
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.3960342407226562E-002
-(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
-(PID.TID 0000.0001)     Wall clock time:   3.3971071243286133E-002
+(PID.TID 0000.0001)           User time:   3.2242774963378906E-002
+(PID.TID 0000.0001)         System time:   2.9802322387695312E-006
+(PID.TID 0000.0001)     Wall clock time:   3.2254934310913086E-002
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.42747306823730469
-(PID.TID 0000.0001)         System time:   4.0189623832702637E-003
-(PID.TID 0000.0001)     Wall clock time:  0.43152904510498047
+(PID.TID 0000.0001)           User time:  0.38834571838378906
+(PID.TID 0000.0001)         System time:   2.8108000755310059E-002
+(PID.TID 0000.0001)     Wall clock time:  0.41657781600952148
 (PID.TID 0000.0001)          No. starts:          16
 (PID.TID 0000.0001)           No. stops:          16
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   16.687347412109375
-(PID.TID 0000.0001)         System time:   7.9140067100524902E-003
-(PID.TID 0000.0001)     Wall clock time:   16.708460330963135
+(PID.TID 0000.0001)           User time:   16.870871543884277
+(PID.TID 0000.0001)         System time:   4.1490793228149414E-003
+(PID.TID 0000.0001)     Wall clock time:   16.888961553573608
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.6702880859375000E-005
-(PID.TID 0000.0001)         System time:   1.0132789611816406E-006
-(PID.TID 0000.0001)     Wall clock time:   4.1007995605468750E-005
+(PID.TID 0000.0001)           User time:   4.0054321289062500E-005
+(PID.TID 0000.0001)         System time:   1.0728836059570312E-006
+(PID.TID 0000.0001)     Wall clock time:   4.0054321289062500E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.1139574050903320
-(PID.TID 0000.0001)         System time:   4.3988227844238281E-005
-(PID.TID 0000.0001)     Wall clock time:   3.1151030063629150
+(PID.TID 0000.0001)           User time:   3.1130828857421875
+(PID.TID 0000.0001)         System time:   7.2956085205078125E-005
+(PID.TID 0000.0001)     Wall clock time:   3.1144797801971436
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_TILE           [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7683715820312500E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.9100646972656250E-005
+(PID.TID 0000.0001)           User time:   2.6702880859375000E-005
+(PID.TID 0000.0001)         System time:   9.5367431640625000E-007
+(PID.TID 0000.0001)     Wall clock time:   3.5762786865234375E-005
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6467838287353516
-(PID.TID 0000.0001)         System time:  0.32749503850936890
-(PID.TID 0000.0001)     Wall clock time:   4.0713934898376465
+(PID.TID 0000.0001)           User time:   3.7590522766113281
+(PID.TID 0000.0001)         System time:  0.25174915790557861
+(PID.TID 0000.0001)     Wall clock time:   4.1479270458221436
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.3832950592041016
-(PID.TID 0000.0001)         System time:  0.27969193458557129
-(PID.TID 0000.0001)     Wall clock time:   1.7364521026611328
+(PID.TID 0000.0001)           User time:   1.3772354125976562
+(PID.TID 0000.0001)         System time:  0.22763299942016602
+(PID.TID 0000.0001)     Wall clock time:   1.6808328628540039
 (PID.TID 0000.0001)          No. starts:           8
 (PID.TID 0000.0001)           No. stops:           8
 (PID.TID 0000.0001)   Seconds in section "COST_AVERAGESFIELDS [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.38261413574218750
-(PID.TID 0000.0001)         System time:   3.5899996757507324E-002
-(PID.TID 0000.0001)     Wall clock time:  0.42853999137878418
+(PID.TID 0000.0001)           User time:  0.42007446289062500
+(PID.TID 0000.0001)         System time:   7.9270601272583008E-003
+(PID.TID 0000.0001)     Wall clock time:  0.43480920791625977
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "PROFILES_INLOOP    [THE_MAIN_LOOP]":
 (PID.TID 0000.0001)           User time:   3.4332275390625000E-004
-(PID.TID 0000.0001)         System time:   6.0796737670898438E-006
-(PID.TID 0000.0001)     Wall clock time:   3.5214424133300781E-004
+(PID.TID 0000.0001)         System time:   5.9604644775390625E-006
+(PID.TID 0000.0001)     Wall clock time:   3.5190582275390625E-004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_DRIVER        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   1.7855911254882812
-(PID.TID 0000.0001)         System time:  0.10784792900085449
-(PID.TID 0000.0001)     Wall clock time:   2.0247499942779541
+(PID.TID 0000.0001)           User time:   1.9313201904296875
+(PID.TID 0000.0001)         System time:  0.16791999340057373
+(PID.TID 0000.0001)     Wall clock time:   3.8628830909729004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_GENCOST_ALL  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.3925018310546875
-(PID.TID 0000.0001)         System time:   8.7903976440429688E-002
-(PID.TID 0000.0001)     Wall clock time:   1.6015319824218750
+(PID.TID 0000.0001)           User time:   1.4985504150390625
+(PID.TID 0000.0001)         System time:  0.14791500568389893
+(PID.TID 0000.0001)     Wall clock time:   3.3823699951171875
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "CTRL_COST_DRIVER  [COST_DRIVER]":
-(PID.TID 0000.0001)           User time:  0.39306640625000000
-(PID.TID 0000.0001)         System time:   1.9942998886108398E-002
-(PID.TID 0000.0001)     Wall clock time:  0.42320013046264648
+(PID.TID 0000.0001)           User time:  0.43274688720703125
+(PID.TID 0000.0001)         System time:   2.0004987716674805E-002
+(PID.TID 0000.0001)     Wall clock time:  0.48049497604370117
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "COST_FINAL         [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   9.3078613281250000E-004
-(PID.TID 0000.0001)         System time:   1.6093254089355469E-005
-(PID.TID 0000.0001)     Wall clock time:   9.4699859619140625E-004
+(PID.TID 0000.0001)           User time:   1.0910034179687500E-003
+(PID.TID 0000.0001)         System time:   2.2053718566894531E-005
+(PID.TID 0000.0001)     Wall clock time:   9.4919204711914062E-003
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001) // ======================================================

--- a/update_history
+++ b/update_history
@@ -1,6 +1,9 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #1014 (seaice lsr.F bug fix): update affected reference output
+    (when SEAICEselectMetricTerms=2): 2 cs32 + 3 forward llc90.
+
 checkpoint69p (2026/07/24) synchronised with main MITgcm code.
 checkpoint69o (2026/07/06) synchronised with main MITgcm code.
 checkpoint69n (2026/05/08) synchronised with main MITgcm code.


### PR DESCRIPTION
A bug (seaiceMaskU) was fixed in `seaice_lsr.F` (PR https://github.com/MITgcm/MITgcm/pull/1014) in the computation of metric-terms (i.e., when using SEAICEselectMetricTerms=2), see also issue https://github.com/MITgcm/MITgcm/issues/1012.

This PR updates the reference output of test experiments that are affected by this bug:
1. forward and adjoint cs32 primary test (note: secondary AD test ".sens" not affected much, skip this update)
2. forward llc90 tests (except ".ecco_v4", which uses SEAICEselectMetricTerms=1).

No effect on llc90 AD tests (the only one using `pkg/seaice`, i.e., ecco_v4, uses SEAICEselectMetricTerms=1).