### PR TITLE
Post PR 1025 output update

### DIFF
--- a/global_ocean.gm_k3d/results/output.txt
+++ b/global_ocean.gm_k3d/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68s
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Wed Oct 18 15:30:50 EDT 2023
+(PID.TID 0000.0001) // Build date:        Wed Aug 19 17:07:04 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -366,7 +366,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -690,37 +694,37 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   252
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   268
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOTSQ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    75 PHIBOTSQ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    47 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    32 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    38 WVELSQ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    64 RHOAnoma
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 CONVADJ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   205 GM_Kwx
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   206 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   207 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    65 RHOAnoma
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    80 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   212 GM_Kwx
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   213 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   214 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all diagnostics:     185 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   205  GM_Kwx   , Parms: UM      LR , mate:   206
-(PID.TID 0000.0001)   set mate pointer for diag #   206  GM_Kwy   , Parms: VM      LR , mate:   205
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   212  GM_Kwx   , Parms: UM      LR , mate:   213
+(PID.TID 0000.0001)   set mate pointer for diag #   213  GM_Kwy   , Parms: VM      LR , mate:   212
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: oceDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     185 levels (numDiags =     300 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -733,14 +737,12 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    38 WVELSQ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    64 RHOAnoma
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    79 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    65 RHOAnoma
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    80 CONVADJ
 (PID.TID 0000.0001)   space allocated for all stats-diags:     138 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use     138 levels (diagSt_size=     300 )
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
-(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) Empty tile: #    30 (bi,bj=   3   4 )
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4265546244797E-04
@@ -979,7 +981,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -1059,17 +1061,14 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectMetricTerms= /* Scheme selector for Horizontal Metric Terms */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : Off (ignore Spherical/Cylindrical Metric Terms)
+(PID.TID 0000.0001)    = 1 : original discretization
+(PID.TID 0000.0001)    = 2 : using (Spherical) grid-spacing
+(PID.TID 0000.0001)    = 3 : as 2 but gU-Metric inside Advection
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -1078,12 +1077,23 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
 (PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
 (PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
+(PID.TID 0000.0001)    = 4 : hFac weighted average (Angular Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1123,6 +1133,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doThetaClimRelax = /* apply SST relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1210,7 +1223,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -1893,6 +1906,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.450614146649756E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 1.523452939709265E+11
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 2.315000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 2.930900000000000E+04
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) the_run_name = /* Name of this simulation */
 (PID.TID 0000.0001)               'global_ocean.90x40x15'
 (PID.TID 0000.0001)     ;
@@ -1981,6 +2003,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_useBatesK3d = /* if TRUE => use BatesK3d for GM diffusivity */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -2013,6 +2038,8 @@
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: ncep_emp.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sst.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sss.bin
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001)  write diagnostics summary to file ioUnit:      6
 Iter.Nb:         0 ; Time(s):  0.0000000000000E+00
 ------------------------------------------------------------------------
@@ -2026,16 +2053,16 @@ listId=    1 ; file name: surfDiag
     23 |ETAN    |      1 |      0 |   1 |       0 |
     24 |ETANSQ  |      2 |      0 |   1 |       0 |
     25 |DETADT2 |      3 |      0 |   1 |       0 |
-    73 |PHIBOT  |      4 |      0 |   1 |       0 |
-    74 |PHIBOTSQ|      5 |      0 |   1 |       0 |
+    74 |PHIBOT  |      4 |      0 |   1 |       0 |
+    75 |PHIBOTSQ|      5 |      0 |   1 |       0 |
 ------------------------------------------------------------------------
 listId=    2 ; file name: dynDiag
  nFlds, nActive,       freq     &     phase        , nLev               
     6  |    6  |    864000.000000         0.000000 |  15
  levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-    45 |UVELMASS|      6 |     21 |  15 |       0 |       0 |
-    46 |VVELMASS|     21 |      6 |  15 |       0 |       0 |
+    46 |UVELMASS|      6 |     21 |  15 |       0 |       0 |
+    47 |VVELMASS|     21 |      6 |  15 |       0 |       0 |
     32 |WVEL    |     36 |      0 |  15 |       0 |
     26 |THETA   |     51 |      0 |  15 |       0 |
     27 |SALT    |     66 |      0 |  15 |       0 |
@@ -2046,12 +2073,12 @@ listId=    3 ; file name: oceDiag
     6  |    6  |    864000.000000         0.000000 |  15
  levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-    64 |RHOAnoma|     96 |      0 |  15 |       0 |
-    78 |DRHODR  |    111 |      0 |  15 |       0 |
-    79 |CONVADJ |    126 |      0 |  15 |       0 |
-   205 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
-   206 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
-   207 |GM_Kwz  |    171 |      0 |  15 |       0 |
+    65 |RHOAnoma|     96 |      0 |  15 |       0 |
+    79 |DRHODR  |    111 |      0 |  15 |       0 |
+    80 |CONVADJ |    126 |      0 |  15 |       0 |
+   212 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
+   213 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
+   214 |GM_Kwz  |    171 |      0 |  15 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     2
 ------------------------------------------------------------------------
@@ -2075,9 +2102,9 @@ listId=   2 ; file name: oceStDiag
     3  |    3  |   2592000.000000         0.000000 |
  Regions:   0
  diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
-    64 |RHOAnoma|     94 |      0 | 0.00000E+00 |
-    78 |DRHODR  |    109 |      0 | 0.00000E+00 |
-    79 |CONVADJ |    124 |      0 | 0.00000E+00 |
+    65 |RHOAnoma|     94 |      0 | 0.00000E+00 |
+    79 |DRHODR  |    109 |      0 | 0.00000E+00 |
+    80 |CONVADJ |    124 |      0 | 0.00000E+00 |
 ------------------------------------------------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
@@ -2210,15 +2237,15 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4877872181906E-06
 (PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2517961305325E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9728054875999E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9001762389149E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9002108847545E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197724302515E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171732187342E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6178760109057E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7463731105160E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4172006434074E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6234842203075E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7471986894621E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754801130016E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005931612E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613653999259E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0134714574705E-03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9614951912190E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0144216394829E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2589080810547E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8702698516846E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6700205338390E+01
@@ -2244,9 +2271,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.3653356424172E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5157892194461E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4595114894327E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4054823754733E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.7188508438575E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5000215817829E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.4031315132498E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   3.7172097446577E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.4971760037403E-01
 (PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.3090086855632E-03
 (PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1713738838292E-03
 (PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1976122965097E-02
@@ -2261,51 +2288,51 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604246321620E-05
 (PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655725552E-05
 (PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162541671689E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1146570946742E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7416746440331E-07
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1147655272483E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7417580362175E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.19824186312956E-03  2.64084066567303E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.69554327123605E-01
+ cg2d: Sum(rhs),rhsMax =   7.18293638918555E-03  2.64646779583191E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.65141658547679E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.40096816183781E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.36672672879418E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0285855867950E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3158555567357E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248845E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4264819776323E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5958585789729E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1597165812308E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2721567753622E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3944237129519E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3860906776214E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3931286271120E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5653208439293E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.2923270938792E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2472802982222E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.1952192651173E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.3814021855052E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0695551245843E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6487158050696E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9115318953491E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1783455167384E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6783366768201E-07
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0285957563421E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3159402664391E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248847E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4265083261688E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5972724899899E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1594153994258E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -3.2720620133782E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3944909844761E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3866553672445E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.3972041332964E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   3.5625830669804E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -4.2919188052195E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2473395121804E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.1957232563431E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.3836836407160E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0738679891303E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6595662622836E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9104197662105E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1790489432843E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6808223788976E-07
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722308005702E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9008346573785E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197819091101E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170122129282E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5917248130378E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7452028229035E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9008647528786E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197819215894E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170551171993E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6005722122010E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7468252890638E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755557241746E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518206E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9607905899772E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0181103879290E-03
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004515686E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610287266199E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0201573246028E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2693899536133E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8655982259115E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6687693382567E+01
@@ -2331,68 +2358,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2915731155564E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5261152700224E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4588571962377E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.0375272919735E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7498083766322E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1157889881859E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0815673763508E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.3393031369056E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.3869367200762E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   3.9922876946649E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5072558072876E-04
-(PID.TID 0000.0001) %MON ke_max                       =   8.8892753580871E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1192011852104E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.9563895576370E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7465948294875E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.1141060937972E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0836925488627E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   8.3385098975215E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4460774133388E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.0619986699444E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5072856561437E-04
+(PID.TID 0000.0001) %MON ke_max                       =   8.8875991455197E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1195144901717E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782213082E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7624393898787E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   1.4426470977407E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807287184E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604184698675E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642652918E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162947583969E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8472317992664E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9396412983158E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -1.7624453666977E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   1.4425741984474E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807287290E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604184697720E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642653051E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162947628447E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8472409123682E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9394524678053E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.19283869484093E-02  2.40538789309102E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.88220013995103E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.20129636285750E-14
+ cg2d: Sum(rhs),rhsMax =   1.18538620329358E-02  2.42051050283090E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.58859115645483E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
+(PID.TID 0000.0001)      cg2d_last_res =   9.76550414099329E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9400806269462E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5798403757555E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231130E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3005182337299E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4443367949570E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0030273173681E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.6559298561136E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2257652153469E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4733425309193E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6797456554622E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0583333902776E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2109575558593E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1325823962766E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.7735640851030E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1519046695087E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4752643292296E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2795150759033E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9383245156908E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6155366927860E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2738711102079E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716044173787E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9014896836854E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198503546259E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169559785271E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5351759996237E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7443438306178E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755613726605E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004666549E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606240316603E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0157025366165E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9401390722794E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5798666183879E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231133E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3005440204927E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4480899750812E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   5.0260424527041E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.6557011511816E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2257964885807E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4752134628586E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.6911570238441E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.0515968871693E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2118467865757E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1327327590838E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.7755445219351E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.1595428898853E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4812392758337E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2822507978961E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9435752803835E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6180488477242E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2807085998142E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716044191697E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9019488595848E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198505116634E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170178496570E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5498681227140E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7462127431680E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755614054244E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004667866E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9609648535519E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0189886784668E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2798718261719E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8609266001383E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6675181426744E+01
@@ -2418,68 +2445,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2178105886956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5379778517573E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.5916638539381E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7669022795310E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.6479695493555E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6451734887751E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2066894413202E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.5982103655036E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2025784810338E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5951576605136E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0576664464422E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1129660784435E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   4.5930188160917E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.5915962993516E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1766657577963E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6315818264913E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2068622045868E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6156568538561E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2223175027078E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5951926411274E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.0594437247389E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1145848989536E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781986628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3766780911043E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0010725963208E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209482E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604169458268E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640488223E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163345285209E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3824488720338E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2633907191561E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3767335008126E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0009677569468E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807209146E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604169468092E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640490381E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163345373195E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3822001425909E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2631026503684E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.73511265539675E-02  2.21854415885629E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.78154868559106E-01
+ cg2d: Sum(rhs),rhsMax =   1.73621488140904E-02  2.21713572888061E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.56057948434110E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.18599366430738E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.84112682195968E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7452684587046E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6006971544695E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451990E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5727120235969E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3508030184768E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0071937348665E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8578845582734E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4741226723404E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6303081493818E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7452565026647E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2556296920411E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8278411545787E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6183744695476E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2110122664686E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6561569583175E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8015611624962E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5177480137856E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.9742590067866E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9719244270197E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7294389479347E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9710411433299E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9021344497034E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199346327544E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169382742829E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4677794573327E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435891681762E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754870761039E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005975710E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605894617121E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0139208330756E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7459554391992E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.6007539379491E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451985E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5726638614843E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3549732074860E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   7.0342935959449E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.8592026228615E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4742519347842E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.6339999012195E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.7681304024183E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.2431291554846E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.8319009497469E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6187506157777E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.2146952533560E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.6698409173481E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8064731821151E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5224741722079E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.0664635760827E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9762705221999E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7412679892867E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9710411548256E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9128206739471E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199349961927E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170201415729E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4831562668641E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7453425818279E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754871793134E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005984433E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610411329747E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0178731044561E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2903536987305E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8562549743652E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6662669470921E+01
@@ -2505,68 +2532,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1440480618348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6510809416035E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1831791793885E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5819370324460E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2695655884255E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5208239928561E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.6415591775249E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.3832525072064E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9738779272179E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.5960769920979E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.3552893627394E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.9847351616785E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.7795529871241E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.1831153172778E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.2633422136575E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5216127459460E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.6565590475652E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.4002227180546E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9738092391230E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.5984312683857E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.3592313107351E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6081521606623E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2158678826405E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807117001E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185055845E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649830954E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163575667269E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0526453706598E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2056812335894E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6090152306296E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2160582610682E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807114822E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185087898E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649818415E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163575749295E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0525679390165E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2018551577152E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.40181507944756E-02  2.01576461884639E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.38116340694593E-01
+ cg2d: Sum(rhs),rhsMax =   2.38845692672105E-02  2.02703837946583E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.51479766778670E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.81547749455509E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.60676729628975E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8761459228581E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5497031628780E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911402E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5667298857627E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2640954486002E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0539158168804E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8296466446528E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8577823056758E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8715013538903E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.5879343753791E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3638630907844E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.2145845008607E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6778237036573E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4031408911984E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8540740151901E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0297372661958E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6716444506730E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   2.6766491253412E-12
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2365164291482E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0312131861976E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9705984790108E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028099963173E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200164354285E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169360980727E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3936557925468E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7430985245439E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753520150718E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007495300E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605799692826E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0116531605948E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8747793645439E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5497316121212E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911399E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5666028271760E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2664523950356E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   9.0850122329962E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8332284823076E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8577448318923E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8752962862232E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.6110324310462E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.3628244893419E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.2139398979757E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6786094386290E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.4081555838662E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   8.8705047265686E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0374342312059E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6785548112719E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.7566935705710E-11
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2414777671961E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0436111000399E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9705985078124E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9316963694589E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200170745588E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170355280787E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4102796383632E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7443432902444E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753522003903E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007516643E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9611353462391E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0163238367540E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3008355712891E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8515833485921E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6650157515098E+01
@@ -2592,68 +2619,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5182524902451E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.6611988106844E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5110553834955E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8934724104636E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7902459843493E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4004778096035E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.2421044582851E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9653514218738E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.3873465862690E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.7609349283604E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5191178623832E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.4364962489859E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5119136494896E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8857858337931E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.7901207483469E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.4240436885245E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.2687698246529E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9651704085936E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.3900918424170E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.7667466021380E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5048490269060E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.1282849934173E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807042198E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217446064E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661310853E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163652165584E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1163957093681E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0236758928935E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5061324892623E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.1291352948500E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807040569E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217480270E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661291302E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163652310792E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.1136901827638E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0246128479108E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.25259823795894E-02  1.79716299464722E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.68467196838569E-01
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.60697861579319E-14
+ cg2d: Sum(rhs),rhsMax =   3.23108385782996E-02  1.80912952028462E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.34216174876071E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
+(PID.TID 0000.0001)      cg2d_last_res =   9.81752530192113E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0322556456152E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5012496599892E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609404E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4688933204061E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1755153121988E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1048932828576E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.5638651213784E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8061135803988E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1752719312028E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2283112340879E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2533755809608E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0329413262862E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2373706770142E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3086419118443E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.7240005418242E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1490337624441E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7327745072023E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6463678234462E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4053077924816E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1794111228656E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9702575955406E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9035096112554E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200909616189E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169364539521E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3182807371533E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7429259802022E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751839461958E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008703397E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605836871481E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0099188021775E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0320763380123E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5014147621541E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609402E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4687531283801E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1765275429573E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.1082357645681E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.5664036194182E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8058422741228E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.1790980554512E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.2495465408930E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.2492273871615E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0327977305113E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.9233857840211E-07
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.3151876535178E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.7428982425754E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1590845711356E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7418761250523E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6446567723960E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4102425742824E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1902511837915E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9702576314989E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9336665431415E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200919065765E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170541606025E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3369080325266E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433765778277E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751841999790E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008740701E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9612427095763E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0151074731840E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3113174438477E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8469117228190E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6637645559275E+01
@@ -2679,68 +2706,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9965230081132E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.6960764354126E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6968532129347E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.0167288901682E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.5396775582561E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0068393331025E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9611376805517E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8757255433277E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8271931010586E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3249783077519E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.2396499651788E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5850408704369E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.3624759448293E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5745959204954E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4709890423252E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0065603495418E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9884786605411E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.9066672932792E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8269968877637E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.3280285651273E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.2476168960051E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3982398327786E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.0978421875217E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806999812E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257512686E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668362887E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163639262630E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0673715604640E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1889566755307E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.3969461327002E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.0990853068528E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274806997896E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257557303E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668332425E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163639661737E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0692498765161E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1901882621774E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.36100013893281E-02  1.57332947091255E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.28600911626996E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.38563906440047E-14
+ cg2d: Sum(rhs),rhsMax =   4.32698260005959E-02  1.58569855148888E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.55002400739184E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
+(PID.TID 0000.0001)      cg2d_last_res =   9.68974628437308E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0917306898126E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4653892813964E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545966E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3616333678086E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0863164840790E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2914049742637E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.0416242449303E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5926093446021E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.5051118418188E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.7082165233282E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8694251091007E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1065715296614E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9247033221178E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9232423570130E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0269979037802E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1665192647474E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8007131592003E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8124352346940E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4815143921838E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1938034853182E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699789946443E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9042468620250E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201589330980E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169368195670E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2457076624578E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7428440751353E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750127304290E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009485146E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605935232739E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0085111425769E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0915468667839E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4655023108579E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545969E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3614932594072E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0818355565028E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2947415307751E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.0430300030962E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5923987060331E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.5086752037188E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.7164966184734E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.8610058796945E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1063416783498E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9241640673394E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.9310393199938E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0287294110730E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1733540021649E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8262494156537E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8086655238242E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4853507194809E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1921524776692E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699790264753E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9475263557890E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201602271448E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170716471261E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2672233552277E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7426164161039E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750130236152E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009542879E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613537914481E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0144749351626E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164062E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8422400970459E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6625133603452E+01
@@ -2766,68 +2793,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9227604812524E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5428261471424E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0780179283847E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5233506267686E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.0143034554910E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1498910093955E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3112555742873E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2719178436617E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6785427462724E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.3073304016956E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   7.7118755936426E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.5422105374155E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   7.0840502265166E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.5227561148265E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9920974486451E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.1494444451609E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3312949039410E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2945897013843E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6783504960468E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3108238193276E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.7215783125505E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5131623880930E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.2614941772689E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807004568E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298811512E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669448647E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163594451975E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7355445731956E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9855957798938E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.5114357215801E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.2632543824452E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807002992E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298854602E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669409795E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163594897912E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7375130261609E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9866288468002E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.81048037411143E-02  1.35772189299144E+00
-(PID.TID 0000.0001)      cg2d_init_res =   1.17340260294000E+00
-(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.56583043054020E-14
+ cg2d: Sum(rhs),rhsMax =   5.75744927118402E-02  1.37022768958008E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.62742102578432E-01
+(PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
+(PID.TID 0000.0001)      cg2d_last_res =   9.36084578285345E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0695119071568E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4352421265092E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721100E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2821196062772E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9895636941463E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4584911175158E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2621209719035E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.3080932931421E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8186456634188E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0505723849939E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2124181000822E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1415858609817E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9446404137476E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0259292104907E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0508436450610E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1821186527504E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8975877507481E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1464209341079E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4733331710191E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0771658265326E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697420233150E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9050226316197E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202226169865E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169372807813E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1778134593685E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7427126537622E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748637444170E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009933985E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606148768783E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0077081393541E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0693762661496E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4353226329333E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721105E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2820629106957E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9903667794545E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4615974336965E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2625148602326E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.3033987935801E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.8224551624806E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0570209828943E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.1993211180670E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1408808362459E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9440172228225E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0268526298422E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0526697055587E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1868426687408E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9227927793961E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1625477563051E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4770344369877E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0721892325425E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697420503297E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9476883842794E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202243488577E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170868206714E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2028307298346E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7423547637697E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748640409911E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010021523E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9614513445567E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0147648586744E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3322811889648E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8375684712728E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6612621647628E+01
@@ -2853,68 +2880,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.2901865223541E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   9.1389432607016E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.5254857610810E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4358913718381E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2179182395273E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.4200566587095E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.3950935446143E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5702462494843E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1240843688464E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   9.1091094023645E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.4239000299239E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.3624213349809E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   2.6519490627841E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.4265534541498E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2165484895380E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.4337937093865E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.4106369379273E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5701696075665E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.1245365071189E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   9.1210169836215E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9407421326669E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.4551336506605E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807049325E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336510427E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665671744E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550098998E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2614455506114E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.5009076146937E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.9467981168303E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.4537105009346E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807047902E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336559030E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665628803E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550582051E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2612389638853E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4980770978773E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   6.90430904826673E-02  1.29319650116630E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.76394069166657E-01
+ cg2d: Sum(rhs),rhsMax =   7.40712377992796E-02  1.20541097590218E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.45073255278046E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.82457400168641E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.54515980379815E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8825072514207E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4075384562417E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134810E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2485699330130E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9086470495925E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6008644410025E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2865044227247E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5152221862889E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1074296738773E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.3136344585597E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2912502202158E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1653729732031E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1262282635885E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0344726650475E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0485432338140E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1296409044361E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9396833465223E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1314446050671E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3979202485261E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8708646894339E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695477956133E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9116489222056E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202837954352E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169413241731E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1182449666938E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7425493656240E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9747539220671E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010187582E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606444862254E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0072349852916E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8824619596867E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4075876040269E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134806E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2485448271392E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9091309008849E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.6036369603119E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.2859498338679E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5159864783222E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1078368439851E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.3173747738348E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.2727431922906E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1646375592279E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1260999060400E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0355134695484E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0503755385328E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.1318786488133E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9633360041563E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1309396261931E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4010930006868E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.8616435909888E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695478052697E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9537406258383E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202859352784E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171064972861E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1467703566713E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7424164829981E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9747541847770E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010301225E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9615712177337E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0151963869309E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3427630615234E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8328968454997E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6600109691805E+01
@@ -2940,68 +2967,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.7073705927011E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   6.6252784692877E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   9.6302284455572E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7648939319466E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2641327835794E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3147312134609E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2760103572886E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5250382160683E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.3045653371621E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0381452181614E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.5299498638789E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.1596882705922E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   8.4565475862515E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.7551602804548E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2627039921717E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.3207471404942E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.2828180701905E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5250044930415E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.3052336261636E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0395223050181E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3438298320797E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6547539324193E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807118005E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367324589E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658662851E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518318062E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3324391833282E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6111805631451E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3518153000242E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.6528254149719E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807116975E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367374415E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658622202E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518943121E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3310397117051E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.6076033424139E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   8.51565955181952E-02  1.17197331045202E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.21079353132107E-01
+ cg2d: Sum(rhs),rhsMax =   8.74206185218349E-02  1.14162149437730E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.38683710846844E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.52663149918248E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.55969527310670E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7942544718851E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3835118220314E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787087E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2642506748513E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8414094708889E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7143204927278E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5766195783696E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1480348761495E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2232025246373E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5311888420439E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.3333248323417E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1549093168113E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7012165914170E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0222351591285E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0258155602910E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0148317754004E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9270690818353E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4921926987445E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2742350492033E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6087906450107E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694100674406E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9129086131433E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203437430433E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169491440813E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0670121315615E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7424225890537E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9746915112430E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010380920E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606750981259E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0070936076174E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7967455405321E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3835243741873E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787086E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2642609629790E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8421168545232E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7166848522855E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.5851820333155E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1491179180074E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2236626417344E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5355925580569E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.3441342117148E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1542978359119E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7012379806462E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0233671399037E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0275921442125E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0146502959210E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9481343190521E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4917241155122E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2772884499309E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.5982816124822E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9694100496085E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9590233543159E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203463364470E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171298334081E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0988715115767E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7425242059310E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9746917090261E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010525711E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9616952150019E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0159397638298E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3532449340820E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8282252197266E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6587597735982E+01
@@ -3027,206 +3054,206 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9002360978858E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3592695292239E-01
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.8453942310846E-01
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9794746616406E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2438035773788E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0077412020167E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.9287547984109E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5461338772180E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.4657332036848E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1496656965508E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.7118514239169E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3595160539013E-01
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3495990216742E-01
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   4.9761337433136E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2426155680609E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.0062839941642E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.9271074464797E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5461477378999E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.4667417967614E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1512170688666E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6791416277665E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.8549509887023E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807182305E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389889761E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649853956E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163499951727E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1224124657517E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7849750297558E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6891456192348E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   2.8549452541773E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807181359E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389944061E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649820641E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163500550503E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1211309165076E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7835154092087E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #     23  ETAN         Counter:      10   Parms: SM      M1      
- Computing Diagnostic #     24  ETANSQ       Counter:      10   Parms: SM P    M1      
- Computing Diagnostic #     25  DETADT2      Counter:      10   Parms: SM      M1      
- Computing Diagnostic #     73  PHIBOT       Counter:      10   Parms: SM      M1      
- Computing Diagnostic #     74  PHIBOTSQ     Counter:      10   Parms: SM P    M1      
- Computing Diagnostic #     45  UVELMASS     Counter:      10   Parms: UUr     MR      
-           Vector  Mate for  UVELMASS     Diagnostic #     46  VVELMASS exists 
- Computing Diagnostic #     46  VVELMASS     Counter:      10   Parms: VVr     MR      
-           Vector  Mate for  VVELMASS     Diagnostic #     45  UVELMASS exists 
- Computing Diagnostic #     32  WVEL         Counter:      10   Parms: WM      LR      
- Computing Diagnostic #     26  THETA        Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     27  SALT         Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     38  WVELSQ       Counter:      10   Parms: WM P    LR      
- Computing Diagnostic #     64  RHOAnoma     Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     78  DRHODR       Counter:      10   Parms: SM      LR      
- Computing Diagnostic #     79  CONVADJ      Counter:      10   Parms: SMR     LR      
- Computing Diagnostic #    205  GM_Kwx       Counter:      10   Parms: UM      LR      
-           Vector  Mate for  GM_Kwx       Diagnostic #    206  GM_Kwy   exists 
- Computing Diagnostic #    206  GM_Kwy       Counter:      10   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    205  GM_Kwx   exists 
- Computing Diagnostic #    207  GM_Kwz       Counter:      10   Parms: WM P    LR      
+ Computing Diagnostic #    23 "ETAN    " (list#  1) Parms "SM      M1      ", Count=      10
+ Computing Diagnostic #    24 "ETANSQ  " (list#  1) Parms "SM P    M1      ", Count=      10
+ Computing Diagnostic #    25 "DETADT2 " (list#  1) Parms "SM      M1      ", Count=      10
+ Computing Diagnostic #    74 "PHIBOT  " (list#  1) Parms "SM      M1      ", Count=      10
+ Computing Diagnostic #    75 "PHIBOTSQ" (list#  1) Parms "SM P    M1      ", Count=      10
+ Computing Diagnostic #    46 "UVELMASS" (list#  2) Parms "UUr     MR      ", Count=      10
+             Vector  Mate for "UVELMASS" :  Diagnostic #     47 "VVELMASS" exists
+ Computing Diagnostic #    47 "VVELMASS" (list#  2) Parms "VVr     MR      ", Count=      10
+             Vector  Mate for "VVELMASS" :  Diagnostic #     46 "UVELMASS" exists
+ Computing Diagnostic #    32 "WVEL    " (list#  2) Parms "WM      LR      ", Count=      10
+ Computing Diagnostic #    26 "THETA   " (list#  2) Parms "SMR     MR      ", Count=      10
+ Computing Diagnostic #    27 "SALT    " (list#  2) Parms "SMR     MR      ", Count=      10
+ Computing Diagnostic #    38 "WVELSQ  " (list#  2) Parms "WM P    LR      ", Count=      10
+ Computing Diagnostic #    65 "RHOAnoma" (list#  3) Parms "SMR     MR      ", Count=      10
+ Computing Diagnostic #    79 "DRHODR  " (list#  3) Parms "SM      LR      ", Count=      10
+ Computing Diagnostic #    80 "CONVADJ " (list#  3) Parms "SMR     LR      ", Count=      10
+ Computing Diagnostic #   212 "GM_Kwx  " (list#  3) Parms "UM      LR      ", Count=      10
+             Vector  Mate for "GM_Kwx  " :  Diagnostic #    213 "GM_Kwy  " exists
+ Computing Diagnostic #   213 "GM_Kwy  " (list#  3) Parms "VM      LR      ", Count=      10
+             Vector  Mate for "GM_Kwy  " :  Diagnostic #    212 "GM_Kwx  " exists
+ Computing Diagnostic #   214 "GM_Kwz  " (list#  3) Parms "WM P    LR      ", Count=      10
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.163372689392418
-(PID.TID 0000.0001)         System time:  0.34001099457964301
-(PID.TID 0000.0001)     Wall clock time:   15.630686998367310
+(PID.TID 0000.0001)           User time:   10.538522558053955
+(PID.TID 0000.0001)         System time:   9.9942997097969055E-002
+(PID.TID 0000.0001)     Wall clock time:   10.645356893539429
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.13631499558687210
-(PID.TID 0000.0001)         System time:   8.4128998219966888E-002
-(PID.TID 0000.0001)     Wall clock time:  0.23538589477539062
+(PID.TID 0000.0001)           User time:   7.7284997329115868E-002
+(PID.TID 0000.0001)         System time:   3.6343000829219818E-002
+(PID.TID 0000.0001)     Wall clock time:  0.11458420753479004
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   15.027025014162064
-(PID.TID 0000.0001)         System time:  0.25585701316595078
-(PID.TID 0000.0001)     Wall clock time:   15.395258903503418
+(PID.TID 0000.0001)           User time:   10.461212694644928
+(PID.TID 0000.0001)         System time:   6.3596997410058975E-002
+(PID.TID 0000.0001)     Wall clock time:   10.530754804611206
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.69827499985694885
-(PID.TID 0000.0001)         System time:   8.9116007089614868E-002
-(PID.TID 0000.0001)     Wall clock time:  0.83624196052551270
+(PID.TID 0000.0001)           User time:  0.51511000841856003
+(PID.TID 0000.0001)         System time:   3.9131999015808105E-002
+(PID.TID 0000.0001)     Wall clock time:  0.55779385566711426
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.328725337982178
-(PID.TID 0000.0001)         System time:  0.16673500835895538
-(PID.TID 0000.0001)     Wall clock time:   14.558988094329834
+(PID.TID 0000.0001)           User time:   9.9460898041725159
+(PID.TID 0000.0001)         System time:   2.4462997913360596E-002
+(PID.TID 0000.0001)     Wall clock time:   9.9729468822479248
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   14.328653693199158
-(PID.TID 0000.0001)         System time:  0.16672500967979431
-(PID.TID 0000.0001)     Wall clock time:   14.558902502059937
+(PID.TID 0000.0001)           User time:   9.9460409879684448
+(PID.TID 0000.0001)         System time:   2.4460993707180023E-002
+(PID.TID 0000.0001)     Wall clock time:   9.9728949069976807
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   14.328501999378204
-(PID.TID 0000.0001)         System time:  0.16670501232147217
-(PID.TID 0000.0001)     Wall clock time:   14.558735847473145
+(PID.TID 0000.0001)           User time:   9.9459572434425354
+(PID.TID 0000.0001)         System time:   2.4460993707180023E-002
+(PID.TID 0000.0001)     Wall clock time:   9.9728119373321533
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.29756152629852295
-(PID.TID 0000.0001)         System time:   3.2580047845840454E-003
-(PID.TID 0000.0001)     Wall clock time:  0.30087971687316895
+(PID.TID 0000.0001)           User time:  0.18019658327102661
+(PID.TID 0000.0001)         System time:   1.9799917936325073E-004
+(PID.TID 0000.0001)     Wall clock time:  0.18044924736022949
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.26358032226562500
-(PID.TID 0000.0001)         System time:   3.9429962635040283E-003
-(PID.TID 0000.0001)     Wall clock time:  0.26756215095520020
+(PID.TID 0000.0001)           User time:  0.17733621597290039
+(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
+(PID.TID 0000.0001)     Wall clock time:  0.17737555503845215
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7867267131805420E-002
-(PID.TID 0000.0001)         System time:   4.3230056762695312E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5809288024902344E-002
+(PID.TID 0000.0001)           User time:   1.2475192546844482E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.3892889022827148E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7695903778076172E-002
-(PID.TID 0000.0001)         System time:   4.3179988861083984E-003
-(PID.TID 0000.0001)     Wall clock time:   2.5636434555053711E-002
+(PID.TID 0000.0001)           User time:   1.1715888977050781E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   1.3134241104125977E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   7.7784061431884766E-005
-(PID.TID 0000.0001)         System time:   1.9967555999755859E-006
-(PID.TID 0000.0001)     Wall clock time:   7.8678131103515625E-005
+(PID.TID 0000.0001)           User time:   3.7372112274169922E-005
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   4.1723251342773438E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.6169438958168030
-(PID.TID 0000.0001)         System time:   3.9340004324913025E-002
-(PID.TID 0000.0001)     Wall clock time:   4.7158522605895996
+(PID.TID 0000.0001)           User time:   2.9866501688957214
+(PID.TID 0000.0001)         System time:   1.6055010259151459E-002
+(PID.TID 0000.0001)     Wall clock time:   3.0033969879150391
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GMREDI_CALC_BATES_K [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.1666583418846130
-(PID.TID 0000.0001)         System time:   3.8543015718460083E-002
-(PID.TID 0000.0001)     Wall clock time:   3.2646999359130859
+(PID.TID 0000.0001)           User time:   2.0102680325508118
+(PID.TID 0000.0001)         System time:   1.4873996376991272E-002
+(PID.TID 0000.0001)     Wall clock time:   2.0258569717407227
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.7343857288360596
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   2.7344331741333008
+(PID.TID 0000.0001)           User time:   2.0330392122268677
+(PID.TID 0000.0001)         System time:   4.4994056224822998E-005
+(PID.TID 0000.0001)     Wall clock time:   2.0330944061279297
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6270654201507568
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6271636486053467
+(PID.TID 0000.0001)           User time:   2.8005529642105103
+(PID.TID 0000.0001)         System time:   7.6003372669219971E-005
+(PID.TID 0000.0001)     Wall clock time:   2.8007164001464844
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.7568082809448242E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   4.7579765319824219E-002
+(PID.TID 0000.0001)           User time:   3.0088305473327637E-002
+(PID.TID 0000.0001)         System time:   6.9960951805114746E-006
+(PID.TID 0000.0001)     Wall clock time:   3.0104637145996094E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.4127354621887207
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   1.4127690792083740
+(PID.TID 0000.0001)           User time:  0.91990339756011963
+(PID.TID 0000.0001)         System time:   5.3003430366516113E-005
+(PID.TID 0000.0001)     Wall clock time:  0.91997241973876953
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.9592218399047852E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.9618206024169922E-002
+(PID.TID 0000.0001)           User time:   6.0707449913024902E-002
+(PID.TID 0000.0001)         System time:   3.9935111999511719E-006
+(PID.TID 0000.0001)     Wall clock time:   6.0731410980224609E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.12697291374206543
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.12698888778686523
+(PID.TID 0000.0001)           User time:   8.4146976470947266E-002
+(PID.TID 0000.0001)         System time:   2.3007392883300781E-005
+(PID.TID 0000.0001)     Wall clock time:   8.4176540374755859E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.2109022140502930E-002
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.2119035720825195E-002
+(PID.TID 0000.0001)           User time:   2.0346164703369141E-002
+(PID.TID 0000.0001)         System time:   6.9960951805114746E-006
+(PID.TID 0000.0001)     Wall clock time:   2.0355701446533203E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.5129013061523438E-005
+(PID.TID 0000.0001)           User time:   4.8398971557617188E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   9.7036361694335938E-005
+(PID.TID 0000.0001)     Wall clock time:   4.7206878662109375E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.33742499351501465
-(PID.TID 0000.0001)         System time:   3.6139935255050659E-003
-(PID.TID 0000.0001)     Wall clock time:  0.34107494354248047
+(PID.TID 0000.0001)           User time:  0.18082714080810547
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.18087792396545410
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.57836461067199707
-(PID.TID 0000.0001)         System time:   6.1988830566406250E-005
-(PID.TID 0000.0001)     Wall clock time:  0.57846260070800781
+(PID.TID 0000.0001)           User time:  0.34651446342468262
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.34652137756347656
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   6.0855865478515625E-002
-(PID.TID 0000.0001)         System time:   5.6000009179115295E-002
-(PID.TID 0000.0001)     Wall clock time:  0.11694526672363281
+(PID.TID 0000.0001)           User time:   4.7278165817260742E-002
+(PID.TID 0000.0001)         System time:   3.9789974689483643E-003
+(PID.TID 0000.0001)     Wall clock time:   5.1328182220458984E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.2698822021484375E-002
-(PID.TID 0000.0001)         System time:   5.6012019515037537E-002
-(PID.TID 0000.0001)     Wall clock time:  0.13879203796386719
+(PID.TID 0000.0001)           User time:   6.4422369003295898E-002
+(PID.TID 0000.0001)         System time:   4.0019974112510681E-003
+(PID.TID 0000.0001)     Wall clock time:   6.8475723266601562E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -3629,9 +3656,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          17448
+(PID.TID 0000.0001) //            No. barriers =          17404
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          17448
+(PID.TID 0000.0001) //     Total barrier spins =          17404
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/global_ocean.gm_res/results/output.txt
+++ b/global_ocean.gm_res/results/output.txt
@@ -5,10 +5,10 @@
 (PID.TID 0000.0001) // ======================================================
 (PID.TID 0000.0001) // execution environment starting up...
 (PID.TID 0000.0001) 
-(PID.TID 0000.0001) // MITgcmUV version:  checkpoint68s
+(PID.TID 0000.0001) // MITgcmUV version:  checkpoint69p
 (PID.TID 0000.0001) // Build user:        jm_c
 (PID.TID 0000.0001) // Build host:        villon
-(PID.TID 0000.0001) // Build date:        Wed Oct 18 15:32:48 EDT 2023
+(PID.TID 0000.0001) // Build date:        Wed Aug 19 17:08:14 EDT 2026
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Execution Environment parameter file "eedata"
@@ -367,7 +367,11 @@
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "diagnostics_list": OK
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": start
 (PID.TID 0000.0001) S/R DIAGNOSTICS_READPARMS, read namelist "DIAG_STATIS_PARMS": OK
+(PID.TID 0000.0001) -----------------------------------------------------
 (PID.TID 0000.0001)  DIAGNOSTICS_READPARMS: global parameter summary:
+(PID.TID 0000.0001)  diag_dBugLevel = /* level of printed debug messages */
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001)  dumpAtLast = /* always write time-ave diags at the end */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
@@ -691,37 +695,37 @@
 (PID.TID 0000.0001) // ===================================
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGNOSTICS_SET_LEVELS: done
-(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   258
+(PID.TID 0000.0001)  Total Nb of available Diagnostics: ndiagt=   265
 (PID.TID 0000.0001)  write list of available Diagnostics to file: available_diagnostics.log
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    23 ETAN
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    24 ETANSQ
 (PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    25 DETADT2
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    73 PHIBOT
-(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOTSQ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    45 UVELMASS
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 VVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    74 PHIBOT
+(PID.TID 0000.0001) SETDIAG: Allocate  1 x  1 Levels for Diagnostic #    75 PHIBOTSQ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    46 UVELMASS
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    47 VVELMASS
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    32 WVEL
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    38 WVELSQ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    64 RHOAnoma
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 CONVADJ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   209 GM_Kwx
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   210 GM_Kwy
-(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   211 GM_Kwz
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    65 RHOAnoma
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #    80 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   216 GM_Kwx
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   217 GM_Kwy
+(PID.TID 0000.0001) SETDIAG: Allocate 15 x  1 Levels for Diagnostic #   218 GM_Kwz
 (PID.TID 0000.0001)   space allocated for all diagnostics:     185 levels
-(PID.TID 0000.0001)   set mate pointer for diag #    45  UVELMASS , Parms: UUr     MR , mate:    46
-(PID.TID 0000.0001)   set mate pointer for diag #    46  VVELMASS , Parms: VVr     MR , mate:    45
-(PID.TID 0000.0001)   set mate pointer for diag #   209  GM_Kwx   , Parms: UM      LR , mate:   210
-(PID.TID 0000.0001)   set mate pointer for diag #   210  GM_Kwy   , Parms: VM      LR , mate:   209
+(PID.TID 0000.0001)   set mate pointer for diag #    46  UVELMASS , Parms: UUr     MR , mate:    47
+(PID.TID 0000.0001)   set mate pointer for diag #    47  VVELMASS , Parms: VVr     MR , mate:    46
+(PID.TID 0000.0001)   set mate pointer for diag #   216  GM_Kwx   , Parms: UM      LR , mate:   217
+(PID.TID 0000.0001)   set mate pointer for diag #   217  GM_Kwy   , Parms: VM      LR , mate:   216
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: surfDiag
 (PID.TID 0000.0001)  Levels:       1.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: dynDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
 (PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: Set levels for Outp.Stream: oceDiag
 (PID.TID 0000.0001)  Levels:       1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  12.  13.  14.  15.
-(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGNOSTICS_SET_POINTERS: done, use     185 levels (numDiags =     300 )
 (PID.TID 0000.0001) ------------------------------------------------------------
 (PID.TID 0000.0001) DIAGSTATS_SET_REGIONS: define no region
 (PID.TID 0000.0001) ------------------------------------------------------------
@@ -734,14 +738,12 @@
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    26 THETA
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    27 SALT
 (PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    38 WVELSQ
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    64 RHOAnoma
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    78 DRHODR
-(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    79 CONVADJ
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    65 RHOAnoma
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    79 DRHODR
+(PID.TID 0000.0001) SETDIAG: Allocate 15 Levels for Stats-Diag #    80 CONVADJ
 (PID.TID 0000.0001)   space allocated for all stats-diags:     138 levels
-(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done
+(PID.TID 0000.0001) DIAGSTATS_SET_POINTERS: done, use     138 levels (diagSt_size=     300 )
 (PID.TID 0000.0001) ------------------------------------------------------------
-(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
-(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) Empty tile: #    30 (bi,bj=   3   4 )
 (PID.TID 0000.0001) 
 (PID.TID 0000.0001) %MON fCori_max                    =   1.4265546244797E-04
@@ -980,7 +982,7 @@
 (PID.TID 0000.0001) hFacMinDr = /* minimum partial cell thickness ( m) */
 (PID.TID 0000.0001)                 5.000000000000000E+01
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) exactConserv =  /* Exact Volume Conservation on/off flag */
+(PID.TID 0000.0001) exactConserv = /* Update etaN from continuity Eq on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) linFSConserveTr = /* Tracer correction for Lin Free Surface on/off flag */
@@ -1060,17 +1062,14 @@
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     0= Expl. ; 1= Impl. on provis. Vel ; 2= Fully Impl (with surf.P)
 (PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) metricTerms =  /* metric-Terms on/off flag */
-(PID.TID 0000.0001)                   T
+(PID.TID 0000.0001) selectMetricTerms= /* Scheme selector for Horizontal Metric Terms */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : Off (ignore Spherical/Cylindrical Metric Terms)
+(PID.TID 0000.0001)    = 1 : original discretization
+(PID.TID 0000.0001)    = 2 : using (Spherical) grid-spacing
+(PID.TID 0000.0001)    = 3 : as 2 but gU-Metric inside Advection
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useNHMTerms = /* Non-Hydrostatic Metric-Terms on/off */
-(PID.TID 0000.0001)                   T
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
-(PID.TID 0000.0001)                       2
-(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
-(PID.TID 0000.0001)     ;
-(PID.TID 0000.0001) use3dCoriolis = /* 3-D Coriolis on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) useCoriolis =  /* Coriolis on/off flag */
@@ -1079,12 +1078,23 @@
 (PID.TID 0000.0001) useCDscheme =  /* CD scheme on/off flag */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectCoriMap = /* Coriolis Map options (0,1,2,3)*/
+(PID.TID 0000.0001)                       2
+(PID.TID 0000.0001)     0= f-Plane ; 1= Beta-Plane ; 2= Spherical ; 3= read from file
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) select3dCoriScheme= /* Scheme selector for 3-D Coriolis-Term */
+(PID.TID 0000.0001)                       1
+(PID.TID 0000.0001)    = 0 : Off (ignore 3-D Coriolis Terms in Omega.Cos(Lat) )
+(PID.TID 0000.0001)    = 1 : original discretization ; = 2 : using averaged Transport
+(PID.TID 0000.0001)    = 3 : same as 2 with hFac in gW_Cor
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) selectCoriScheme= /* Scheme selector for Coriolis-Term */
 (PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)    = 0 : original discretization (simple averaging, no hFac)
 (PID.TID 0000.0001)    = 1 : Wet-point averaging (Jamar & Ozer 1986)
 (PID.TID 0000.0001)    = 2 : energy conserving scheme (no hFac weight)
 (PID.TID 0000.0001)    = 3 : energy conserving scheme using Wet-point averaging
+(PID.TID 0000.0001)    = 4 : hFac weighted average (Angular Mom. conserving)
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) momForcing =  /* Momentum forcing on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1124,6 +1134,9 @@
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) tempForcing  =  /* Temperature forcing on/off flag */
 (PID.TID 0000.0001)                   T
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) selectPenetratingSW = /* short wave penetration selector */
+(PID.TID 0000.0001)                       0
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) doThetaClimRelax = /* apply SST relaxation on/off flag */
 (PID.TID 0000.0001)                   T
@@ -1211,7 +1224,7 @@
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) printResidualFreq = /* Freq. for printing CG residual */
-(PID.TID 0000.0001)                       0
+(PID.TID 0000.0001)                      -1
 (PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) //
 (PID.TID 0000.0001) // Time stepping paramters ( PARM03 in namelist )
@@ -1894,6 +1907,15 @@
 (PID.TID 0000.0001) globalArea = /* Integrated horizontal Area (m^2) */
 (PID.TID 0000.0001)                 3.450614146649756E+14
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) rAc_3dMean = /* 3-D Averaged grid-cell Area (m^2) */
+(PID.TID 0000.0001)                 1.523452939709265E+11
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n2dWetPts = /* Number of wet surface points (-) */
+(PID.TID 0000.0001)                 2.315000000000000E+03
+(PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) n3dWetPts = /* Number of wet grid points (-) */
+(PID.TID 0000.0001)                 2.930900000000000E+04
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) the_run_name = /* Name of this simulation */
 (PID.TID 0000.0001)               'global_ocean.90x40x15'
 (PID.TID 0000.0001)     ;
@@ -1982,6 +2004,9 @@
 (PID.TID 0000.0001) GM_useLeithQG = /* if TRUE => add QG Leith viscosity to GMRedi tensor */
 (PID.TID 0000.0001)                   F
 (PID.TID 0000.0001)     ;
+(PID.TID 0000.0001) GM_useGEOM = /* using GEOMETRIC */
+(PID.TID 0000.0001)                   F
+(PID.TID 0000.0001)     ;
 (PID.TID 0000.0001) GM_useBatesK3d = /* if TRUE => use BatesK3d for GM diffusivity */
 (PID.TID 0000.0001)                   T
 (PID.TID 0000.0001)     ;
@@ -2014,6 +2039,8 @@
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: ncep_emp.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sst.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sss.bin
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: dynStDiag.0000000000.txt , unit=     9
+(PID.TID 0000.0001) DIAGSTATS_INI_IO: open file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001)  write diagnostics summary to file ioUnit:      6
 Iter.Nb:         0 ; Time(s):  0.0000000000000E+00
 ------------------------------------------------------------------------
@@ -2027,16 +2054,16 @@ listId=    1 ; file name: surfDiag
     23 |ETAN    |      1 |      0 |   1 |       0 |
     24 |ETANSQ  |      2 |      0 |   1 |       0 |
     25 |DETADT2 |      3 |      0 |   1 |       0 |
-    73 |PHIBOT  |      4 |      0 |   1 |       0 |
-    74 |PHIBOTSQ|      5 |      0 |   1 |       0 |
+    74 |PHIBOT  |      4 |      0 |   1 |       0 |
+    75 |PHIBOTSQ|      5 |      0 |   1 |       0 |
 ------------------------------------------------------------------------
 listId=    2 ; file name: dynDiag
  nFlds, nActive,       freq     &     phase        , nLev               
     6  |    6  |    864000.000000         0.000000 |  15
  levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-    45 |UVELMASS|      6 |     21 |  15 |       0 |       0 |
-    46 |VVELMASS|     21 |      6 |  15 |       0 |       0 |
+    46 |UVELMASS|      6 |     21 |  15 |       0 |       0 |
+    47 |VVELMASS|     21 |      6 |  15 |       0 |       0 |
     32 |WVEL    |     36 |      0 |  15 |       0 |
     26 |THETA   |     51 |      0 |  15 |       0 |
     27 |SALT    |     66 |      0 |  15 |       0 |
@@ -2047,12 +2074,12 @@ listId=    3 ; file name: oceDiag
     6  |    6  |    864000.000000         0.000000 |  15
  levels:   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
  diag# | name   |   ipt  |  iMate | kLev|   count |   mate.C|           
-    64 |RHOAnoma|     96 |      0 |  15 |       0 |
-    78 |DRHODR  |    111 |      0 |  15 |       0 |
-    79 |CONVADJ |    126 |      0 |  15 |       0 |
-   209 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
-   210 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
-   211 |GM_Kwz  |    171 |      0 |  15 |       0 |
+    65 |RHOAnoma|     96 |      0 |  15 |       0 |
+    79 |DRHODR  |    111 |      0 |  15 |       0 |
+    80 |CONVADJ |    126 |      0 |  15 |       0 |
+   216 |GM_Kwx  |    141 |    156 |  15 |       0 |       0 |
+   217 |GM_Kwy  |    156 |    141 |  15 |       0 |       0 |
+   218 |GM_Kwz  |    171 |      0 |  15 |       0 |
 ------------------------------------------------------------------------
 Global & Regional Statistics diagnostics: Number of lists:     2
 ------------------------------------------------------------------------
@@ -2076,9 +2103,9 @@ listId=   2 ; file name: oceStDiag
     3  |    3  |   2592000.000000         0.000000 |
  Regions:   0
  diag# | name   |   ipt  |  iMate |    Volume   |   mate-Vol. |         
-    64 |RHOAnoma|     94 |      0 | 0.00000E+00 |
-    78 |DRHODR  |    109 |      0 | 0.00000E+00 |
-    79 |CONVADJ |    124 |      0 | 0.00000E+00 |
+    65 |RHOAnoma|     94 |      0 | 0.00000E+00 |
+    79 |DRHODR  |    109 |      0 | 0.00000E+00 |
+    80 |CONVADJ |    124 |      0 | 0.00000E+00 |
 ------------------------------------------------------------------------
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Model current state
@@ -2181,45 +2208,45 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sss.bin
 (PID.TID 0000.0001)  MDS_READ_FIELD: opening global file: lev_sss.bin
 (PID.TID 0000.0001) SOLVE_FOR_PRESSURE: putPmEinXvector =    F
- cg2d: Sum(rhs),rhsMax =   3.67591829168393E-03  2.56950143267917E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.15969088495369E+00
+ cg2d: Sum(rhs),rhsMax =   3.67598307399292E-03  2.56945615003488E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.15975242148583E+00
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     142
-(PID.TID 0000.0001)      cg2d_last_res =   9.15031803252077E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.15124084880862E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     1
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+04
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.6379351160100E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.1361300215674E-01
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.4811745051382E-05
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.6150815675587E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5421386549167E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5129685984542E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6965193862067E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1745467191398E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2680342090763E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8753133810391E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.8235807074029E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.1416477614513E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.3568468890886E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5054224114479E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3347101154764E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.3463062352325E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.5525837366268E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6947689214721E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.5029438102793E-06
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2636831152799E-08
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   6.6379892816892E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -8.1364896856929E-01
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.4811745051380E-05
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   2.6150983948871E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.5419470164653E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5129541790531E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6967002321920E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -5.1752685160906E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2641534725920E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   1.8583059816064E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.8292983389526E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -2.1409135097440E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   7.3567932288611E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   2.5046057223031E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   2.3329875835709E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   6.3387357833892E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -5.5402851766524E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.6948220062803E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   6.4923081315827E-06
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   9.2577900163259E-08
 (PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9728259248109E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9003219474105E+00
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9003565932500E+00
 (PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197724302515E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171727219657E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6226606639741E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7463785423825E+01
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4172003318693E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6269685097276E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7472026319485E+01
 (PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754631576469E+01
 (PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005931612E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613638387481E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0137115524298E-03
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9614930379056E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0147095627273E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2589080810547E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8702698516846E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6700205338390E+01
@@ -2248,65 +2275,65 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   0.0000000000000E+00
 (PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   0.0000000000000E+00
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   7.6106864467594E-03
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1608781214940E-03
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1904135602154E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.5815588388253E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7508795481285E-05
-(PID.TID 0000.0001) %MON ke_max                       =   1.9795569475726E-04
-(PID.TID 0000.0001) %MON ke_mean                      =   3.9132120648658E-06
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.3278954215884E-03
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   4.1594515881865E-03
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   2.1996873786504E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   2.5924886962665E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   8.7509921674750E-05
+(PID.TID 0000.0001) %MON ke_max                       =   1.9830683313384E-04
+(PID.TID 0000.0001) %MON ke_mean                      =   3.9069411025030E-06
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782436723E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -8.9746123090013E-08
-(PID.TID 0000.0001) %MON vort_r_max                   =   9.0045926623809E-08
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807342295E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604246649079E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655729977E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162543798019E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1146188128188E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7418065146031E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -8.6828144957017E-08
+(PID.TID 0000.0001) %MON vort_r_max                   =   9.0070503077256E-08
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807340561E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604246509374E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845655727791E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162543307977E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   4.1147261233518E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.7416626706128E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         1 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4666666667  0.5333333333
- cg2d: Sum(rhs),rhsMax =   7.16813586183551E-03  2.65193213408884E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.62251143887446E-01
+ cg2d: Sum(rhs),rhsMax =   7.16897137727934E-03  2.65162306181813E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.63228463962901E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     139
-(PID.TID 0000.0001)      cg2d_last_res =   8.29535289397693E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.31627563259177E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     2
 (PID.TID 0000.0001) %MON time_secondsf                =   1.7280000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0313201408371E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3152821062703E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.0319101987508E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3151296342806E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.3043905248849E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4265808301676E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6033374482507E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.1664573940932E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.2003689709766E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3926681502034E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.4071060586250E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.6260695392005E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   4.4702328464518E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.2565812532143E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2476234507487E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2882366226146E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.6111561563683E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0838722036122E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.7054720510930E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9097292626887E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1888749135362E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6952041823942E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722816655378E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9010069650174E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197821317186E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170085998133E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6080536285734E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7453385091336E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755263556884E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004518366E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9607864241114E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0186906304573E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   4.4267418428412E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.6025323469574E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   3.4873081270486E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.1003516640006E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.3943133565783E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   2.3808069601942E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   3.5104349982492E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.8264964720907E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0178379251612E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.2480544062726E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   4.2862333512443E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   4.7532695320835E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.0802996469669E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -9.6788756615222E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.9117364809492E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.1832394948234E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   1.6884802273175E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9722816640730E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9010388025269E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6197821228672E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170527134237E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.6128161050930E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7469369198394E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755264733385E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004514868E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610277946779E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0206074060779E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2693899536133E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8655982259115E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6687693382567E+01
@@ -2332,68 +2359,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2915731155564E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5261152700224E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4588571962377E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0253748153421E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.1326311151428E-03
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.9022012496607E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.1490965811346E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2155533940001E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.4534769865458E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.0707207610498E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5073677929865E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.1119128307457E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1591935896751E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.0102585139115E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   5.1306014929202E-03
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   1.9102548288279E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.6968707579509E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.9774958470109E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   3.5630228741561E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   4.2033924148280E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   2.5075502025324E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.6403408021137E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1527179300636E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226782213082E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3204015592220E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.6241279600299E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807293205E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185644270E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642660608E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162954556151E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8469057147529E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9402714072754E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.8649388403108E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.0051592378685E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807290801E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185258879E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845642659211E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3162950638995E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   3.8472873108180E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.9404925640181E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         2 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4333333333  0.5666666667
- cg2d: Sum(rhs),rhsMax =   1.17830971018648E-02  2.43504719530063E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.74158928933647E-01
+ cg2d: Sum(rhs),rhsMax =   1.17850438567744E-02  2.43464495325853E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.81536620749658E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   9.29799732860208E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.46847462403533E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     3
 (PID.TID 0000.0001) %MON time_secondsf                =   2.5920000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9383638884377E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5755398538757E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231129E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3006725219829E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4661520897884E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8819984395924E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.4824963420169E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2249255683459E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4223061941524E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8970017687484E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1072234500326E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.5144972751232E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1324755498483E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8973489920508E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3393106937557E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4780776993987E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2899001972708E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9627102466070E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6334715487077E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2999222912990E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716839455832E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9015825644587E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198511413005E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169590004215E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5576057777667E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7443915425368E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755307001402E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004659929E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606903388482E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0170705870311E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.9403471346720E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5781045486086E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -1.9688192231127E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3011247099759E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.4653276538594E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   4.8600353433097E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -4.9749681724009E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -9.2269536731427E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   3.4421526593568E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   4.8181388849089E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   5.1358222824277E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -6.7459244091158E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   8.1334476231230E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   5.8482164742692E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   6.3302992790750E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.4848997121720E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.2856158362099E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.9613900496793E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.6273957813010E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.2957444583862E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9716839342663E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9020284138184E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6198512051658E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170224542460E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.5641833750257E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7459810002710E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9755311412137E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718004657216E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610430502000E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0196935518739E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2798718261719E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8609266001383E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6675181426744E+01
@@ -2419,68 +2446,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.2178105886956E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5379778517573E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4636987924417E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1494745817187E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3103044368273E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.5102648237831E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.5651585597840E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.2656623405813E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6553699851867E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2670077079646E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5953669602714E-04
-(PID.TID 0000.0001) %MON ke_max                       =   2.0646860629351E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   2.1618279046175E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   1.7872912212943E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1316395889217E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   3.3951938290935E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.0588180490956E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.3106249210711E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   4.6608631944104E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   5.2732226061205E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5959804110684E-04
+(PID.TID 0000.0001) %MON ke_max                       =   2.4558635213869E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   2.1421332555842E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781986628E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -2.6819334208268E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   2.9720973430816E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807223761E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604170361375E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640520201E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163353116466E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3814008265202E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2641651292485E-07
+(PID.TID 0000.0001) %MON vort_r_min                   =  -2.8633724722941E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.1371668767494E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807219086E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604170025129E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845640495687E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163348980048E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.3821762701349E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   1.2640250630289E-07
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         3 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.4000000000  0.6000000000
- cg2d: Sum(rhs),rhsMax =   1.71255172881747E-02  2.24777096178169E+00
-(PID.TID 0000.0001)      cg2d_init_res =   4.26389685583531E-01
+ cg2d: Sum(rhs),rhsMax =   1.71417658459114E-02  2.24564031570005E+00
+(PID.TID 0000.0001)      cg2d_init_res =   4.25954916874080E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   8.60239701461040E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.61686251355630E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     4
 (PID.TID 0000.0001) %MON time_secondsf                =   3.4560000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7595040433693E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5955625143174E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451983E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5723845201053E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3754605817638E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8673071741663E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.7714050814428E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4753443364421E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.5101794348536E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.0215473437167E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3336425282422E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -8.0976990335269E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6179613730282E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.4080034639009E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8884021844702E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8124870852026E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5333789675501E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   6.0823877662633E-10
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.0011931367908E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7737123713159E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9711432913690E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9021928717384E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199360659886E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169422885594E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4911410263870E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7437965862062E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754547450631E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005962772E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606340813926E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0146767494622E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.7614843226634E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5983542894431E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -2.6414035451976E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5731169509758E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.3748697009778E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   6.8605968859199E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -5.9944729503996E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -8.4764122883394E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   4.5835780878760E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   5.9777807391555E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   6.3711713134526E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -7.9901943132837E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   5.6197872981940E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   7.3154750965916E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   7.8628058623166E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   1.8179581804157E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.5273572985691E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =   5.8616165860837E-10
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   1.9933156754472E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.7676882762411E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9711432507023E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9033097153925E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6199362737635E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170234391851E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4991212210441E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7447735025450E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9754555821102E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718005965611E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9610909937306E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0180152609776E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.2903536987305E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8562549743652E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6662669470921E+01
@@ -2506,68 +2533,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.1440480618348E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5513649503191E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4740184358134E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.5655576591506E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.3641287258070E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.7961747226356E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.8306155893304E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5732530507357E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.8655926959051E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.6361441770498E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9734108582736E-04
-(PID.TID 0000.0001) %MON ke_max                       =   3.6073371772804E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   3.4346992717026E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.1113453766691E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.4125917481484E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   4.3684515032812E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   2.7463377720348E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.5523666077609E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   5.9081020610748E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   6.6842377858321E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9744554521524E-04
+(PID.TID 0000.0001) %MON ke_max                       =   3.6152144464319E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   3.4038792975922E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781757359E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1075556450475E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2671366043701E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807135630E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604186020231E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649839003E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163586344066E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0507707683574E-06
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2075055330181E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3082536984617E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.3899107037809E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807136301E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604185582114E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649818398E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163578525371E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   1.0507216250898E-06
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =   4.2051442049294E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         4 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3666666667  0.6333333333
- cg2d: Sum(rhs),rhsMax =   2.36375476596636E-02  2.04822172243693E+00
-(PID.TID 0000.0001)      cg2d_init_res =   5.14677497395544E-01
+ cg2d: Sum(rhs),rhsMax =   2.36741231758457E-02  2.04505730674870E+00
+(PID.TID 0000.0001)      cg2d_init_res =   5.14661700531070E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     138
-(PID.TID 0000.0001)      cg2d_last_res =   7.46447899162277E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.47490570571953E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     5
 (PID.TID 0000.0001) %MON time_secondsf                =   4.3200000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8777975775856E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5432238150061E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911403E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5658255355912E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2913269741464E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.9050240821152E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -6.8305572726688E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8611285794193E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.7115415734053E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.9282734997072E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4412151188211E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4030270589650E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6782235904036E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.6679514018878E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.1279085363692E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0481371190015E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7265712867491E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -2.0655719037675E-11
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2763313114233E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0876227389108E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9707175597629E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9028192113379E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200186036514E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169388770782E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4183337567373E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7436632479703E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753429994380E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007475513E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605774871015E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0118413697100E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8777996346643E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.5467106739885E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -3.3221434911408E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.5668146794064E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2898066838543E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   8.9112924658330E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -7.2112190034273E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -6.8608229229068E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   5.8009717759591E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   6.8533111675761E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   7.4513888934468E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -9.4173545027089E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   2.6795518099353E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   8.5432884636654E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   9.0980750045093E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.0529836302849E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.6849283498018E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -8.4405912123072E-12
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.2651070889774E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.0795683279794E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9707174693179E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9046936548779E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200189953713E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170380284207E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.4283237666713E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7438603007024E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9753437810419E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718007487004E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9611386825884E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0159468876904E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3008355712891E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8515833485921E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6650157515098E+01
@@ -2593,68 +2620,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -6.0702855349740E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5662631572644E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.4897783530480E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.8310403129941E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6336192939406E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.6052316591348E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.2575315570183E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8268573511337E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.8609281103712E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.7622519790854E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9640631345864E-04
-(PID.TID 0000.0001) %MON ke_max                       =   5.4013478953991E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   4.8797305805115E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   2.7466382544574E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.6659268437190E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   5.3881889972281E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.4067258133525E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   1.8296409436686E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   6.9116874051631E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   7.8196792613039E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.9654722249462E-04
+(PID.TID 0000.0001) %MON ke_max                       =   5.4133349367757E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   4.8301808145223E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781525276E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.2039177169536E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   3.2285733120516E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807069385E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604218272499E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661319056E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163666305984E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0854759375217E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0228297549658E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.4193136464297E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.6730361811052E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807069941E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604217873313E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845661273694E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163655414623E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =   2.0972920200843E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -2.0196435871919E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         5 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3333333333  0.6666666667
- cg2d: Sum(rhs),rhsMax =   3.19253387837991E-02  1.83097483453495E+00
-(PID.TID 0000.0001)      cg2d_init_res =   6.26115996708907E-01
+ cg2d: Sum(rhs),rhsMax =   3.19823725562598E-02  1.82770967958390E+00
+(PID.TID 0000.0001)      cg2d_init_res =   6.26148883464067E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     136
-(PID.TID 0000.0001)      cg2d_last_res =   9.61790666523831E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.62582272769442E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     6
 (PID.TID 0000.0001) %MON time_secondsf                =   5.1840000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0324494695148E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4936645375733E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609398E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4674921472835E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2025090841702E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0905621736217E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.1129114795118E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8118372371677E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   6.9750899897844E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.6103149899784E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.4152548753138E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0626286821971E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   9.8756490759922E-07
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.6531021445634E-03
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0043702033452E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2434239832782E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8374626452105E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6468815460120E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4534837388408E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2433662253162E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9703921752775E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9034895357452E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200938776482E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169407352750E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3436424633386E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7437078383823E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751939694213E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008673623E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605675424207E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0098653460363E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0324355676580E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4972214777337E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.0110390609401E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.4686647156719E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.2006800786213E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.0917532166520E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -8.9374106212105E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.8099389739046E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   7.0910839941099E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   7.5586307003585E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   8.3733685577248E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.0545502631179E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =   1.0745122531193E-06
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   9.4931618031198E-03
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0013103133974E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2529326059195E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.7496046141425E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.6309535873220E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4395147200118E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2343292286698E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9703920282954E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9061114448273E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6200945262887E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170577161376E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.3558039043446E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7434933831478E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9751948544259E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718008696480E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9612317842808E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0146771743667E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3113174438477E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8469117228190E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6637645559275E+01
@@ -2680,68 +2707,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9965230081132E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.5826577347902E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5109215240509E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.2578615500354E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7767671000876E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.4862584634488E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   3.9963564850570E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0645171043579E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.6308481296447E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.6333871606481E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8252322398953E-04
-(PID.TID 0000.0001) %MON ke_max                       =   7.3428468022032E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   6.4042149563262E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.4070741708244E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.7985686129322E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.1905794151989E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.0768809345083E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.0488220317096E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   7.6588417825832E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   8.6650581905794E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.8268731475860E-04
+(PID.TID 0000.0001) %MON ke_max                       =   7.3561909364822E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   6.3408537135731E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781290379E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1197993562371E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.1012221377744E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807028997E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604258193298E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668329957E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163650224591E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0946749277173E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1891815411545E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3202880558424E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   3.8950241763642E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807036580E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604257758367E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845668299171E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163642312733E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -2.0817991242497E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.1802005504391E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         6 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.3000000000  0.7000000000
- cg2d: Sum(rhs),rhsMax =   4.27065817461170E-02  1.60661185248258E+00
-(PID.TID 0000.0001)      cg2d_init_res =   7.36174558208514E-01
+ cg2d: Sum(rhs),rhsMax =   4.28032685383517E-02  1.60298273368650E+00
+(PID.TID 0000.0001)      cg2d_init_res =   7.37160092083567E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     135
-(PID.TID 0000.0001)      cg2d_last_res =   9.63795532728593E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.63743316701424E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     7
 (PID.TID 0000.0001) %MON time_secondsf                =   6.0480000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0919912970085E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4566490977245E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545966E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3598334344746E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1086410903730E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2784112262049E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -9.0025292200396E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.6006768221756E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.2850819675800E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.1144309506199E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0957497952758E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1340642051417E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9240676211630E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0341594333130E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0628200193222E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3717409599198E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9232509014696E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8235214263355E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5374976324220E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2546072562475E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701289071333E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9043078564365E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201625887070E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169429389181E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2695001839694E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7436888033282E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750544512943E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009441156E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605768017097E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0084141219138E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0919477177684E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4614269194433E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -4.7080902545961E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.3611377893556E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.1064294373864E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.2803426980897E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1099895939139E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -2.5974404501354E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   8.4218928414637E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.0776490660871E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.0260999605475E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1335430906689E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -1.9235098184424E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0145920078539E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0606770307829E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3757916375470E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.8329953078488E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -3.8205549241066E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5201252232660E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.2439405716127E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9701287150210E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9073336987504E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6201635837287E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170774218212E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2842956607095E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7434630028944E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9750551894836E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009480805E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9613422684193E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0139489145663E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3217993164062E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8422400970459E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6625133603452E+01
@@ -2767,68 +2794,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.9227604812524E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6005326854092E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5373726950670E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   3.9970994079050E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9838811636437E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.9102796657307E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   5.1138714440517E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2033048685588E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.1347790984516E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.2036105018281E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6760733438446E-04
-(PID.TID 0000.0001) %MON ke_max                       =   9.3283684434953E-03
-(PID.TID 0000.0001) %MON ke_mean                      =   7.9246619811438E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.0778245787320E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   1.9834772103403E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   6.8598377342087E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.3052770491158E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2022924267148E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.1478011688797E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.2183433295721E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.6778627591333E-04
+(PID.TID 0000.0001) %MON ke_max                       =   9.3450411658591E-03
+(PID.TID 0000.0001) %MON ke_mean                      =   7.8485193583106E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226781052668E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.0314577670180E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.4414584997349E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807037086E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604299344363E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669388286E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163606122832E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7579631892295E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9810300937057E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.1260276558080E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.4551420558267E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807044017E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604298890555E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845669366169E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163596436810E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -3.7466465618605E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.9718144772026E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         7 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2666666667  0.7333333333
- cg2d: Sum(rhs),rhsMax =   5.68035912187068E-02  1.38882353095458E+00
-(PID.TID 0000.0001)      cg2d_init_res =   8.55551901906148E-01
+ cg2d: Sum(rhs),rhsMax =   5.69582372568591E-02  1.38505276719678E+00
+(PID.TID 0000.0001)      cg2d_init_res =   8.57124187232465E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   9.17206777111523E-14
+(PID.TID 0000.0001)      cg2d_last_res =   9.14243212789241E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     8
 (PID.TID 0000.0001) %MON time_secondsf                =   6.9120000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0698881275461E+00
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4256004230624E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721101E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2801319046977E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0165717637167E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4476605055902E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.1809762001809E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.4162990328284E-05
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.6045761033905E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5163751106815E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.5073330618725E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1742356529818E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9439814944159E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0743268991235E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0941908543665E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4230465194419E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9282085885903E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1732692398410E-09
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5357209508242E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1422241068323E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699059922938E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9052684513020E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202269780947E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169464846448E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2001849957637E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7436457076132E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749380778547E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009870112E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9605994943595E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0074700064905E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   1.0697958860617E+00
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4306690124950E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -5.4132970721099E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2815092407720E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   2.0145751673794E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.4503282948130E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4245663767590E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =  -4.3640728147227E-05
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   9.7491082562188E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.5017478327660E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.4122591180678E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1734758861964E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.9434415216696E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0520014518205E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0921319752124E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.4185222452830E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9401757297915E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -7.1727684901635E-09
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.5163923566757E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   3.1309965481711E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9699057812088E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9087444554325E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202283792156E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4170978318192E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.2176009560256E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433773687224E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9749386037016E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718009932801E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9614606447729E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0138277335447E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3322811889648E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8375684712728E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6612621647628E+01
@@ -2854,68 +2881,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.8489979543915E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6198708258185E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.5690396795039E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   5.1148198161772E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1330367275524E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2861916472806E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   6.7085152612073E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2813515489864E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3935706984555E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4964943287993E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5675597365172E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.1264869994580E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   9.3765528308148E-05
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.3064462307271E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.1320566479885E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.2978551359113E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.0922251249656E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.2798754439743E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3840273983499E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4856969684158E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5694211916948E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.1287091015380E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   9.2905119499298E-05
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780812142E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.3655340872789E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   4.7699647423267E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807081758E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336757836E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665590663E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163558699692E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2765007650101E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4892213138392E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.6066845049051E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.5646461114913E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807090997E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604336432790E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845665571330E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163550149651E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.2678016243293E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -5.4827318914201E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         8 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2333333333  0.7666666667
- cg2d: Sum(rhs),rhsMax =   7.44606920469408E-02  1.19910627456465E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.63695102931408E-01
+ cg2d: Sum(rhs),rhsMax =   7.38386789524619E-02  1.20920748188625E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.54616176658628E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   8.35886315559167E-14
+(PID.TID 0000.0001)      cg2d_last_res =   8.34107379708698E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                     9
 (PID.TID 0000.0001) %MON time_secondsf                =   7.7760000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8882453060821E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3974832106352E+00
-(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134807E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2464932920513E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9348778802850E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5929158984262E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.4203259460712E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5026020653757E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.0889924373414E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.8398813246706E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.6640436331645E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1950051414461E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1257800168224E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0884578473785E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0976414677336E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3870306681949E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9759753131057E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1339567283412E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4627632179762E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9347053361934E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697244229024E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9134806315828E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202888962280E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169527716289E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1374762102829E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435922390202E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748610422466E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010103789E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606292793431E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0066987433836E-03
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   9.8866822121693E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.4026492733019E+00
+(PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.1266595134804E-04
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2478908080736E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.9328473244477E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.5961991159748E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.6418273473236E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   1.5091334568096E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.1027019002659E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   8.8389092818985E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0021348092410E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1934769693850E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -3.1260104179588E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0635022141692E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0939085030618E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.3829546653653E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9902842811944E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.1363136151148E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.4425396231497E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.9234313787959E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9697242262125E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9135774611238E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6202907062922E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171205842336E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1574114246031E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7433389555306E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748613118200E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010187981E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9615866109222E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0138338922001E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3427630615234E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8328968454997E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6600109691805E+01
@@ -2941,68 +2968,68 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7752354275308E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6406538642117E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6058148956476E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   6.7097592404347E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2085977271024E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.5180580102994E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   8.0681374304137E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3217033340471E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3740296182766E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4744834959621E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5222493494952E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.3072406078877E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.0711975802286E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0937252980811E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2071687763904E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.5095100999959E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.3263723808325E-02
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3187343408218E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.3662437275876E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.4656743095478E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5241260501813E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.3103459122708E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.0607393898806E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780568803E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7173465150976E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.1345418474685E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807149206E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367477968E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658565640E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163526291112E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3416135538007E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5928933649420E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -3.7533328114176E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.8701879813752E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807158552E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604367060085E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845658549000E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163518265404E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.3369297778500E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -4.5924546878632E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
  EXTERNAL_FIELDS_LOAD,         9 : iP,iLd,i0,i1=   12    1   12    1 ; Wght=  0.2000000000  0.8000000000
- cg2d: Sum(rhs),rhsMax =   8.81727137592683E-02  1.13188369622790E+00
-(PID.TID 0000.0001)      cg2d_init_res =   9.64190393516074E-01
+ cg2d: Sum(rhs),rhsMax =   8.74310037428381E-02  1.14148589040377E+00
+(PID.TID 0000.0001)      cg2d_init_res =   9.54824033306872E-01
 (PID.TID 0000.0001)      cg2d_iters(min,last) =      -1     137
-(PID.TID 0000.0001)      cg2d_last_res =   7.57869323459449E-14
+(PID.TID 0000.0001)      cg2d_last_res =   7.52471325278481E-14
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // Begin MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) %MON time_tsnumber                =                    10
 (PID.TID 0000.0001) %MON time_secondsf                =   8.6400000000000E+05
-(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8031936148742E-01
-(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3730376320144E+00
+(PID.TID 0000.0001) %MON dynstat_eta_max              =   8.8009778951251E-01
+(PID.TID 0000.0001) %MON dynstat_eta_min              =  -1.3782914621236E+00
 (PID.TID 0000.0001) %MON dynstat_eta_mean             =  -6.8481775787083E-04
-(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2621190942498E-01
-(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8673921310992E-03
-(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7098543242898E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.5914683846032E-01
-(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1337975926248E-04
-(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2099980137782E-02
-(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.1537575005792E-05
-(PID.TID 0000.0001) %MON dynstat_vvel_max             =   9.8760905477631E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1904825923563E-01
-(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7010590612980E-04
-(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0802864818132E-02
-(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0832445919536E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2814021180197E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9675732453851E-04
-(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4952934212153E-08
-(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3402069350255E-05
-(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6752786983317E-07
-(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695978474112E+01
-(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9137195573120E+00
-(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203495174393E+00
-(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4169626478263E+00
-(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.0826161595515E-03
-(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7435310590324E+01
-(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748285631237E+01
-(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010274321E+01
-(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9606610367291E-01
-(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0062289394427E-03
+(PID.TID 0000.0001) %MON dynstat_eta_sd               =   5.2635558150755E-01
+(PID.TID 0000.0001) %MON dynstat_eta_del2             =   1.8656088971592E-03
+(PID.TID 0000.0001) %MON dynstat_uvel_max             =   1.7139093873256E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_min             =  -1.7920264067730E-01
+(PID.TID 0000.0001) %MON dynstat_uvel_mean            =   3.1420885687880E-04
+(PID.TID 0000.0001) %MON dynstat_uvel_sd              =   1.2220087618452E-02
+(PID.TID 0000.0001) %MON dynstat_uvel_del2            =   9.1618799995804E-05
+(PID.TID 0000.0001) %MON dynstat_vvel_max             =   1.0832457578468E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_min             =  -1.1887858904106E-01
+(PID.TID 0000.0001) %MON dynstat_vvel_mean            =  -2.7009333400002E-04
+(PID.TID 0000.0001) %MON dynstat_vvel_sd              =   1.0539109179774E-02
+(PID.TID 0000.0001) %MON dynstat_vvel_del2            =   1.0758182718655E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_max             =   2.2841429591563E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_min             =  -1.9830889233414E-04
+(PID.TID 0000.0001) %MON dynstat_wvel_mean            =  -1.4973771620646E-08
+(PID.TID 0000.0001) %MON dynstat_wvel_sd              =   2.3185997637040E-05
+(PID.TID 0000.0001) %MON dynstat_wvel_del2            =   2.6595369310639E-07
+(PID.TID 0000.0001) %MON dynstat_theta_max            =   2.9695976985207E+01
+(PID.TID 0000.0001) %MON dynstat_theta_min            =  -1.9137846927971E+00
+(PID.TID 0000.0001) %MON dynstat_theta_mean           =   3.6203517634008E+00
+(PID.TID 0000.0001) %MON dynstat_theta_sd             =   4.4171464988372E+00
+(PID.TID 0000.0001) %MON dynstat_theta_del2           =   5.1055663333062E-03
+(PID.TID 0000.0001) %MON dynstat_salt_max             =   3.7432112941148E+01
+(PID.TID 0000.0001) %MON dynstat_salt_min             =   2.9748285854194E+01
+(PID.TID 0000.0001) %MON dynstat_salt_mean            =   3.4718010383867E+01
+(PID.TID 0000.0001) %MON dynstat_salt_sd              =   2.9617120115972E-01
+(PID.TID 0000.0001) %MON dynstat_salt_del2            =   1.0141389724110E-03
 (PID.TID 0000.0001) %MON forcing_qnet_max             =   4.3532449340820E+02
 (PID.TID 0000.0001) %MON forcing_qnet_min             =  -1.8282252197266E+02
 (PID.TID 0000.0001) %MON forcing_qnet_mean            =  -1.6587597735982E+01
@@ -3028,206 +3055,206 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) %MON forcing_fv_mean              =  -5.7014729006700E-03
 (PID.TID 0000.0001) %MON forcing_fv_sd                =   4.6628624802842E-02
 (PID.TID 0000.0001) %MON forcing_fv_del2              =   4.6475770842672E-04
-(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   8.0696329458291E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2476525729429E-02
-(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.5006327676367E-02
-(PID.TID 0000.0001) %MON advcfl_uvel_max              =   9.0403091478082E-02
-(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3129167464953E-02
-(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.1342256186246E-02
-(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.2032674671987E-02
-(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5432626890828E-04
-(PID.TID 0000.0001) %MON ke_max                       =   1.4686611414821E-02
-(PID.TID 0000.0001) %MON ke_mean                      =   1.1898604121231E-04
+(PID.TID 0000.0001) %MON trAdv_CFL_u_max              =   9.3281004788395E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_v_max              =   2.2447781825961E-02
+(PID.TID 0000.0001) %MON trAdv_CFL_w_max              =   7.4936588283920E-02
+(PID.TID 0000.0001) %MON advcfl_uvel_max              =   1.0179575588806E-01
+(PID.TID 0000.0001) %MON advcfl_vvel_max              =   2.3096203267331E-02
+(PID.TID 0000.0001) %MON advcfl_wvel_max              =   8.1383442337336E-02
+(PID.TID 0000.0001) %MON advcfl_W_hf_max              =   9.2079272891415E-02
+(PID.TID 0000.0001) %MON pe_b_mean                    =   3.5451977899570E-04
+(PID.TID 0000.0001) %MON ke_max                       =   1.4731832913775E-02
+(PID.TID 0000.0001) %MON ke_mean                      =   1.1778619733675E-04
 (PID.TID 0000.0001) %MON ke_vol                       =   1.3226780322649E+18
-(PID.TID 0000.0001) %MON vort_r_min                   =  -4.2847439529282E-07
-(PID.TID 0000.0001) %MON vort_r_max                   =   5.4657527121821E-07
-(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807208904E-05
-(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389706260E-05
-(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649735110E-05
-(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163504623863E-04
-(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1285441952209E-07
-(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7673468452168E-08
+(PID.TID 0000.0001) %MON vort_r_min                   =  -4.0221835330009E-07
+(PID.TID 0000.0001) %MON vort_r_max                   =   4.8297997426541E-07
+(PID.TID 0000.0001) %MON vort_a_mean                  =  -2.5274807218090E-05
+(PID.TID 0000.0001) %MON vort_a_sd                    =   7.3604389496828E-05
+(PID.TID 0000.0001) %MON vort_p_mean                  =  -3.1845649705663E-05
+(PID.TID 0000.0001) %MON vort_p_sd                    =   1.3163498091388E-04
+(PID.TID 0000.0001) %MON surfExpan_theta_mean         =  -4.1270781653616E-07
+(PID.TID 0000.0001) %MON surfExpan_salt_mean          =  -3.7685783761957E-08
 (PID.TID 0000.0001) // =======================================================
 (PID.TID 0000.0001) // End MONITOR dynamic field statistics
 (PID.TID 0000.0001) // =======================================================
- Computing Diagnostic #     23  ETAN         Counter:      10   Parms: SM      M1      
- Computing Diagnostic #     24  ETANSQ       Counter:      10   Parms: SM P    M1      
- Computing Diagnostic #     25  DETADT2      Counter:      10   Parms: SM      M1      
- Computing Diagnostic #     73  PHIBOT       Counter:      10   Parms: SM      M1      
- Computing Diagnostic #     74  PHIBOTSQ     Counter:      10   Parms: SM P    M1      
- Computing Diagnostic #     45  UVELMASS     Counter:      10   Parms: UUr     MR      
-           Vector  Mate for  UVELMASS     Diagnostic #     46  VVELMASS exists 
- Computing Diagnostic #     46  VVELMASS     Counter:      10   Parms: VVr     MR      
-           Vector  Mate for  VVELMASS     Diagnostic #     45  UVELMASS exists 
- Computing Diagnostic #     32  WVEL         Counter:      10   Parms: WM      LR      
- Computing Diagnostic #     26  THETA        Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     27  SALT         Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     38  WVELSQ       Counter:      10   Parms: WM P    LR      
- Computing Diagnostic #     64  RHOAnoma     Counter:      10   Parms: SMR     MR      
- Computing Diagnostic #     78  DRHODR       Counter:      10   Parms: SM      LR      
- Computing Diagnostic #     79  CONVADJ      Counter:      10   Parms: SMR     LR      
- Computing Diagnostic #    209  GM_Kwx       Counter:      10   Parms: UM      LR      
-           Vector  Mate for  GM_Kwx       Diagnostic #    210  GM_Kwy   exists 
- Computing Diagnostic #    210  GM_Kwy       Counter:      10   Parms: VM      LR      
-           Vector  Mate for  GM_Kwy       Diagnostic #    209  GM_Kwx   exists 
- Computing Diagnostic #    211  GM_Kwz       Counter:      10   Parms: WM P    LR      
+ Computing Diagnostic #    23 "ETAN    " (list#  1) Parms "SM      M1      ", Count=      10
+ Computing Diagnostic #    24 "ETANSQ  " (list#  1) Parms "SM P    M1      ", Count=      10
+ Computing Diagnostic #    25 "DETADT2 " (list#  1) Parms "SM      M1      ", Count=      10
+ Computing Diagnostic #    74 "PHIBOT  " (list#  1) Parms "SM      M1      ", Count=      10
+ Computing Diagnostic #    75 "PHIBOTSQ" (list#  1) Parms "SM P    M1      ", Count=      10
+ Computing Diagnostic #    46 "UVELMASS" (list#  2) Parms "UUr     MR      ", Count=      10
+             Vector  Mate for "UVELMASS" :  Diagnostic #     47 "VVELMASS" exists
+ Computing Diagnostic #    47 "VVELMASS" (list#  2) Parms "VVr     MR      ", Count=      10
+             Vector  Mate for "VVELMASS" :  Diagnostic #     46 "UVELMASS" exists
+ Computing Diagnostic #    32 "WVEL    " (list#  2) Parms "WM      LR      ", Count=      10
+ Computing Diagnostic #    26 "THETA   " (list#  2) Parms "SMR     MR      ", Count=      10
+ Computing Diagnostic #    27 "SALT    " (list#  2) Parms "SMR     MR      ", Count=      10
+ Computing Diagnostic #    38 "WVELSQ  " (list#  2) Parms "WM P    LR      ", Count=      10
+ Computing Diagnostic #    65 "RHOAnoma" (list#  3) Parms "SMR     MR      ", Count=      10
+ Computing Diagnostic #    79 "DRHODR  " (list#  3) Parms "SM      LR      ", Count=      10
+ Computing Diagnostic #    80 "CONVADJ " (list#  3) Parms "SMR     LR      ", Count=      10
+ Computing Diagnostic #   216 "GM_Kwx  " (list#  3) Parms "UM      LR      ", Count=      10
+             Vector  Mate for "GM_Kwx  " :  Diagnostic #    217 "GM_Kwy  " exists
+ Computing Diagnostic #   217 "GM_Kwy  " (list#  3) Parms "VM      LR      ", Count=      10
+             Vector  Mate for "GM_Kwy  " :  Diagnostic #    216 "GM_Kwx  " exists
+ Computing Diagnostic #   218 "GM_Kwz  " (list#  3) Parms "WM P    LR      ", Count=      10
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: dynStDiag.0000000000.txt , unit=     9
 (PID.TID 0000.0001) DIAGSTATS_CLOSE_IO: close file: oceStDiag.0000000000.txt , unit=    10
 (PID.TID 0000.0001) %CHECKPOINT        10 ckptA
 (PID.TID 0000.0001)   Seconds in section "ALL                    [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.435054422821850
-(PID.TID 0000.0001)         System time:  0.28051999281160533
-(PID.TID 0000.0001)     Wall clock time:   16.725636959075928
+(PID.TID 0000.0001)           User time:   10.683526992797852
+(PID.TID 0000.0001)         System time:   6.8467000965029001E-002
+(PID.TID 0000.0001)     Wall clock time:   10.753706932067871
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_FIXED       [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:  0.17052999697625637
-(PID.TID 0000.0001)         System time:   7.9357999376952648E-002
-(PID.TID 0000.0001)     Wall clock time:  0.25843501091003418
+(PID.TID 0000.0001)           User time:   9.0130999684333801E-002
+(PID.TID 0000.0001)         System time:   2.7832001680508256E-002
+(PID.TID 0000.0001)     Wall clock time:  0.11868309974670410
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "THE_MAIN_LOOP          [THE_MODEL_MAIN]":
-(PID.TID 0000.0001)           User time:   16.264468699693680
-(PID.TID 0000.0001)         System time:  0.20113798975944519
-(PID.TID 0000.0001)     Wall clock time:   16.467136859893799
+(PID.TID 0000.0001)           User time:   10.593385227024555
+(PID.TID 0000.0001)         System time:   4.0618002414703369E-002
+(PID.TID 0000.0001)     Wall clock time:   10.635003089904785
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "INITIALISE_VARIA    [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:  0.78636597096920013
-(PID.TID 0000.0001)         System time:   6.4582005143165588E-002
-(PID.TID 0000.0001)     Wall clock time:  0.85104417800903320
+(PID.TID 0000.0001)           User time:  0.55479097366333008
+(PID.TID 0000.0001)         System time:   1.6419000923633575E-002
+(PID.TID 0000.0001)     Wall clock time:  0.57147502899169922
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN LOOP           [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.478080093860626
-(PID.TID 0000.0001)         System time:  0.13655199110507965
-(PID.TID 0000.0001)     Wall clock time:   15.616068124771118
+(PID.TID 0000.0001)           User time:   10.038580417633057
+(PID.TID 0000.0001)         System time:   2.4197001010179520E-002
+(PID.TID 0000.0001)     Wall clock time:   10.063513994216919
 (PID.TID 0000.0001)          No. starts:           1
 (PID.TID 0000.0001)           No. stops:           1
 (PID.TID 0000.0001)   Seconds in section "MAIN_DO_LOOP        [THE_MAIN_LOOP]":
-(PID.TID 0000.0001)           User time:   15.478000640869141
-(PID.TID 0000.0001)         System time:  0.13655099272727966
-(PID.TID 0000.0001)     Wall clock time:   15.615987539291382
+(PID.TID 0000.0001)           User time:   10.038535833358765
+(PID.TID 0000.0001)         System time:   2.4197001010179520E-002
+(PID.TID 0000.0001)     Wall clock time:   10.063471555709839
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "FORWARD_STEP        [MAIN_DO_LOOP]":
-(PID.TID 0000.0001)           User time:   15.477854430675507
-(PID.TID 0000.0001)         System time:  0.13654999434947968
-(PID.TID 0000.0001)     Wall clock time:   15.615839242935181
+(PID.TID 0000.0001)           User time:   10.038451969623566
+(PID.TID 0000.0001)         System time:   2.4196002632379532E-002
+(PID.TID 0000.0001)     Wall clock time:   10.063384771347046
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_R_STAR       [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.31277477741241455
-(PID.TID 0000.0001)         System time:   6.9990754127502441E-005
-(PID.TID 0000.0001)     Wall clock time:  0.31289553642272949
+(PID.TID 0000.0001)           User time:  0.17428636550903320
+(PID.TID 0000.0001)         System time:   9.7997486591339111E-005
+(PID.TID 0000.0001)     Wall clock time:  0.17441654205322266
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "DO_STATEVARS_DIAGS  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.28230375051498413
-(PID.TID 0000.0001)         System time:   1.7401576042175293E-004
-(PID.TID 0000.0001)     Wall clock time:  0.28251647949218750
+(PID.TID 0000.0001)           User time:  0.16899299621582031
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.16903185844421387
 (PID.TID 0000.0001)          No. starts:          20
 (PID.TID 0000.0001)           No. stops:          20
 (PID.TID 0000.0001)   Seconds in section "LOAD_FIELDS_DRIVER  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.7694711685180664E-002
-(PID.TID 0000.0001)         System time:   7.0035457611083984E-006
-(PID.TID 0000.0001)     Wall clock time:   1.7698526382446289E-002
+(PID.TID 0000.0001)           User time:   1.1214196681976318E-002
+(PID.TID 0000.0001)         System time:   6.6995620727539062E-005
+(PID.TID 0000.0001)     Wall clock time:   1.1281967163085938E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "EXTERNAL_FLDS_LOAD [LOAD_FLDS_DRIVER]":
-(PID.TID 0000.0001)           User time:   1.7499208450317383E-002
-(PID.TID 0000.0001)         System time:   6.0051679611206055E-006
-(PID.TID 0000.0001)     Wall clock time:   1.7509937286376953E-002
+(PID.TID 0000.0001)           User time:   1.0479629039764404E-002
+(PID.TID 0000.0001)         System time:   6.3996762037277222E-005
+(PID.TID 0000.0001)     Wall clock time:   1.0548830032348633E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_ATMOSPHERIC_PHYS [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0704689025878906E-005
-(PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.0108642578125000E-005
+(PID.TID 0000.0001)           User time:   3.7372112274169922E-005
+(PID.TID 0000.0001)         System time:   1.0021030902862549E-006
+(PID.TID 0000.0001)     Wall clock time:   3.6954879760742188E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_OCEANIC_PHYS     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.8851264715194702
-(PID.TID 0000.0001)         System time:   6.0229018330574036E-002
-(PID.TID 0000.0001)     Wall clock time:   4.9459810256958008
+(PID.TID 0000.0001)           User time:   3.0246925354003906
+(PID.TID 0000.0001)         System time:   8.0459974706172943E-003
+(PID.TID 0000.0001)     Wall clock time:   3.0327219963073730
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "GMREDI_CALC_BATES_K [GMREDI_CALC_TENSOR]":
-(PID.TID 0000.0001)           User time:   3.2552852630615234
-(PID.TID 0000.0001)         System time:   5.1818996667861938E-002
-(PID.TID 0000.0001)     Wall clock time:   3.3077001571655273
+(PID.TID 0000.0001)           User time:   2.0412150025367737
+(PID.TID 0000.0001)         System time:   7.8990012407302856E-003
+(PID.TID 0000.0001)     Wall clock time:   2.0491321086883545
 (PID.TID 0000.0001)          No. starts:         360
 (PID.TID 0000.0001)           No. stops:         360
 (PID.TID 0000.0001)   Seconds in section "THERMODYNAMICS      [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   2.8601326942443848
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   2.8606145381927490
+(PID.TID 0000.0001)           User time:   2.0131531953811646
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.0131609439849854
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DYNAMICS            [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   4.1093819141387939
-(PID.TID 0000.0001)         System time:   8.0019235610961914E-006
-(PID.TID 0000.0001)     Wall clock time:   4.1096191406250000
+(PID.TID 0000.0001)           User time:   2.8816483020782471
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   2.8819551467895508
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "UPDATE_CG2D         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   5.0323963165283203E-002
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:   5.0334930419921875E-002
+(PID.TID 0000.0001)           User time:   2.9268980026245117E-002
+(PID.TID 0000.0001)         System time:   3.0025839805603027E-006
+(PID.TID 0000.0001)     Wall clock time:   2.9291391372680664E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "SOLVE_FOR_PRESSURE  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   1.5172023773193359
-(PID.TID 0000.0001)         System time:   2.1010637283325195E-005
-(PID.TID 0000.0001)     Wall clock time:   1.5172586441040039
+(PID.TID 0000.0001)           User time:  0.91718363761901855
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.91718292236328125
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MOM_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   9.8677635192871094E-002
-(PID.TID 0000.0001)         System time:   5.8993697166442871E-005
-(PID.TID 0000.0001)     Wall clock time:   9.8749160766601562E-002
+(PID.TID 0000.0001)           User time:   5.9713840484619141E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   5.9720993041992188E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "INTEGR_CONTINUITY   [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.13827443122863770
-(PID.TID 0000.0001)         System time:   4.9918889999389648E-006
-(PID.TID 0000.0001)     Wall clock time:  0.13830232620239258
+(PID.TID 0000.0001)           User time:   8.5276126861572266E-002
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:   8.5284948348999023E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "CALC_R_STAR         [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   3.6375999450683594E-002
+(PID.TID 0000.0001)           User time:   2.1238088607788086E-002
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   3.6392688751220703E-002
+(PID.TID 0000.0001)     Wall clock time:   2.1241426467895508E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "TRC_CORRECTION_STEP [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.0585479736328125E-005
+(PID.TID 0000.0001)           User time:   5.0306320190429688E-005
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:   8.1062316894531250E-005
+(PID.TID 0000.0001)     Wall clock time:   5.2452087402343750E-005
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "BLOCKING_EXCHANGES  [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.36056566238403320
-(PID.TID 0000.0001)         System time:   9.9837779998779297E-007
-(PID.TID 0000.0001)     Wall clock time:  0.36061048507690430
+(PID.TID 0000.0001)           User time:  0.17843317985534668
+(PID.TID 0000.0001)         System time:   0.0000000000000000
+(PID.TID 0000.0001)     Wall clock time:  0.17845320701599121
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "MONITOR             [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.61893606185913086
+(PID.TID 0000.0001)           User time:  0.34667491912841797
 (PID.TID 0000.0001)         System time:   0.0000000000000000
-(PID.TID 0000.0001)     Wall clock time:  0.61897635459899902
+(PID.TID 0000.0001)     Wall clock time:  0.34667849540710449
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_THE_MODEL_IO     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:   8.6414813995361328E-002
-(PID.TID 0000.0001)         System time:   2.7963995933532715E-002
-(PID.TID 0000.0001)     Wall clock time:  0.11447405815124512
+(PID.TID 0000.0001)           User time:   5.0654888153076172E-002
+(PID.TID 0000.0001)         System time:   1.1985998600721359E-002
+(PID.TID 0000.0001)     Wall clock time:   6.3031435012817383E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001)   Seconds in section "DO_WRITE_PICKUP     [FORWARD_STEP]":
-(PID.TID 0000.0001)           User time:  0.10068392753601074
-(PID.TID 0000.0001)         System time:   4.7992005944252014E-002
-(PID.TID 0000.0001)     Wall clock time:  0.14872312545776367
+(PID.TID 0000.0001)           User time:   7.4596881866455078E-002
+(PID.TID 0000.0001)         System time:   3.9900019764900208E-003
+(PID.TID 0000.0001)     Wall clock time:   7.8634023666381836E-002
 (PID.TID 0000.0001)          No. starts:          10
 (PID.TID 0000.0001)           No. stops:          10
 (PID.TID 0000.0001) // ======================================================
@@ -3630,9 +3657,9 @@ listId=   2 ; file name: oceStDiag
 (PID.TID 0000.0001) //          Total. Y spins =              0
 (PID.TID 0000.0001) //            Avg. Y spins =       0.00E+00
 (PID.TID 0000.0001) // o Thread number: 000001
-(PID.TID 0000.0001) //            No. barriers =          17446
+(PID.TID 0000.0001) //            No. barriers =          17452
 (PID.TID 0000.0001) //      Max. barrier spins =              1
 (PID.TID 0000.0001) //      Min. barrier spins =              1
-(PID.TID 0000.0001) //     Total barrier spins =          17446
+(PID.TID 0000.0001) //     Total barrier spins =          17452
 (PID.TID 0000.0001) //      Avg. barrier spins =       1.00E+00
 PROGRAM MAIN: Execution ended Normally

--- a/update_history
+++ b/update_history
@@ -1,6 +1,8 @@
     Update history and content of "MITgcm/verification_other"
     =================================================================
 
+  - post PR #1025 (Bates K3d bug fix): update 2 affected reference output
+    (when GM_useBatesK3d=T) for exp. global_ocean.gm_k3d & global_ocean.gm_res.
   - post PR #1014 (seaice lsr.F bug fix): update affected reference output
     (when SEAICEselectMetricTerms=2): 2 cs32 + 3 forward llc90.
 


### PR DESCRIPTION
MITgcm  https://github.com/MITgcm/MITgcm/pull/1025 fixes the signed cap on Bates wave speed.
This affects all experiments using `GM_useBatesK3d=True`, i.e., `global_ocean.gm_k3d` (primary test) and `global_ocean.gm_res`. 

This PR updates these 2 ref. output affected by PR 1025. 
To merge only after PR 1025 has been merged.

